### PR TITLE
Convert top navbar to collapsible left sidebar

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "phoenix",
+      "runtimeExecutable": "mise",
+      "runtimeArgs": ["x", "--", "mix", "phx.server"],
+      "port": 4000
+    }
+  ]
+}

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -101,6 +101,15 @@
 /* Use the data attribute for dark mode  */
 @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
 
+/* Sidebar expanded state — driven by data-sidebar on <html> */
+@custom-variant sidebar-open ([data-sidebar=expanded] &);
+
+/* Theme indicator — show only active theme's icon/label */
+.theme-indicator > :is(.theme-system, .theme-light, .theme-dark) { display: none; }
+:root:not([data-theme]) .theme-indicator > .theme-system,
+[data-theme="light"] .theme-indicator > .theme-light,
+[data-theme="dark"] .theme-indicator > .theme-dark { display: inline-block; }
+
 /* Make LiveView wrapper divs transparent for layout */
 [data-phx-session], [data-phx-teleported-src] { display: contents }
 

--- a/lib/destila_web/components/board_components.ex
+++ b/lib/destila_web/components/board_components.ex
@@ -12,7 +12,7 @@ defmodule DestilaWeb.BoardComponents do
     <div class="flex flex-col min-w-[280px] max-w-[320px] w-full">
       <div class="flex items-center justify-between mb-3 px-1">
         <div class="flex items-center gap-2">
-          <h3 class="text-sm font-semibold text-base-content/70 uppercase tracking-wide">
+          <h3 class="text-xs font-medium text-base-content/50 uppercase">
             {column_label(@column)}
           </h3>
           <span class="badge badge-sm badge-ghost">{length(@cards)}</span>
@@ -44,7 +44,7 @@ defmodule DestilaWeb.BoardComponents do
     <.link
       navigate={"/prompts/#{@card.id}"}
       data-id={@card.id}
-      class="card bg-base-100 border border-base-300 shadow-sm hover:shadow-md hover:border-base-content/20 transition-all cursor-pointer"
+      class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow cursor-pointer"
     >
       <div class="card-body p-4 gap-2">
         <h4 class={[
@@ -54,10 +54,10 @@ defmodule DestilaWeb.BoardComponents do
           {@card.title}
         </h4>
 
-        <div class="flex items-center gap-2 flex-wrap">
+        <div class="flex items-center justify-between gap-2">
           <.workflow_badge type={@card.workflow_type} />
-          <span :if={@card.repo_url} class="text-xs text-base-content/40 truncate max-w-[140px]">
-            {repo_short_name(@card.repo_url)}
+          <span class="text-xs text-base-content/40">
+            {@card.steps_completed}/{@card.steps_total}
           </span>
         </div>
 
@@ -90,17 +90,14 @@ defmodule DestilaWeb.BoardComponents do
     assigns = assign(assigns, :percentage, floor(assigns.completed / max(assigns.total, 1) * 100))
 
     ~H"""
-    <div class="flex items-center gap-2">
-      <div class="flex-1 h-1.5 bg-base-300 rounded-full overflow-hidden">
-        <div
-          class={[
-            "h-full rounded-full transition-all",
-            if(@percentage == 100, do: "bg-success", else: "bg-primary")
-          ]}
-          style={"width: #{@percentage}%"}
-        />
-      </div>
-      <span class="text-xs text-base-content/40">{@completed}/{@total}</span>
+    <div class="h-1 bg-base-300 rounded-full overflow-hidden">
+      <div
+        class={[
+          "h-full rounded-full transition-all",
+          if(@percentage == 100, do: "bg-success", else: "bg-primary")
+        ]}
+        style={"width: #{@percentage}%"}
+      />
     </div>
     """
   end
@@ -121,12 +118,4 @@ defmodule DestilaWeb.BoardComponents do
 
   defp workflow_badge_class(:feature_request), do: "badge-info"
   defp workflow_badge_class(:project), do: "badge-secondary"
-
-  defp repo_short_name(nil), do: ""
-
-  defp repo_short_name(url) do
-    url
-    |> String.replace(~r{^https?://github\.com/}, "")
-    |> String.trim_trailing("/")
-  end
 end

--- a/lib/destila_web/components/layouts.ex
+++ b/lib/destila_web/components/layouts.ex
@@ -5,73 +5,142 @@ defmodule DestilaWeb.Layouts do
 
   attr :flash, :map, required: true
   attr :current_user, :map, default: nil
+  attr :page_title, :string, default: nil
   slot :inner_block, required: true
 
   def app(assigns) do
     ~H"""
-    <div class="min-h-screen flex flex-col bg-base-100">
-      <header :if={@current_user} class="navbar bg-base-100 border-b border-base-300 px-6 h-16">
-        <div class="flex-1 flex items-center gap-8">
-          <.link navigate={~p"/"} class="text-lg font-bold tracking-tight hover:opacity-80">
-            Destila
-          </.link>
+    <div class="min-h-screen bg-base-100">
+      <.sidebar :if={@current_user} current_user={@current_user} page_title={@page_title} />
 
-          <nav class="flex items-center gap-1">
-            <.link
-              navigate={~p"/"}
-              class="btn btn-ghost btn-sm text-sm font-medium"
-            >
-              Dashboard
-            </.link>
-            <.link
-              navigate={~p"/crafting"}
-              class="btn btn-ghost btn-sm text-sm font-medium"
-            >
-              Prompt Crafting
-            </.link>
-            <.link
-              navigate={~p"/implementation"}
-              class="btn btn-ghost btn-sm text-sm font-medium"
-            >
-              Implementation
-            </.link>
-          </nav>
-        </div>
-
-        <div class="flex-none flex items-center gap-3">
-          <.link navigate={~p"/prompts/new"} class="btn btn-primary btn-sm">
-            <.icon name="hero-plus-micro" class="size-4" /> Create
-          </.link>
-
-          <.theme_toggle />
-
-          <div class="dropdown dropdown-end">
-            <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar placeholder">
-              <div class="bg-neutral text-neutral-content w-8 rounded-full">
-                <span class="text-xs">
-                  {String.first(@current_user.name)}
-                </span>
-              </div>
-            </div>
-            <ul
-              tabindex="0"
-              class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow-lg border border-base-300 mt-2"
-            >
-              <li class="menu-title text-xs">{@current_user.email}</li>
-              <li>
-                <.link href={~p"/logout"} class="text-sm">Sign out</.link>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </header>
-
-      <main class="flex-1">
+      <main class={[
+        "min-h-screen transition-[margin-left] duration-200",
+        @current_user && "ml-16 sidebar-open:ml-60"
+      ]}>
         {render_slot(@inner_block)}
       </main>
 
       <.flash_group flash={@flash} />
     </div>
+    """
+  end
+
+  attr :current_user, :map, required: true
+  attr :page_title, :string, default: nil
+
+  defp sidebar(assigns) do
+    ~H"""
+    <aside class="fixed left-0 top-0 h-screen w-16 sidebar-open:w-60 bg-base-200 border-r border-base-300 flex flex-col z-30 transition-[width] duration-200 ease-in-out overflow-hidden">
+      <%!-- Logo --%>
+      <div class="h-14 flex items-center px-2 shrink-0">
+        <.link navigate={~p"/"} class="flex items-center">
+          <div class="w-12 h-10 flex items-center justify-center shrink-0">
+            <div class="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center">
+              <span class="text-primary font-bold text-sm">D</span>
+            </div>
+          </div>
+          <span class="text-base font-bold tracking-tight whitespace-nowrap opacity-0 sidebar-open:opacity-100 transition-opacity duration-200">
+            Destila
+          </span>
+        </.link>
+      </div>
+
+      <%!-- Navigation --%>
+      <nav class="flex-1 flex flex-col gap-0.5 px-2 mt-1">
+        <.sidebar_item
+          navigate={~p"/crafting"}
+          icon="hero-beaker"
+          label="Prompt Crafting"
+          active={@page_title == "Prompt Crafting"}
+        />
+        <.sidebar_item
+          navigate={~p"/implementation"}
+          icon="hero-rocket-launch"
+          label="Implementation"
+          active={@page_title == "Implementation"}
+        />
+
+        <div class="my-2 mx-1 border-t border-base-300/50" />
+
+        <.sidebar_item navigate={~p"/prompts/new"} icon="hero-plus-circle" label="Create Prompt" />
+      </nav>
+
+      <%!-- Bottom --%>
+      <div class="shrink-0 border-t border-base-300/50 mx-2 pt-2 pb-3 space-y-1">
+        <%!-- User --%>
+        <div class="flex items-center rounded-lg">
+          <div class="w-12 h-10 flex items-center justify-center shrink-0">
+            <div class="w-8 h-8 rounded-full bg-neutral flex items-center justify-center text-neutral-content">
+              <span class="text-xs font-medium">{String.first(@current_user.name)}</span>
+            </div>
+          </div>
+          <div class="min-w-0 whitespace-nowrap opacity-0 sidebar-open:opacity-100 transition-opacity duration-200">
+            <p class="text-sm font-medium truncate">{@current_user.name}</p>
+            <.link
+              href={~p"/logout"}
+              class="text-xs text-base-content/50 hover:text-error transition-colors"
+            >
+              Sign out
+            </.link>
+          </div>
+        </div>
+
+        <%!-- Theme toggle --%>
+        <button
+          phx-click={JS.dispatch("phx:cycle-theme")}
+          class="flex items-center h-10 w-full rounded-lg text-base-content/60 hover:text-base-content hover:bg-base-300/50 cursor-pointer transition-colors"
+        >
+          <div class="w-12 flex items-center justify-center shrink-0 theme-indicator">
+            <.icon name="hero-computer-desktop-micro" class="theme-system size-5" />
+            <.icon name="hero-sun-micro" class="theme-light size-5" />
+            <.icon name="hero-moon-micro" class="theme-dark size-5" />
+          </div>
+          <span class="text-sm whitespace-nowrap opacity-0 sidebar-open:opacity-100 transition-opacity duration-200 theme-indicator">
+            <span class="theme-system">System</span>
+            <span class="theme-light">Light</span>
+            <span class="theme-dark">Dark</span>
+          </span>
+        </button>
+
+        <%!-- Sidebar toggle --%>
+        <button
+          phx-click={JS.dispatch("phx:toggle-sidebar")}
+          class="flex items-center justify-center w-full h-9 rounded-lg text-base-content/40 hover:text-base-content hover:bg-base-300/50 cursor-pointer transition-colors"
+        >
+          <.icon
+            name="hero-chevron-right-micro"
+            class="size-4 sidebar-open:rotate-180 transition-transform duration-200"
+          />
+        </button>
+      </div>
+    </aside>
+    """
+  end
+
+  attr :navigate, :string, required: true
+  attr :icon, :string, required: true
+  attr :label, :string, required: true
+  attr :active, :boolean, default: false
+
+  defp sidebar_item(assigns) do
+    ~H"""
+    <.link
+      navigate={@navigate}
+      class={[
+        "flex items-center h-10 rounded-lg transition-colors",
+        if(@active,
+          do: "bg-base-100 text-base-content font-medium shadow-sm",
+          else: "text-base-content/60 hover:text-base-content hover:bg-base-300/50"
+        )
+      ]}
+    >
+      <div class="w-12 flex items-center justify-center shrink-0">
+        <.icon name={@icon} class="size-5" />
+      </div>
+      <span class="text-sm whitespace-nowrap opacity-0 sidebar-open:opacity-100 transition-opacity duration-200">
+        {@label}
+      </span>
+    </.link>
     """
   end
 
@@ -107,38 +176,6 @@ defmodule DestilaWeb.Layouts do
         {gettext("Attempting to reconnect")}
         <.icon name="hero-arrow-path" class="ml-1 size-3 motion-safe:animate-spin" />
       </.flash>
-    </div>
-    """
-  end
-
-  def theme_toggle(assigns) do
-    ~H"""
-    <div class="card relative flex flex-row items-center border-2 border-base-300 bg-base-300 rounded-full">
-      <div class="absolute w-1/3 h-full rounded-full border-1 border-base-200 bg-base-100 brightness-200 left-0 [[data-theme=light]_&]:left-1/3 [[data-theme=dark]_&]:left-2/3 transition-[left]" />
-
-      <button
-        class="flex p-2 cursor-pointer w-1/3"
-        phx-click={JS.dispatch("phx:set-theme")}
-        data-phx-theme="system"
-      >
-        <.icon name="hero-computer-desktop-micro" class="size-4 opacity-75 hover:opacity-100" />
-      </button>
-
-      <button
-        class="flex p-2 cursor-pointer w-1/3"
-        phx-click={JS.dispatch("phx:set-theme")}
-        data-phx-theme="light"
-      >
-        <.icon name="hero-sun-micro" class="size-4 opacity-75 hover:opacity-100" />
-      </button>
-
-      <button
-        class="flex p-2 cursor-pointer w-1/3"
-        phx-click={JS.dispatch("phx:set-theme")}
-        data-phx-theme="dark"
-      >
-        <.icon name="hero-moon-micro" class="size-4 opacity-75 hover:opacity-100" />
-      </button>
     </div>
     """
   end

--- a/lib/destila_web/components/layouts/root.html.heex
+++ b/lib/destila_web/components/layouts/root.html.heex
@@ -27,6 +27,27 @@
         window.addEventListener("storage", (e) => e.key === "phx:theme" && setTheme(e.newValue || "system"));
         
         window.addEventListener("phx:set-theme", (e) => setTheme(e.target.dataset.phxTheme));
+
+        window.addEventListener("phx:cycle-theme", () => {
+          const current = localStorage.getItem("phx:theme") || "system";
+          const next = current === "system" ? "light" : current === "light" ? "dark" : "system";
+          setTheme(next);
+        });
+
+        // Sidebar toggle — restore from localStorage
+        if (localStorage.getItem("phx:sidebar") === "expanded") {
+          document.documentElement.setAttribute("data-sidebar", "expanded");
+        }
+        window.addEventListener("phx:toggle-sidebar", () => {
+          const el = document.documentElement;
+          if (el.getAttribute("data-sidebar") === "expanded") {
+            localStorage.removeItem("phx:sidebar");
+            el.removeAttribute("data-sidebar");
+          } else {
+            localStorage.setItem("phx:sidebar", "expanded");
+            el.setAttribute("data-sidebar", "expanded");
+          }
+        });
       })();
     </script>
   </head>

--- a/lib/destila_web/live/crafting_board_live.ex
+++ b/lib/destila_web/live/crafting_board_live.ex
@@ -42,7 +42,7 @@ defmodule DestilaWeb.CraftingBoardLive do
 
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash} current_user={@current_user}>
+    <Layouts.app flash={@flash} current_user={@current_user} page_title={@page_title}>
       <div class="p-6 lg:p-8">
         <div class="flex items-center justify-between mb-6">
           <h1 class="text-2xl font-bold tracking-tight">Prompt Crafting</h1>

--- a/lib/destila_web/live/dashboard_live.ex
+++ b/lib/destila_web/live/dashboard_live.ex
@@ -64,36 +64,31 @@ defmodule DestilaWeb.DashboardLive do
       |> assign(:implementation_summary, implementation_summary)
 
     ~H"""
-    <Layouts.app flash={@flash} current_user={@current_user}>
+    <Layouts.app flash={@flash} current_user={@current_user} page_title={@page_title}>
       <div class="p-6 lg:p-8 max-w-6xl mx-auto">
-        <div class="mb-8">
-          <h1 class="text-2xl font-bold tracking-tight">Welcome back, {@current_user.name}</h1>
-          <p class="text-base-content/50 mt-1">Here's an overview of your prompt boards.</p>
-        </div>
+        <h1 class="text-2xl font-bold tracking-tight mb-8">
+          Welcome back, {@current_user.name}
+        </h1>
 
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <%!-- Prompt Crafting Board Preview --%>
           <.link
             navigate={~p"/crafting"}
-            class="card bg-base-100 border border-base-300 shadow-sm hover:shadow-md hover:border-base-content/20 transition-all"
+            class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow"
           >
             <div class="card-body">
-              <div class="flex items-center justify-between mb-4">
-                <h2 class="card-title text-lg">Prompt Crafting</h2>
-                <.icon name="hero-beaker" class="size-5 text-base-content/30" />
+              <h2 class="card-title text-lg mb-1">Prompt Crafting</h2>
+
+              <div class="flex gap-3 text-xs text-base-content/50 mb-3">
+                <span :for={{col, cards} <- @crafting_summary}>
+                  {length(cards)} {column_label(col)}
+                </span>
               </div>
 
-              <div class="flex gap-4 mb-4">
-                <div :for={{col, cards} <- @crafting_summary} class="flex items-center gap-1.5">
-                  <span class="text-xs text-base-content/50">{column_label(col)}</span>
-                  <span class="badge badge-sm badge-ghost">{length(cards)}</span>
-                </div>
-              </div>
-
-              <div class="space-y-2">
+              <div class="divide-y divide-base-200">
                 <div
                   :for={prompt <- @crafting_prompts |> Enum.take(3)}
-                  class="flex items-center justify-between py-1.5 px-2 bg-base-200/50 rounded-lg"
+                  class="flex items-center justify-between py-2"
                 >
                   <span class="text-sm truncate mr-2">{prompt.title}</span>
                   <.workflow_badge type={prompt.workflow_type} />
@@ -105,25 +100,21 @@ defmodule DestilaWeb.DashboardLive do
           <%!-- Implementation Board Preview --%>
           <.link
             navigate={~p"/implementation"}
-            class="card bg-base-100 border border-base-300 shadow-sm hover:shadow-md hover:border-base-content/20 transition-all"
+            class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow"
           >
             <div class="card-body">
-              <div class="flex items-center justify-between mb-4">
-                <h2 class="card-title text-lg">Implementation</h2>
-                <.icon name="hero-rocket-launch" class="size-5 text-base-content/30" />
+              <h2 class="card-title text-lg mb-1">Implementation</h2>
+
+              <div class="flex gap-3 text-xs text-base-content/50 mb-3 flex-wrap">
+                <span :for={{col, cards} <- @implementation_summary}>
+                  {length(cards)} {column_label(col)}
+                </span>
               </div>
 
-              <div class="flex gap-4 mb-4 flex-wrap">
-                <div :for={{col, cards} <- @implementation_summary} class="flex items-center gap-1.5">
-                  <span class="text-xs text-base-content/50">{column_label(col)}</span>
-                  <span class="badge badge-sm badge-ghost">{length(cards)}</span>
-                </div>
-              </div>
-
-              <div class="space-y-2">
+              <div class="divide-y divide-base-200">
                 <div
                   :for={prompt <- @implementation_prompts |> Enum.take(3)}
-                  class="flex items-center justify-between py-1.5 px-2 bg-base-200/50 rounded-lg"
+                  class="flex items-center justify-between py-2"
                 >
                   <span class="text-sm truncate mr-2">{prompt.title}</span>
                   <.workflow_badge type={prompt.workflow_type} />

--- a/lib/destila_web/live/implementation_board_live.ex
+++ b/lib/destila_web/live/implementation_board_live.ex
@@ -42,7 +42,7 @@ defmodule DestilaWeb.ImplementationBoardLive do
 
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash} current_user={@current_user}>
+    <Layouts.app flash={@flash} current_user={@current_user} page_title={@page_title}>
       <div class="p-6 lg:p-8">
         <div class="flex items-center justify-between mb-6">
           <h1 class="text-2xl font-bold tracking-tight">Implementation</h1>

--- a/lib/destila_web/live/new_prompt_live.ex
+++ b/lib/destila_web/live/new_prompt_live.ex
@@ -142,8 +142,8 @@ defmodule DestilaWeb.NewPromptLive do
 
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash} current_user={@current_user}>
-      <div class="flex items-center justify-center min-h-[calc(100vh-4rem)]">
+    <Layouts.app flash={@flash} current_user={@current_user} page_title={@page_title}>
+      <div class="flex items-center justify-center min-h-screen">
         <div class="w-full max-w-lg px-6">
           <%!-- Step indicator --%>
           <div class="flex items-center justify-center gap-2 mb-8">

--- a/lib/destila_web/live/prompt_detail_live.ex
+++ b/lib/destila_web/live/prompt_detail_live.ex
@@ -216,8 +216,8 @@ defmodule DestilaWeb.PromptDetailLive do
 
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash} current_user={@current_user}>
-      <div class="flex flex-col h-[calc(100vh-4rem)]">
+    <Layouts.app flash={@flash} current_user={@current_user} page_title={@page_title}>
+      <div class="flex flex-col h-screen">
         <%!-- Header --%>
         <div class="border-b border-base-300 bg-base-100 px-6 py-4">
           <div class="flex items-center justify-between">
@@ -271,11 +271,16 @@ defmodule DestilaWeb.PromptDetailLive do
             </div>
 
             <div class="flex items-center gap-3 ml-4">
-              <div class="w-32">
-                <.progress_indicator
-                  completed={@prompt.steps_completed}
-                  total={@prompt.steps_total}
-                />
+              <div class="flex items-center gap-2">
+                <div class="w-24">
+                  <.progress_indicator
+                    completed={@prompt.steps_completed}
+                    total={@prompt.steps_total}
+                  />
+                </div>
+                <span class="text-xs text-base-content/40">
+                  {@prompt.steps_completed}/{@prompt.steps_total}
+                </span>
               </div>
               <button
                 :if={@prompt.column == :done && @prompt.board == :crafting}


### PR DESCRIPTION
## Summary
- Replace horizontal navigation bar with a fixed left sidebar (icons-only when collapsed, icons + labels when expanded via toggle click)
- Add theme indicator that's always visible — shows current theme icon when collapsed, icon + label when expanded, click to cycle through system/light/dark
- Distill UI: simplify board cards (shadow-only, inline progress fractions), flatten dashboard rows, soften column headers, remove redundant elements

## Test plan
- [x] `mix precommit` passes (compilation + 4 tests)
- [x] Visually verified sidebar collapse/expand with smooth transitions
- [x] Verified theme cycling: System → Light → Dark → System
- [x] Verified sidebar and theme state persist across page reloads via localStorage
- [x] Verified no layout shift when toggling sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)