### PR TITLE
feat: Introduce Project entity

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -31,10 +31,19 @@ const ScrollBottomHook = {
   updated() { this.el.scrollTop = this.el.scrollHeight },
 }
 
+const FocusFirstErrorHook = {
+  updated() {
+    let el = this.el.querySelector("[aria-invalid='true']")
+    if (!el) return
+    requestAnimationFrame(() => el.focus())
+  }
+}
+
 const Hooks = {
   ...colocatedHooks,
   Sortable: SortableHook,
   ScrollBottom: ScrollBottomHook,
+  FocusFirstError: FocusFirstErrorHook,
 }
 
 const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")

--- a/docs/plans/2026-03-21-feat-introduce-project-entity-plan.md
+++ b/docs/plans/2026-03-21-feat-introduce-project-entity-plan.md
@@ -1,0 +1,617 @@
+---
+title: "feat: Introduce Project Entity"
+type: feat
+date: 2026-03-21
+---
+
+# Introduce Project Entity
+
+## Overview
+
+Replace the current `repo_url` string field on prompts with a first-class **Project** entity. A Project represents a codebase that prompts operate against, with a name, an optional git repository URL, and an optional local folder path (at least one of the latter two is required). Projects are shared across prompts and managed independently.
+
+## Problem Statement / Motivation
+
+Currently, each prompt stores a raw `repo_url` string. This has limitations:
+
+- No way to share repository context across prompts — the same URL is duplicated
+- No structured representation of where a codebase lives (git URL vs local folder)
+- AI phases only receive a URL string, losing richer context (project name, local path)
+- No management UI for repositories — they're just free-text fields in the wizard
+
+A first-class Project entity solves these by providing a shared, structured representation.
+
+## Proposed Solution
+
+Add a Project entity to ETS alongside existing prompts and messages, with a CRUD management page, integration into the wizard, and updated AI phase context.
+
+## Technical Approach
+
+### Entity Relationship
+
+```mermaid
+erDiagram
+    PROJECT {
+        string id PK
+        string name
+        string git_repo_url
+        string local_folder
+        datetime created_at
+        datetime updated_at
+    }
+    PROMPT {
+        string id PK
+        string title
+        atom workflow_type
+        string project_id FK
+        atom board
+        atom column
+        integer steps_completed
+        integer steps_total
+        atom phase_status
+        integer position
+        datetime created_at
+        datetime updated_at
+    }
+    PROJECT ||--o{ PROMPT : "has many"
+```
+
+### Architecture
+
+**Storage layer** (`lib/destila/store.ex`): Add Project CRUD to the existing ETS table using `{:project, id}` composite keys, following the established pattern for prompts (`{:prompt, id}`) and messages (`{:message, prompt_id, id}`).
+
+**PubSub**: Use the existing `"store:updates"` topic with new event tuples: `{:project_created, project}`, `{:project_updated, project}`, `{:project_deleted, project}`.
+
+**Prompt schema change**: Replace `repo_url` field with `project_id` (string or nil). Remove `repo_url` entirely.
+
+### Implementation Phases
+
+#### Phase 1: Storage & Data Layer
+
+Add Project CRUD to `Destila.Store`:
+
+- `lib/destila/store.ex` — Add functions:
+
+```elixir
+# Project CRUD
+def list_projects do
+  :ets.match_object(@table, {{:project, :_}, :_})
+  |> Enum.map(fn {_key, project} -> project end)
+  |> Enum.sort_by(& &1.name)
+end
+
+def get_project(id) do
+  case :ets.lookup(@table, {:project, id}) do
+    [{_, project}] -> project
+    [] -> nil
+  end
+end
+
+def create_project(attrs) do
+  id = generate_id()
+  now = DateTime.utc_now()
+
+  project =
+    Map.merge(
+      %{id: id, name: "", git_repo_url: nil, local_folder: nil, created_at: now, updated_at: now},
+      attrs
+    )
+    |> Map.put(:id, id)
+
+  :ets.insert(@table, {{:project, id}, project})
+  Phoenix.PubSub.broadcast(Destila.PubSub, "store:updates", {:project_created, project})
+  project
+end
+
+def update_project(id, attrs) do
+  case get_project(id) do
+    nil -> nil
+    project ->
+      updated = Map.merge(project, attrs) |> Map.put(:updated_at, DateTime.utc_now())
+      :ets.insert(@table, {{:project, id}, updated})
+      Phoenix.PubSub.broadcast(Destila.PubSub, "store:updates", {:project_updated, updated})
+      updated
+  end
+end
+
+def delete_project(id) do
+  case get_project(id) do
+    nil -> {:error, :not_found}
+    project ->
+      linked = list_prompts() |> Enum.any?(&(&1[:project_id] == id))
+      if linked do
+        {:error, :has_linked_prompts}
+      else
+        :ets.delete(@table, {:project, id})
+        Phoenix.PubSub.broadcast(Destila.PubSub, "store:updates", {:project_deleted, project})
+        :ok
+      end
+  end
+end
+```
+
+- `lib/destila/store.ex` — Update `create_prompt/1` defaults: replace `repo_url: nil` with `project_id: nil`
+
+**Files to modify:**
+- `lib/destila/store.ex` — Add 5 project functions, update prompt defaults
+
+#### Phase 2: Seeds Migration
+
+Update `lib/destila/seeds.ex` to create Project entities and link prompts via `project_id`.
+
+**Deduplication mapping** (current seed `repo_url` values → projects):
+
+| Project Name | git_repo_url | Used by prompts |
+|---|---|---|
+| Acme Webapp | `https://github.com/acme/webapp` | "Add dark mode toggle", "Fix flaky test" |
+| Acme API Server | `https://github.com/acme/api-server` | "Refactor authentication middleware" |
+| Acme Payments | `https://github.com/acme/payments` | "Refactor payment gateway error handling" |
+| Acme Webhooks | `https://github.com/acme/webhooks` | "Implement webhook retry logic" |
+| Acme Gateway | `https://github.com/acme/gateway` | "Add rate limiting to API gateway" |
+| Acme Notifications | `https://github.com/acme/notifications` | "Build notification service" |
+| Acme Auth | `https://github.com/acme/auth` | "Migrate user sessions to Redis" |
+| Acme Reports | `https://github.com/acme/reports` | "GraphQL schema for reporting API" |
+| Acme Store | `https://github.com/acme/store` | "E2E test suite for checkout flow" |
+| Acme Search | `https://github.com/acme/search` | "Search indexing pipeline" |
+
+Prompts with `repo_url: nil` (project workflow type) get `project_id: nil`.
+
+**Structure:**
+- Add `seed_projects/0` called before `seed_crafting_board/0`
+- Use `insert_project/1` (direct ETS insert, no PubSub) mirroring `insert_prompt/1`
+- Store project IDs in module attribute or map for referencing in prompts
+
+**Files to modify:**
+- `lib/destila/seeds.ex` — Add project seeds, update all prompt seeds to use `project_id` instead of `repo_url`
+
+#### Phase 3: Update All `repo_url` References
+
+Replace all `repo_url` references across the codebase with `project_id` + project lookups.
+
+**Files to modify (9 files):**
+
+1. `lib/destila/store.ex:40` — Change default from `repo_url: nil` to `project_id: nil`
+2. `lib/destila_web/live/new_prompt_live.ex:11,89` — Change assign and prompt creation (full rework in Phase 5)
+3. `lib/destila_web/live/prompt_detail_live.ex:734` — Look up project by `@prompt.project_id`, display project name + URL/folder
+4. `lib/destila/workflows/chore_task_phases.ex:66` — Look up project in `system_prompt/2`:
+   ```elixir
+   def system_prompt(2, prompt) do
+     project = if prompt[:project_id], do: Destila.Store.get_project(prompt[:project_id])
+     repo_ref = cond do
+       project && project.git_repo_url -> project.git_repo_url
+       project && project.local_folder -> project.local_folder
+       true -> "unknown"
+     end
+     # ... use repo_ref in the prompt string
+   end
+   ```
+5. `lib/destila/seeds.ex` — (done in Phase 2)
+6. `test/destila_web/live/new_prompt_live_test.exs` — Update test assertions and setup
+7. `test/destila_web/live/chore_task_workflow_live_test.exs` — Update `create_prompt_in_phase/2` helper to use `project_id`
+8. `test/destila_web/live/generated_prompt_viewing_live_test.exs` — Update test setup
+
+#### Phase 4: Project Management Page
+
+Create a new LiveView at `/projects` for listing, creating, editing, and deleting projects.
+
+**New files:**
+- `lib/destila_web/live/projects_live.ex` — Single LiveView handling all CRUD via assigns
+
+**UI design:**
+
+- **List view**: Card-based list showing project name, git URL (if set), local folder (if set), and linked prompt count. Each card has edit/delete actions.
+- **Create/Edit**: Inline form that appears at top of list (not a separate page). Fields: name (required), git_repo_url (optional), local_folder (optional). Validation: name required + at least one of git_repo_url/local_folder.
+- **Delete**: Confirmation via a "Confirm delete" button that replaces the delete button. If project has linked prompts, show error message instead.
+- **Empty state**: "No projects yet" message with "Create your first project" CTA.
+
+**State management:**
+- `@projects` — stream of projects
+- `@form` — `to_form` for create/edit
+- `@editing_project_id` — nil or the ID being edited
+- `@creating` — boolean for showing create form
+
+**PubSub:** Subscribe to `"store:updates"` on mount, handle `{:project_created, _}`, `{:project_updated, _}`, `{:project_deleted, _}` to re-stream.
+
+**Router:** Add `live "/projects", ProjectsLive` to the authenticated scope.
+
+**Sidebar:** Add nav item after "Implementation":
+```heex
+<.sidebar_item
+  navigate={~p"/projects"}
+  icon="hero-folder"
+  label="Projects"
+  active={@page_title == "Projects"}
+/>
+```
+
+**Files to modify:**
+- `lib/destila_web/live/projects_live.ex` — New file
+- `lib/destila_web/router.ex` — Add route
+- `lib/destila_web/components/layouts.ex` — Add sidebar item
+
+#### Phase 5: Wizard Step 2 Redesign
+
+Replace the repository URL text input in `NewPromptLive` step 2 with a project selection interface.
+
+**UI design for step 2:**
+
+Two sub-views controlled by an `@project_step` assign (`:select` or `:create`):
+
+**Select view** (default):
+- Heading: "Link a project"
+- Project list: clickable cards showing project name + git URL or local folder. Selected project gets a highlighted border.
+- "Create New Project" button below the list
+- "Continue" button (enabled when a project is selected)
+- "Skip" button (only for `:project` workflow type)
+- "Back" button
+
+**Empty state** (no projects exist, non-project workflow):
+- "No projects yet. Create one to get started."
+- "Create New Project" button (prominent CTA)
+
+**Create view** (inline creation):
+- Heading: "Create a new project"
+- Form: name, git_repo_url, local_folder fields
+- "Create & Select" submit button
+- "Back to selection" button
+- Validation: name required + at least one of git_repo_url/local_folder
+
+**Assigns changes:**
+- Remove `repo_url` assign
+- Add `project_id` (selected project ID or nil)
+- Add `projects` (list of all projects, refreshed on mount and PubSub events)
+- Add `project_step` (`:select` or `:create`)
+- Add `project_form` (for inline creation form)
+
+**Event handlers:**
+- `select_project` — set `project_id` assign
+- `continue_project` — validate project selected (for non-project types), advance to step 3
+- `skip_project` — only for `:project` workflow type, advance to step 3 with `project_id: nil`
+- `show_create_project` — switch to `:create` sub-view
+- `back_to_select` — switch back to `:select` sub-view
+- `create_and_select_project` — validate, create project via Store, set `project_id`, switch to `:select` view with new project selected
+- `back` (from step 2) — go to step 1
+- `back_to_project` (from step 3) — go to step 2
+
+**PubSub:** Subscribe to `"store:updates"` for project events to keep the list current.
+
+**Prompt creation:** In `create_prompt_with_idea/3`, change `repo_url: socket.assigns.repo_url` to `project_id: socket.assigns.project_id`.
+
+**Files to modify:**
+- `lib/destila_web/live/new_prompt_live.ex` — Major rework of step 2
+
+#### Phase 6: AI Phase Context Update
+
+Update `ChoreTaskPhases.system_prompt/2` (phase 2) to resolve full project context.
+
+Pass both `git_repo_url` and `local_folder` to the AI prompt so it can use whichever is available:
+
+```elixir
+def system_prompt(2, prompt) do
+  project = if prompt[:project_id], do: Destila.Store.get_project(prompt[:project_id])
+
+  repo_context = cond do
+    project && project.git_repo_url && project.local_folder ->
+      "The project \"#{project.name}\" has a git repository at #{project.git_repo_url} and a local folder at #{project.local_folder}."
+    project && project.git_repo_url ->
+      "The project \"#{project.name}\" has a git repository at #{project.git_repo_url}."
+    project && project.local_folder ->
+      "The project \"#{project.name}\" has a local folder at #{project.local_folder}."
+    true ->
+      "The repository location is unknown."
+  end
+
+  """
+  You are reviewing Gherkin feature files for a coding task. #{repo_context}
+  ...
+  """
+end
+```
+
+**Files to modify:**
+- `lib/destila/workflows/chore_task_phases.ex` — Update `system_prompt/2` for phase 2
+
+#### Phase 7: Feature Files & Tests
+
+**Update existing feature file:**
+- `features/create_prompt_wizard.feature` — Replace all "repository URL" scenarios with project selection scenarios
+
+**New feature files:**
+- `features/project_management.feature` — CRUD scenarios
+- `features/project_inline_creation.feature` — Inline creation from wizard
+
+**Update existing tests:**
+- `test/destila_web/live/new_prompt_live_test.exs` — Rewrite step 2 tests for project selection
+- `test/destila_web/live/chore_task_workflow_live_test.exs` — Update `create_prompt_in_phase/2` to use `project_id`
+- `test/destila_web/live/generated_prompt_viewing_live_test.exs` — Update setup
+
+**New test files:**
+- `test/destila_web/live/projects_live_test.exs` — Tests for project management page
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] Projects can be created, listed, edited, and deleted at `/projects`
+- [ ] A project has a name (required) + at least one of git_repo_url or local_folder
+- [ ] Projects cannot be deleted while linked to one or more prompts
+- [ ] Wizard step 2 shows project selection (select existing or create inline)
+- [ ] `feature_request` and `chore_task` prompts require a project; `project` type can skip
+- [ ] Inline project creation in wizard creates the project and auto-selects it
+- [ ] Prompt detail header shows project name instead of repo_url
+- [ ] AI phase 2 receives full project context (name, git URL, local folder)
+- [ ] All seed data uses projects instead of repo_url
+- [ ] PubSub broadcasts project CRUD events on `"store:updates"` topic
+- [ ] "Projects" link appears in sidebar navigation
+
+### Quality Gates
+
+- [ ] All existing tests pass after migration
+- [ ] New tests cover project CRUD, wizard integration, and inline creation
+- [ ] Feature files updated to reflect new behavior
+- [ ] `mix precommit` passes
+
+## Dependencies & Risks
+
+**No external dependencies.** All changes are within the existing codebase.
+
+**Risks:**
+- **Broad refactoring scope**: 9+ files reference `repo_url`. Missing a reference will cause runtime errors. Mitigated by grepping thoroughly and running full test suite.
+- **Wizard complexity increase**: Step 2 goes from a simple text input to a selection + inline creation flow. Keep the UI simple to avoid over-engineering.
+
+## File Impact Summary
+
+| File | Change Type |
+|---|---|
+| `lib/destila/store.ex` | Modify — add project CRUD, update prompt defaults |
+| `lib/destila/seeds.ex` | Modify — add project seeds, update prompt seeds |
+| `lib/destila_web/router.ex` | Modify — add `/projects` route |
+| `lib/destila_web/components/layouts.ex` | Modify — add sidebar item |
+| `lib/destila_web/live/projects_live.ex` | **New** — project management page |
+| `lib/destila_web/live/new_prompt_live.ex` | Modify — rework step 2 |
+| `lib/destila_web/live/prompt_detail_live.ex` | Modify — show project instead of repo_url |
+| `lib/destila/workflows/chore_task_phases.ex` | Modify — resolve project in system_prompt |
+| `test/destila_web/live/new_prompt_live_test.exs` | Modify — update step 2 tests |
+| `test/destila_web/live/chore_task_workflow_live_test.exs` | Modify — update setup |
+| `test/destila_web/live/generated_prompt_viewing_live_test.exs` | Modify — update setup |
+| `test/destila_web/live/projects_live_test.exs` | **New** — project management tests |
+| `features/create_prompt_wizard.feature` | Modify — update for project selection |
+| `features/project_management.feature` | **New** |
+| `features/project_inline_creation.feature` | **New** |
+
+## Gherkin Scenarios
+
+### `features/create_prompt_wizard.feature` (updated)
+
+```gherkin
+Feature: Create Prompt Wizard
+  The Create Prompt wizard guides the user through a three-step flow:
+  1. Choose a workflow type (Feature Request, Chore/Task, or Project)
+  2. Link a project (select existing or create new)
+  3. Describe the initial idea
+  After completing the wizard, the user can save and continue to the chat,
+  or save and close to return to their previous page.
+
+  Background:
+    Given I am logged in
+
+  Scenario: Complete the wizard with Save & Continue
+    When I navigate to the new prompt page
+    Then I should see three step indicators
+    And I should see three workflow type options: "Feature Request", "Chore / Task", and "Project"
+    When I select one of the workflow types
+    Then I should be on step 2
+    And I should see a project selection interface
+    When I select an existing project
+    And I click "Continue"
+    Then I should be on step 3
+    And I should see the initial idea question
+    When I enter an initial idea
+    And I click "Save & Continue"
+    Then a new prompt should be created linked to the selected project
+    And the prompt title should be AI-generated based on the user input
+    And I should be redirected to the prompt detail page
+    And the chat should show the initial idea as the first user message
+
+  Scenario: Complete the wizard with Save & Close
+    When I navigate to the new prompt page from the crafting board
+    And I select one of the workflow types
+    And I complete the project step
+    Then I should be on step 3
+    When I enter an initial idea
+    And I click "Save & Close"
+    Then a new prompt should be created linked to the selected project
+    And the prompt title should be AI-generated based on the user input
+    And I should be redirected to the crafting board
+
+  Scenario: Create a new project inline during step 2
+    When I navigate to the new prompt page
+    And I select one of the workflow types
+    Then I should be on step 2
+    When I create a new project
+    Then the new project should be selected
+    When I click "Continue"
+    Then I should be on step 3
+
+  Scenario: Project is required for non-Project workflow types
+    When I navigate to the new prompt page
+    And I select a non-Project workflow type
+    Then I should be on step 2
+    And the "Skip" button should not be available
+    When I click "Continue" without selecting a project
+    Then I should see an error message indicating a project is required
+    And I should remain on step 2
+
+  Scenario: Skip project for Project workflow type
+    When I navigate to the new prompt page
+    And I select the Project workflow type
+    Then I should be on step 2
+    When I click "Skip"
+    Then I should be on step 3
+    And the prompt should not be linked to a project when saved
+
+  Scenario: Attempt to save without an initial idea
+    When I navigate to the new prompt page
+    And I select one of the workflow types
+    And I complete the project step
+    Then I should be on step 3
+    When I click "Save & Continue" without entering an idea
+    Then I should see an error message asking me to describe my initial idea
+    And I should remain on step 3
+    And no prompt should be created
+
+  Scenario: Navigate back from step 3 to step 2
+    When I navigate to the new prompt page
+    And I select one of the workflow types
+    And I complete the project step
+    Then I should be on step 3
+    When I click "Back"
+    Then I should be on step 2
+    And I should see a project selection interface
+
+  Scenario: Navigate back from step 2 to step 1
+    When I navigate to the new prompt page
+    And I select one of the workflow types
+    Then I should be on step 2
+    When I click "Back"
+    Then I should be on step 1
+    And I should see three workflow type options: "Feature Request", "Chore / Task", and "Project"
+```
+
+### `features/project_management.feature` (new)
+
+```gherkin
+Feature: Project Management
+  Users can manage projects independently from prompts. A project has a name,
+  an optional git repository URL, and an optional local folder path. At least
+  one of git repository URL or local folder must be provided. Projects can be
+  shared across multiple prompts.
+
+  Background:
+    Given I am logged in
+
+  Scenario: View list of projects
+    Given there are existing projects
+    When I navigate to the projects page
+    Then I should see a list of all projects
+    And each project should display its name, git repository URL, and local folder
+
+  Scenario: Create a new project with git repository URL
+    When I navigate to the projects page
+    And I click "New Project"
+    Then I should see a form with fields for name, git repository URL, and local folder
+    When I fill in the name and a git repository URL
+    And I click "Create"
+    Then the project should be created
+    And I should see it in the projects list
+
+  Scenario: Create a new project with local folder only
+    When I navigate to the projects page
+    And I click "New Project"
+    When I fill in the name and a local folder path
+    And I click "Create"
+    Then the project should be created
+
+  Scenario: Create a new project with both git URL and local folder
+    When I navigate to the projects page
+    And I click "New Project"
+    When I fill in the name, a git repository URL, and a local folder path
+    And I click "Create"
+    Then the project should be created
+
+  Scenario: Cannot create a project without git URL or local folder
+    When I navigate to the projects page
+    And I click "New Project"
+    When I fill in only the name
+    And I click "Create"
+    Then I should see an error indicating at least a git repository URL or local folder is required
+
+  Scenario: Cannot create a project without a name
+    When I navigate to the projects page
+    And I click "New Project"
+    When I fill in a git repository URL but leave the name empty
+    And I click "Create"
+    Then I should see an error indicating a name is required
+
+  Scenario: Edit an existing project
+    Given there is an existing project
+    When I navigate to the projects page
+    And I click edit on the project
+    Then I should see the project form pre-filled with the current values
+    When I update the project name
+    And I click "Save"
+    Then the project should be updated
+
+  Scenario: Delete a project not linked to any prompts
+    Given there is a project with no linked prompts
+    When I navigate to the projects page
+    And I click delete on the project
+    And I confirm the deletion
+    Then the project should be removed from the list
+
+  Scenario: Cannot delete a project linked to prompts
+    Given there is a project linked to one or more prompts
+    When I navigate to the projects page
+    And I click delete on the project
+    Then I should see a message indicating the project cannot be deleted while linked to prompts
+```
+
+### `features/project_inline_creation.feature` (new)
+
+```gherkin
+Feature: Project Inline Creation
+  Users can create a new project inline from contexts such as the Create Prompt
+  wizard. A project requires a name and at least one of a git repository URL or
+  a local folder path.
+
+  Background:
+    Given I am logged in
+
+  Scenario: Create a project with a git repository URL
+    When I am prompted to select a project
+    And I click "Create New Project"
+    Then I should see fields for project name, git repository URL, and local folder
+    When I fill in the project name and a git repository URL
+    And I click "Create & Select"
+    Then the new project should be created and selected
+
+  Scenario: Create a project with a local folder only
+    When I am prompted to select a project
+    And I click "Create New Project"
+    When I fill in the project name and a local folder path
+    And I click "Create & Select"
+    Then the new project should be created and selected
+
+  Scenario: Create a project with both git URL and local folder
+    When I am prompted to select a project
+    And I click "Create New Project"
+    When I fill in the project name, a git repository URL, and a local folder path
+    And I click "Create & Select"
+    Then the new project should be created and selected
+
+  Scenario: Cannot create a project without git URL or local folder
+    When I am prompted to select a project
+    And I click "Create New Project"
+    When I fill in only the project name
+    And I click "Create & Select"
+    Then I should see an error indicating at least a git repository URL or local folder is required
+
+  Scenario: Cannot create a project without a name
+    When I am prompted to select a project
+    And I click "Create New Project"
+    When I fill in a git repository URL but leave the name empty
+    And I click "Create & Select"
+    Then I should see an error indicating a name is required
+```
+
+## References
+
+### Internal References
+
+- Store pattern: `lib/destila/store.ex` — ETS table with composite keys, PubSub broadcasts
+- Wizard pattern: `lib/destila_web/live/new_prompt_live.ex` — Multi-step form with assign-based state
+- AI phases: `lib/destila/workflows/chore_task_phases.ex:66` — Phase 2 uses `prompt[:repo_url]`
+- Sidebar: `lib/destila_web/components/layouts.ex:49-66` — Navigation items
+- Seeds: `lib/destila/seeds.ex` — Direct ETS inserts, no PubSub
+- Prompt detail header: `lib/destila_web/live/prompt_detail_live.ex:734` — Displays `repo_url`
+- Router: `lib/destila_web/router.ex:27-35` — Authenticated scope

--- a/features/create_prompt_wizard.feature
+++ b/features/create_prompt_wizard.feature
@@ -1,7 +1,7 @@
 Feature: Create Prompt Wizard
   The Create Prompt wizard guides the user through a three-step flow:
   1. Choose a workflow type (Feature Request, Chore/Task, or Project)
-  2. Optionally link a repository URL
+  2. Link a project (select existing or create new)
   3. Describe the initial idea
   After completing the wizard, the user can save and continue to the chat,
   or save and close to return to their previous page.
@@ -15,14 +15,14 @@ Feature: Create Prompt Wizard
     And I should see three workflow type options: "Feature Request", "Chore / Task", and "Project"
     When I select one of the workflow types
     Then I should be on step 2
-    And I should see a repository URL input field
-    When I enter a valid repository URL
+    And I should see a project selection interface
+    When I select an existing project
     And I click "Continue"
     Then I should be on step 3
     And I should see the initial idea question
     When I enter an initial idea
     And I click "Save & Continue"
-    Then a new prompt should be created with the initial idea pre-populated
+    Then a new prompt should be created linked to the selected project
     And the prompt title should be AI-generated based on the user input
     And I should be redirected to the prompt detail page
     And the chat should show the initial idea as the first user message
@@ -30,35 +30,44 @@ Feature: Create Prompt Wizard
   Scenario: Complete the wizard with Save & Close
     When I navigate to the new prompt page from the crafting board
     And I select one of the workflow types
-    And I complete the repository URL step
+    And I complete the project step
     Then I should be on step 3
     When I enter an initial idea
     And I click "Save & Close"
-    Then a new prompt should be created with the initial idea pre-populated
+    Then a new prompt should be created linked to the selected project
     And the prompt title should be AI-generated based on the user input
     And I should be redirected to the crafting board
 
-  Scenario: Repository URL can only be skipped for Project type
+  Scenario: Create a new project inline during step 2
+    When I navigate to the new prompt page
+    And I select one of the workflow types
+    Then I should be on step 2
+    When I create a new project
+    Then the new project should be selected
+    When I click "Continue"
+    Then I should be on step 3
+
+  Scenario: Project is required for non-Project workflow types
     When I navigate to the new prompt page
     And I select a non-Project workflow type
     Then I should be on step 2
     And the "Skip" button should not be available
-    When I click "Continue" without entering a URL
-    Then I should see an error message indicating a repository URL is required
+    When I click "Continue" without selecting a project
+    Then I should see an error message indicating a project is required
     And I should remain on step 2
 
-  Scenario: Skip repository URL for Project type
+  Scenario: Skip project for Project workflow type
     When I navigate to the new prompt page
-    And I select "Project"
+    And I select the Project workflow type
     Then I should be on step 2
     When I click "Skip"
     Then I should be on step 3
-    And the prompt should not have a repository URL when saved
+    And the prompt should not be linked to a project when saved
 
   Scenario: Attempt to save without an initial idea
     When I navigate to the new prompt page
     And I select one of the workflow types
-    And I complete the repository URL step
+    And I complete the project step
     Then I should be on step 3
     When I click "Save & Continue" without entering an idea
     Then I should see an error message asking me to describe my initial idea
@@ -68,11 +77,11 @@ Feature: Create Prompt Wizard
   Scenario: Navigate back from step 3 to step 2
     When I navigate to the new prompt page
     And I select one of the workflow types
-    And I complete the repository URL step
+    And I complete the project step
     Then I should be on step 3
     When I click "Back"
     Then I should be on step 2
-    And I should see a repository URL input field
+    And I should see a project selection interface
 
   Scenario: Navigate back from step 2 to step 1
     When I navigate to the new prompt page

--- a/features/project_inline_creation.feature
+++ b/features/project_inline_creation.feature
@@ -1,0 +1,43 @@
+Feature: Project Inline Creation
+  Users can create a new project inline from contexts such as the Create Prompt
+  wizard. A project requires a name and at least one of a git repository URL or
+  a local folder path.
+
+  Background:
+    Given I am logged in
+
+  Scenario: Create a project with a git repository URL
+    When I am prompted to select a project
+    And I click "Create New Project"
+    Then I should see fields for project name, git repository URL, and local folder
+    When I fill in the project name and a git repository URL
+    And I click "Create & Select"
+    Then the new project should be created and selected
+
+  Scenario: Create a project with a local folder only
+    When I am prompted to select a project
+    And I click "Create New Project"
+    When I fill in the project name and a local folder path
+    And I click "Create & Select"
+    Then the new project should be created and selected
+
+  Scenario: Create a project with both git URL and local folder
+    When I am prompted to select a project
+    And I click "Create New Project"
+    When I fill in the project name, a git repository URL, and a local folder path
+    And I click "Create & Select"
+    Then the new project should be created and selected
+
+  Scenario: Cannot create a project without git URL or local folder
+    When I am prompted to select a project
+    And I click "Create New Project"
+    When I fill in only the project name
+    And I click "Create & Select"
+    Then I should see an error indicating at least a git repository URL or local folder is required
+
+  Scenario: Cannot create a project without a name
+    When I am prompted to select a project
+    And I click "Create New Project"
+    When I fill in a git repository URL but leave the name empty
+    And I click "Create & Select"
+    Then I should see an error indicating a name is required

--- a/features/project_management.feature
+++ b/features/project_management.feature
@@ -1,0 +1,73 @@
+Feature: Project Management
+  Users can manage projects independently from prompts. A project has a name,
+  an optional git repository URL, and an optional local folder path. At least
+  one of git repository URL or local folder must be provided. Projects can be
+  shared across multiple prompts.
+
+  Background:
+    Given I am logged in
+
+  Scenario: View list of projects
+    Given there are existing projects
+    When I navigate to the projects page
+    Then I should see a list of all projects
+    And each project should display its name, git repository URL, and local folder
+
+  Scenario: Create a new project with git repository URL
+    When I navigate to the projects page
+    And I click "New Project"
+    Then I should see a form with fields for name, git repository URL, and local folder
+    When I fill in the name and a git repository URL
+    And I click "Create"
+    Then the project should be created
+    And I should see it in the projects list
+
+  Scenario: Create a new project with local folder only
+    When I navigate to the projects page
+    And I click "New Project"
+    When I fill in the name and a local folder path
+    And I click "Create"
+    Then the project should be created
+
+  Scenario: Create a new project with both git URL and local folder
+    When I navigate to the projects page
+    And I click "New Project"
+    When I fill in the name, a git repository URL, and a local folder path
+    And I click "Create"
+    Then the project should be created
+
+  Scenario: Cannot create a project without git URL or local folder
+    When I navigate to the projects page
+    And I click "New Project"
+    When I fill in only the name
+    And I click "Create"
+    Then I should see an error indicating at least a git repository URL or local folder is required
+
+  Scenario: Cannot create a project without a name
+    When I navigate to the projects page
+    And I click "New Project"
+    When I fill in a git repository URL but leave the name empty
+    And I click "Create"
+    Then I should see an error indicating a name is required
+
+  Scenario: Edit an existing project
+    Given there is an existing project
+    When I navigate to the projects page
+    And I click edit on the project
+    Then I should see the project form pre-filled with the current values
+    When I update the project name
+    And I click "Save"
+    Then the project should be updated
+
+  Scenario: Delete a project not linked to any prompts
+    Given there is a project with no linked prompts
+    When I navigate to the projects page
+    And I click delete on the project
+    And I confirm the deletion
+    Then the project should be removed from the list
+
+  Scenario: Cannot delete a project linked to prompts
+    Given there is a project linked to one or more prompts
+    When I navigate to the projects page
+    And I click delete on the project
+    Then I should see a message indicating the project cannot be deleted while linked to prompts

--- a/lib/destila/seeds.ex
+++ b/lib/destila/seeds.ex
@@ -6,17 +6,47 @@ defmodule Destila.Seeds do
   alias Destila.Store
 
   def seed do
-    seed_crafting_board()
-    seed_implementation_board()
+    projects = seed_projects()
+    seed_crafting_board(projects)
+    seed_implementation_board(projects)
     seed_chat_messages()
   end
 
-  defp seed_crafting_board do
+  defp seed_projects do
+    %{
+      webapp:
+        insert_project(%{name: "Acme Webapp", git_repo_url: "https://github.com/acme/webapp"}),
+      api_server:
+        insert_project(%{
+          name: "Acme API Server",
+          git_repo_url: "https://github.com/acme/api-server"
+        }),
+      payments:
+        insert_project(%{name: "Acme Payments", git_repo_url: "https://github.com/acme/payments"}),
+      webhooks:
+        insert_project(%{name: "Acme Webhooks", git_repo_url: "https://github.com/acme/webhooks"}),
+      gateway:
+        insert_project(%{name: "Acme Gateway", git_repo_url: "https://github.com/acme/gateway"}),
+      notifications:
+        insert_project(%{
+          name: "Acme Notifications",
+          git_repo_url: "https://github.com/acme/notifications"
+        }),
+      auth: insert_project(%{name: "Acme Auth", git_repo_url: "https://github.com/acme/auth"}),
+      reports:
+        insert_project(%{name: "Acme Reports", git_repo_url: "https://github.com/acme/reports"}),
+      store: insert_project(%{name: "Acme Store", git_repo_url: "https://github.com/acme/store"}),
+      search:
+        insert_project(%{name: "Acme Search", git_repo_url: "https://github.com/acme/search"})
+    }
+  end
+
+  defp seed_crafting_board(projects) do
     # Request column
     insert_prompt(%{
       title: "Add dark mode toggle to settings",
       workflow_type: :feature_request,
-      repo_url: "https://github.com/acme/webapp",
+      project_id: projects.webapp.id,
       board: :crafting,
       column: :request,
       steps_completed: 0,
@@ -27,7 +57,7 @@ defmodule Destila.Seeds do
     insert_prompt(%{
       title: "Build onboarding wizard for new users",
       workflow_type: :project,
-      repo_url: nil,
+      project_id: nil,
       board: :crafting,
       column: :request,
       steps_completed: 0,
@@ -40,7 +70,7 @@ defmodule Destila.Seeds do
       %{
         title: "Refactor authentication middleware",
         workflow_type: :feature_request,
-        repo_url: "https://github.com/acme/api-server",
+        project_id: projects.api_server.id,
         board: :crafting,
         column: :distill,
         steps_completed: 2,
@@ -53,7 +83,7 @@ defmodule Destila.Seeds do
     insert_prompt(%{
       title: "CLI tool for database migrations",
       workflow_type: :project,
-      repo_url: nil,
+      project_id: nil,
       board: :crafting,
       column: :distill,
       steps_completed: 1,
@@ -64,7 +94,7 @@ defmodule Destila.Seeds do
     insert_prompt(%{
       title: "Fix flaky test in user registration flow",
       workflow_type: :chore_task,
-      repo_url: "https://github.com/acme/webapp",
+      project_id: projects.webapp.id,
       board: :crafting,
       column: :request,
       steps_completed: 0,
@@ -75,7 +105,7 @@ defmodule Destila.Seeds do
     insert_prompt(%{
       title: "Refactor payment gateway error handling",
       workflow_type: :chore_task,
-      repo_url: "https://github.com/acme/payments",
+      project_id: projects.payments.id,
       board: :crafting,
       column: :distill,
       steps_completed: 1,
@@ -87,7 +117,7 @@ defmodule Destila.Seeds do
     insert_prompt(%{
       title: "Implement webhook retry logic",
       workflow_type: :feature_request,
-      repo_url: "https://github.com/acme/webhooks",
+      project_id: projects.webhooks.id,
       board: :crafting,
       column: :done,
       steps_completed: 4,
@@ -96,11 +126,11 @@ defmodule Destila.Seeds do
     })
   end
 
-  defp seed_implementation_board do
+  defp seed_implementation_board(projects) do
     insert_prompt(%{
       title: "Add rate limiting to API gateway",
       workflow_type: :feature_request,
-      repo_url: "https://github.com/acme/gateway",
+      project_id: projects.gateway.id,
       board: :implementation,
       column: :todo,
       steps_completed: 4,
@@ -111,7 +141,7 @@ defmodule Destila.Seeds do
     insert_prompt(%{
       title: "Build notification service",
       workflow_type: :project,
-      repo_url: "https://github.com/acme/notifications",
+      project_id: projects.notifications.id,
       board: :implementation,
       column: :todo,
       steps_completed: 3,
@@ -122,7 +152,7 @@ defmodule Destila.Seeds do
     insert_prompt(%{
       title: "Migrate user sessions to Redis",
       workflow_type: :feature_request,
-      repo_url: "https://github.com/acme/auth",
+      project_id: projects.auth.id,
       board: :implementation,
       column: :in_progress,
       steps_completed: 4,
@@ -133,7 +163,7 @@ defmodule Destila.Seeds do
     insert_prompt(%{
       title: "GraphQL schema for reporting API",
       workflow_type: :feature_request,
-      repo_url: "https://github.com/acme/reports",
+      project_id: projects.reports.id,
       board: :implementation,
       column: :review,
       steps_completed: 4,
@@ -144,7 +174,7 @@ defmodule Destila.Seeds do
     insert_prompt(%{
       title: "E2E test suite for checkout flow",
       workflow_type: :project,
-      repo_url: "https://github.com/acme/store",
+      project_id: projects.store.id,
       board: :implementation,
       column: :qa,
       steps_completed: 3,
@@ -155,7 +185,7 @@ defmodule Destila.Seeds do
     insert_prompt(%{
       title: "Search indexing pipeline",
       workflow_type: :project,
-      repo_url: "https://github.com/acme/search",
+      project_id: projects.search.id,
       board: :implementation,
       column: :impl_done,
       steps_completed: 3,
@@ -233,6 +263,27 @@ defmodule Destila.Seeds do
         created_at: DateTime.add(base_time, 240, :second)
       })
     end
+  end
+
+  defp insert_project(attrs) do
+    id = :crypto.strong_rand_bytes(16) |> Base.url_encode64(padding: false)
+    now = DateTime.utc_now()
+
+    project =
+      Map.merge(
+        %{
+          id: id,
+          name: "",
+          git_repo_url: nil,
+          local_folder: nil,
+          created_at: now,
+          updated_at: now
+        },
+        attrs
+      )
+
+    :ets.insert(:destila_store, {{:project, id}, project})
+    project
   end
 
   defp insert_prompt(attrs, :with_partial_chat) do

--- a/lib/destila/store.ex
+++ b/lib/destila/store.ex
@@ -37,7 +37,7 @@ defmodule Destila.Store do
           id: id,
           title: "Untitled Prompt",
           workflow_type: :feature_request,
-          repo_url: nil,
+          project_id: nil,
           board: :crafting,
           column: :request,
           steps_completed: 0,
@@ -71,6 +71,81 @@ defmodule Destila.Store do
 
   def move_card(id, new_column, new_position) do
     update_prompt(id, %{column: new_column, position: new_position})
+  end
+
+  # Project API
+
+  def list_projects do
+    :ets.match_object(@table, {{:project, :_}, :_})
+    |> Enum.map(fn {_key, project} -> project end)
+    |> Enum.sort_by(& &1.name)
+  end
+
+  def get_project(id) do
+    case :ets.lookup(@table, {:project, id}) do
+      [{_, project}] -> project
+      [] -> nil
+    end
+  end
+
+  def create_project(attrs) do
+    id = generate_id()
+    now = DateTime.utc_now()
+
+    project =
+      Map.merge(
+        %{
+          id: id,
+          name: "",
+          git_repo_url: nil,
+          local_folder: nil,
+          created_at: now,
+          updated_at: now
+        },
+        attrs
+      )
+      |> Map.put(:id, id)
+
+    :ets.insert(@table, {{:project, id}, project})
+    Phoenix.PubSub.broadcast(Destila.PubSub, "store:updates", {:project_created, project})
+    project
+  end
+
+  def update_project(id, attrs) do
+    case get_project(id) do
+      nil ->
+        nil
+
+      project ->
+        updated = Map.merge(project, attrs) |> Map.put(:updated_at, DateTime.utc_now())
+        :ets.insert(@table, {{:project, id}, updated})
+        Phoenix.PubSub.broadcast(Destila.PubSub, "store:updates", {:project_updated, updated})
+        updated
+    end
+  end
+
+  def delete_project(id) do
+    case get_project(id) do
+      nil ->
+        {:error, :not_found}
+
+      project ->
+        linked = list_prompts() |> Enum.any?(&(&1[:project_id] == id))
+
+        if linked do
+          {:error, :has_linked_prompts}
+        else
+          :ets.delete(@table, {:project, id})
+
+          Phoenix.PubSub.broadcast(
+            Destila.PubSub,
+            "store:updates",
+            {:project_deleted, project}
+          )
+
+          :ok
+        end
+    end
   end
 
   def list_messages(prompt_id) do

--- a/lib/destila/workflows/chore_task_phases.ex
+++ b/lib/destila/workflows/chore_task_phases.ex
@@ -63,10 +63,26 @@ defmodule Destila.Workflows.ChoreTaskPhases do
   end
 
   def system_prompt(2, prompt) do
-    repo_url = prompt[:repo_url] || "unknown"
+    project =
+      if prompt[:project_id], do: Destila.Store.get_project(prompt[:project_id])
+
+    repo_context =
+      cond do
+        project && project.git_repo_url && project.local_folder ->
+          "The project \"#{project.name}\" has a git repository at #{project.git_repo_url} and a local folder at #{project.local_folder}."
+
+        project && project.git_repo_url ->
+          "The project \"#{project.name}\" has a git repository at #{project.git_repo_url}."
+
+        project && project.local_folder ->
+          "The project \"#{project.name}\" has a local folder at #{project.local_folder}."
+
+        true ->
+          "The repository location is unknown."
+      end
 
     """
-    You are reviewing Gherkin feature files for a coding task. The repository is at #{repo_url}.
+    You are reviewing Gherkin feature files for a coding task. #{repo_context}
 
     Use your tools to browse the repository and find existing .feature files. Then:
 

--- a/lib/destila_web/components/layouts.ex
+++ b/lib/destila_web/components/layouts.ex
@@ -60,6 +60,13 @@ defmodule DestilaWeb.Layouts do
           active={@page_title == "Implementation"}
         />
 
+        <.sidebar_item
+          navigate={~p"/projects"}
+          icon="hero-folder"
+          label="Projects"
+          active={@page_title == "Projects"}
+        />
+
         <div class="my-2 mx-1 border-t border-base-300/50" />
 
         <.sidebar_item navigate={~p"/prompts/new"} icon="hero-plus-circle" label="Create Prompt" />

--- a/lib/destila_web/live/new_prompt_live.ex
+++ b/lib/destila_web/live/new_prompt_live.ex
@@ -11,6 +11,10 @@ defmodule DestilaWeb.NewPromptLive do
      |> assign(:project_id, nil)
      |> assign(:projects, Destila.Store.list_projects())
      |> assign(:project_step, :select)
+     |> assign(
+       :project_form,
+       to_form(%{"name" => "", "git_repo_url" => "", "local_folder" => ""})
+     )
      |> assign(:initial_idea, "")
      |> assign(:return_to, "/crafting")
      |> assign(:errors, %{})}
@@ -88,7 +92,10 @@ defmodule DestilaWeb.NewPromptLive do
        |> assign(:project_step, :select)
        |> assign(:errors, %{})}
     else
-      {:noreply, assign(socket, :errors, errors)}
+      {:noreply,
+       socket
+       |> assign(:project_form, to_form(params))
+       |> assign(:errors, errors)}
     end
   end
 
@@ -539,6 +546,7 @@ defmodule DestilaWeb.NewPromptLive do
                     type="text"
                     id="project-name"
                     name="name"
+                    value={@project_form["name"].value}
                     placeholder="My Project"
                     aria-invalid={@errors[:name] && "true"}
                     class={[
@@ -571,6 +579,7 @@ defmodule DestilaWeb.NewPromptLive do
                       type="url"
                       id="project-git-repo-url"
                       name="git_repo_url"
+                      value={@project_form["git_repo_url"].value}
                       placeholder="https://github.com/org/repo"
                       aria-invalid={@errors[:location] && "true"}
                       class={[
@@ -594,6 +603,7 @@ defmodule DestilaWeb.NewPromptLive do
                       type="text"
                       id="project-local-folder"
                       name="local_folder"
+                      value={@project_form["local_folder"].value}
                       placeholder="/path/to/project"
                       aria-invalid={@errors[:location] && "true"}
                       class={[

--- a/lib/destila_web/live/new_prompt_live.ex
+++ b/lib/destila_web/live/new_prompt_live.ex
@@ -429,8 +429,8 @@ defmodule DestilaWeb.NewPromptLive do
 
               <%= if @projects == [] do %>
                 <div class="text-center py-8">
-                  <.icon name="hero-folder" class="size-12 text-base-content/20 mx-auto mb-3" />
-                  <p class="text-sm text-base-content/50 mb-4">No projects yet</p>
+                  <.icon name="hero-folder" class="size-10 text-base-content/20 mx-auto mb-3" />
+                  <p class="text-sm text-base-content/30 mb-4">No projects yet</p>
                   <button
                     phx-click="show_create_project"
                     class="btn btn-primary"
@@ -450,7 +450,7 @@ defmodule DestilaWeb.NewPromptLive do
                       "w-full text-left p-3 rounded-lg border-2 transition-colors cursor-pointer",
                       if(@project_id == project.id,
                         do: "border-primary bg-primary/5",
-                        else: "border-base-300 hover:border-base-content/20"
+                        else: "border-base-300 hover:border-primary"
                       )
                     ]}
                   >

--- a/lib/destila_web/live/new_prompt_live.ex
+++ b/lib/destila_web/live/new_prompt_live.ex
@@ -8,7 +8,9 @@ defmodule DestilaWeb.NewPromptLive do
      |> assign(:page_title, "New Prompt")
      |> assign(:step, 1)
      |> assign(:workflow_type, nil)
-     |> assign(:repo_url, nil)
+     |> assign(:project_id, nil)
+     |> assign(:projects, Destila.Store.list_projects())
+     |> assign(:project_step, :select)
      |> assign(:initial_idea, "")
      |> assign(:return_to, "/crafting")}
   end
@@ -25,29 +27,71 @@ defmodule DestilaWeb.NewPromptLive do
      |> assign(:step, 2)}
   end
 
-  def handle_event("set_repo", %{"repo_url" => repo_url}, socket) do
-    url = if repo_url && repo_url != "", do: repo_url, else: nil
-
-    if url == nil && socket.assigns.workflow_type != :project do
-      {:noreply, put_flash(socket, :error, "Repository URL is required")}
+  def handle_event("continue_project", _params, socket) do
+    if socket.assigns.project_id == nil && socket.assigns.workflow_type != :project do
+      {:noreply, put_flash(socket, :error, "Please select a project")}
     else
-      {:noreply, assign(socket, step: 3, repo_url: url)}
+      {:noreply, assign(socket, step: 3)}
     end
   end
 
-  def handle_event("skip_repo", _params, %{assigns: %{workflow_type: :project}} = socket) do
-    {:noreply, assign(socket, step: 3, repo_url: nil)}
+  def handle_event("skip_project", _params, %{assigns: %{workflow_type: :project}} = socket) do
+    {:noreply, assign(socket, step: 3, project_id: nil)}
   end
 
-  def handle_event("skip_repo", _params, socket) do
-    {:noreply, put_flash(socket, :error, "Repository URL is required")}
+  def handle_event("skip_project", _params, socket) do
+    {:noreply, put_flash(socket, :error, "Please select a project")}
+  end
+
+  def handle_event("select_project", %{"id" => project_id}, socket) do
+    {:noreply, assign(socket, :project_id, project_id)}
+  end
+
+  def handle_event("show_create_project", _params, socket) do
+    {:noreply, assign(socket, :project_step, :create)}
+  end
+
+  def handle_event("back_to_select", _params, socket) do
+    {:noreply, assign(socket, :project_step, :select)}
+  end
+
+  def handle_event("create_and_select_project", params, socket) do
+    name = String.trim(params["name"] || "")
+    git_repo_url = params["git_repo_url"]
+    git_repo_url = if git_repo_url && git_repo_url != "", do: git_repo_url, else: nil
+    local_folder = params["local_folder"]
+    local_folder = if local_folder && local_folder != "", do: local_folder, else: nil
+
+    cond do
+      name == "" ->
+        {:noreply, put_flash(socket, :error, "Project name is required")}
+
+      git_repo_url == nil && local_folder == nil ->
+        {:noreply,
+         put_flash(socket, :error, "At least a git repository URL or local folder is required")}
+
+      true ->
+        project =
+          Destila.Store.create_project(%{
+            name: name,
+            git_repo_url: git_repo_url,
+            local_folder: local_folder
+          })
+
+        {:noreply,
+         socket
+         |> assign(:project_id, project.id)
+         |> assign(:projects, Destila.Store.list_projects())
+         |> assign(:project_step, :select)}
+    end
   end
 
   def handle_event("back", _params, socket) do
-    {:noreply, assign(socket, step: 1, workflow_type: nil)}
+    {:noreply,
+     assign(socket, step: 1, workflow_type: nil, project_id: nil, project_step: :select)}
   end
 
-  def handle_event("back_to_repo", _params, socket) do
+  def handle_event("back_to_project", _params, socket) do
     {:noreply, assign(socket, step: 2)}
   end
 
@@ -86,7 +130,7 @@ defmodule DestilaWeb.NewPromptLive do
         title: "Generating title...",
         title_generating: true,
         workflow_type: workflow_type,
-        repo_url: socket.assigns.repo_url,
+        project_id: socket.assigns.project_id,
         board: :crafting,
         column: :request,
         steps_completed: 1,
@@ -368,51 +412,148 @@ defmodule DestilaWeb.NewPromptLive do
             </div>
           </div>
 
-          <%!-- Step 2: Link repository --%>
+          <%!-- Step 2: Link a project --%>
           <div :if={@step == 2} class="space-y-4">
-            <div class="text-center mb-6">
-              <h2 class="text-xl font-bold">Link a repository</h2>
-              <p class="text-sm text-base-content/50 mt-1">
-                <%= if @workflow_type == :project do %>
-                  Paste a repository URL to give context, or skip for new projects
-                <% else %>
-                  Paste a repository URL to give context for your task
-                <% end %>
-              </p>
-            </div>
+            <%!-- Select existing project --%>
+            <div :if={@project_step == :select}>
+              <div class="text-center mb-6">
+                <h2 class="text-xl font-bold">Link a project</h2>
+                <p class="text-sm text-base-content/50 mt-1">
+                  <%= if @workflow_type == :project do %>
+                    Select a project to give context, or skip for new projects
+                  <% else %>
+                    Select the project this task belongs to
+                  <% end %>
+                </p>
+              </div>
 
-            <form phx-submit="set_repo" class="space-y-4">
-              <fieldset class="fieldset">
-                <label class="fieldset-label text-xs font-medium" for="repo_url">
-                  Repository URL <span :if={@workflow_type != :project} class="text-error">*</span>
-                </label>
-                <input
-                  type="url"
-                  id="repo_url"
-                  name="repo_url"
-                  placeholder="https://github.com/org/repo"
-                  class="input input-bordered w-full"
-                />
-              </fieldset>
+              <%= if @projects == [] do %>
+                <div class="text-center py-8">
+                  <.icon name="hero-folder" class="size-12 text-base-content/20 mx-auto mb-3" />
+                  <p class="text-sm text-base-content/50 mb-4">No projects yet</p>
+                  <button
+                    phx-click="show_create_project"
+                    class="btn btn-primary"
+                    id="create-first-project-btn"
+                  >
+                    <.icon name="hero-plus-micro" class="size-4" /> Create your first project
+                  </button>
+                </div>
+              <% else %>
+                <div class="space-y-2 max-h-64 overflow-y-auto" id="project-list">
+                  <button
+                    :for={project <- @projects}
+                    phx-click="select_project"
+                    phx-value-id={project.id}
+                    id={"project-#{project.id}"}
+                    class={[
+                      "w-full text-left p-3 rounded-lg border-2 transition-colors cursor-pointer",
+                      if(@project_id == project.id,
+                        do: "border-primary bg-primary/5",
+                        else: "border-base-300 hover:border-base-content/20"
+                      )
+                    ]}
+                  >
+                    <div class="font-medium text-sm">{project.name}</div>
+                    <div class="text-xs text-base-content/40 mt-0.5">
+                      {project.git_repo_url || project.local_folder}
+                    </div>
+                  </button>
+                </div>
 
-              <div class="flex gap-3">
-                <button type="submit" class="btn btn-primary flex-1">
+                <button
+                  phx-click="show_create_project"
+                  class="btn btn-ghost btn-sm w-full mt-2"
+                  id="create-new-project-btn"
+                >
+                  <.icon name="hero-plus-micro" class="size-4" /> Create New Project
+                </button>
+              <% end %>
+
+              <div class="flex gap-3 mt-4">
+                <button
+                  phx-click="continue_project"
+                  class="btn btn-primary flex-1"
+                  id="continue-project-btn"
+                >
                   Continue
                 </button>
                 <button
                   :if={@workflow_type == :project}
-                  type="button"
-                  phx-click="skip_repo"
+                  phx-click="skip_project"
                   class="btn btn-ghost flex-1"
+                  id="skip-project-btn"
                 >
                   Skip
                 </button>
               </div>
-            </form>
 
-            <button phx-click="back" class="btn btn-ghost btn-sm w-full mt-2 text-base-content/40">
-              &larr; Back
-            </button>
+              <button phx-click="back" class="btn btn-ghost btn-sm w-full mt-2 text-base-content/40">
+                &larr; Back
+              </button>
+            </div>
+
+            <%!-- Create new project inline --%>
+            <div :if={@project_step == :create}>
+              <div class="text-center mb-6">
+                <h2 class="text-xl font-bold">Create a new project</h2>
+                <p class="text-sm text-base-content/50 mt-1">
+                  Add a name and at least a git URL or local folder
+                </p>
+              </div>
+
+              <form phx-submit="create_and_select_project" class="space-y-4" id="inline-project-form">
+                <fieldset class="fieldset">
+                  <label class="fieldset-label text-xs font-medium" for="project-name">
+                    Project name <span class="text-error">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    id="project-name"
+                    name="name"
+                    placeholder="My Project"
+                    class="input input-bordered w-full"
+                  />
+                </fieldset>
+
+                <fieldset class="fieldset">
+                  <label class="fieldset-label text-xs font-medium" for="project-git-repo-url">
+                    Git repository URL
+                  </label>
+                  <input
+                    type="url"
+                    id="project-git-repo-url"
+                    name="git_repo_url"
+                    placeholder="https://github.com/org/repo"
+                    class="input input-bordered w-full"
+                  />
+                </fieldset>
+
+                <fieldset class="fieldset">
+                  <label class="fieldset-label text-xs font-medium" for="project-local-folder">
+                    Local folder
+                  </label>
+                  <input
+                    type="text"
+                    id="project-local-folder"
+                    name="local_folder"
+                    placeholder="/path/to/project"
+                    class="input input-bordered w-full"
+                  />
+                </fieldset>
+
+                <button type="submit" class="btn btn-primary w-full" id="create-and-select-btn">
+                  <.icon name="hero-plus-micro" class="size-4" /> Create & Select
+                </button>
+              </form>
+
+              <button
+                phx-click="back_to_select"
+                class="btn btn-ghost btn-sm w-full mt-2 text-base-content/40"
+              >
+                &larr; Back to selection
+              </button>
+            </div>
           </div>
 
           <%!-- Step 3: Initial idea --%>
@@ -460,7 +601,7 @@ defmodule DestilaWeb.NewPromptLive do
             </form>
 
             <button
-              phx-click="back_to_repo"
+              phx-click="back_to_project"
               class="btn btn-ghost btn-sm w-full mt-2 text-base-content/40"
             >
               &larr; Back

--- a/lib/destila_web/live/new_prompt_live.ex
+++ b/lib/destila_web/live/new_prompt_live.ex
@@ -549,6 +549,7 @@ defmodule DestilaWeb.NewPromptLive do
                     value={@project_form["name"].value}
                     placeholder="My Project"
                     aria-invalid={@errors[:name] && "true"}
+                    phx-mounted={JS.focus()}
                     class={[
                       "input input-bordered w-full",
                       @errors[:name] && "input-error"

--- a/lib/destila_web/live/new_prompt_live.ex
+++ b/lib/destila_web/live/new_prompt_live.ex
@@ -12,7 +12,8 @@ defmodule DestilaWeb.NewPromptLive do
      |> assign(:projects, Destila.Store.list_projects())
      |> assign(:project_step, :select)
      |> assign(:initial_idea, "")
-     |> assign(:return_to, "/crafting")}
+     |> assign(:return_to, "/crafting")
+     |> assign(:errors, %{})}
   end
 
   def handle_params(params, _uri, socket) do
@@ -29,9 +30,9 @@ defmodule DestilaWeb.NewPromptLive do
 
   def handle_event("continue_project", _params, socket) do
     if socket.assigns.project_id == nil && socket.assigns.workflow_type != :project do
-      {:noreply, put_flash(socket, :error, "Please select a project")}
+      {:noreply, assign(socket, :errors, %{project: "Please select a project"})}
     else
-      {:noreply, assign(socket, step: 3)}
+      {:noreply, assign(socket, step: 3, errors: %{})}
     end
   end
 
@@ -40,15 +41,15 @@ defmodule DestilaWeb.NewPromptLive do
   end
 
   def handle_event("skip_project", _params, socket) do
-    {:noreply, put_flash(socket, :error, "Please select a project")}
+    {:noreply, assign(socket, :errors, %{project: "Please select a project"})}
   end
 
   def handle_event("select_project", %{"id" => project_id}, socket) do
-    {:noreply, assign(socket, :project_id, project_id)}
+    {:noreply, assign(socket, project_id: project_id, errors: %{})}
   end
 
   def handle_event("show_create_project", _params, socket) do
-    {:noreply, assign(socket, :project_step, :create)}
+    {:noreply, assign(socket, project_step: :create, errors: %{})}
   end
 
   def handle_event("back_to_select", _params, socket) do
@@ -62,41 +63,59 @@ defmodule DestilaWeb.NewPromptLive do
     local_folder = params["local_folder"]
     local_folder = if local_folder && local_folder != "", do: local_folder, else: nil
 
-    cond do
-      name == "" ->
-        {:noreply, put_flash(socket, :error, "Project name is required")}
+    errors = %{}
+    errors = if name == "", do: Map.put(errors, :name, "Name is required"), else: errors
 
-      git_repo_url == nil && local_folder == nil ->
-        {:noreply,
-         put_flash(socket, :error, "At least a git repository URL or local folder is required")}
+    errors =
+      if git_repo_url == nil && local_folder == nil do
+        Map.put(errors, :location, "Provide at least one")
+      else
+        errors
+      end
 
-      true ->
-        project =
-          Destila.Store.create_project(%{
-            name: name,
-            git_repo_url: git_repo_url,
-            local_folder: local_folder
-          })
+    if errors == %{} do
+      project =
+        Destila.Store.create_project(%{
+          name: name,
+          git_repo_url: git_repo_url,
+          local_folder: local_folder
+        })
 
-        {:noreply,
-         socket
-         |> assign(:project_id, project.id)
-         |> assign(:projects, Destila.Store.list_projects())
-         |> assign(:project_step, :select)}
+      {:noreply,
+       socket
+       |> assign(:project_id, project.id)
+       |> assign(:projects, Destila.Store.list_projects())
+       |> assign(:project_step, :select)
+       |> assign(:errors, %{})}
+    else
+      {:noreply, assign(socket, :errors, errors)}
     end
   end
 
   def handle_event("back", _params, socket) do
     {:noreply,
-     assign(socket, step: 1, workflow_type: nil, project_id: nil, project_step: :select)}
+     assign(socket,
+       step: 1,
+       workflow_type: nil,
+       project_id: nil,
+       project_step: :select,
+       errors: %{}
+     )}
   end
 
   def handle_event("back_to_project", _params, socket) do
-    {:noreply, assign(socket, step: 2)}
+    {:noreply, assign(socket, step: 2, errors: %{})}
   end
 
   def handle_event("update_idea", %{"initial_idea" => idea}, socket) do
-    {:noreply, assign(socket, :initial_idea, idea)}
+    errors =
+      if idea != "" do
+        Map.delete(socket.assigns.errors, :idea)
+      else
+        socket.assigns.errors
+      end
+
+    {:noreply, assign(socket, initial_idea: idea, errors: errors)}
   end
 
   def handle_event("save_and_continue", %{"initial_idea" => idea}, socket)
@@ -106,7 +125,7 @@ defmodule DestilaWeb.NewPromptLive do
   end
 
   def handle_event("save_and_continue", _params, socket) do
-    {:noreply, put_flash(socket, :error, "Please describe your initial idea")}
+    {:noreply, assign(socket, :errors, %{idea: "Please describe your initial idea"})}
   end
 
   def handle_event("save_and_close", _params, socket) do
@@ -116,7 +135,7 @@ defmodule DestilaWeb.NewPromptLive do
       create_prompt_with_idea(socket, idea, :close)
       {:noreply, push_navigate(socket, to: socket.assigns.return_to)}
     else
-      {:noreply, put_flash(socket, :error, "Please describe your initial idea")}
+      {:noreply, assign(socket, :errors, %{idea: "Please describe your initial idea"})}
     end
   end
 
@@ -470,6 +489,10 @@ defmodule DestilaWeb.NewPromptLive do
                 </button>
               <% end %>
 
+              <p :if={@errors[:project]} class="text-xs text-error text-center mt-2">
+                {@errors[:project]}
+              </p>
+
               <div class="flex gap-3 mt-4">
                 <button
                   phx-click="continue_project"
@@ -512,35 +535,66 @@ defmodule DestilaWeb.NewPromptLive do
                     id="project-name"
                     name="name"
                     placeholder="My Project"
-                    class="input input-bordered w-full"
+                    class={[
+                      "input input-bordered w-full",
+                      @errors[:name] && "input-error"
+                    ]}
                   />
+                  <p :if={@errors[:name]} class="text-xs text-error mt-1">{@errors[:name]}</p>
                 </fieldset>
 
-                <fieldset class="fieldset">
-                  <label class="fieldset-label text-xs font-medium" for="project-git-repo-url">
-                    Git repository URL
-                  </label>
-                  <input
-                    type="url"
-                    id="project-git-repo-url"
-                    name="git_repo_url"
-                    placeholder="https://github.com/org/repo"
-                    class="input input-bordered w-full"
-                  />
-                </fieldset>
+                <div class={[
+                  "rounded-lg p-3 space-y-3",
+                  if(@errors[:location],
+                    do: "ring-1 ring-error/30 bg-error/5",
+                    else: "bg-base-200/50"
+                  )
+                ]}>
+                  <div class="flex items-center gap-2">
+                    <span class="text-xs font-medium text-base-content/50">Location</span>
+                    <span class="text-xs text-base-content/30">at least one required</span>
+                  </div>
 
-                <fieldset class="fieldset">
-                  <label class="fieldset-label text-xs font-medium" for="project-local-folder">
-                    Local folder
-                  </label>
-                  <input
-                    type="text"
-                    id="project-local-folder"
-                    name="local_folder"
-                    placeholder="/path/to/project"
-                    class="input input-bordered w-full"
-                  />
-                </fieldset>
+                  <fieldset class="fieldset">
+                    <label class="fieldset-label text-xs font-medium" for="project-git-repo-url">
+                      Git repository URL
+                    </label>
+                    <input
+                      type="url"
+                      id="project-git-repo-url"
+                      name="git_repo_url"
+                      placeholder="https://github.com/org/repo"
+                      class={[
+                        "input input-bordered w-full",
+                        @errors[:location] && "input-error"
+                      ]}
+                    />
+                  </fieldset>
+
+                  <div class="flex items-center gap-3">
+                    <div class="flex-1 h-px bg-base-300" />
+                    <span class="text-xs text-base-content/30">or</span>
+                    <div class="flex-1 h-px bg-base-300" />
+                  </div>
+
+                  <fieldset class="fieldset">
+                    <label class="fieldset-label text-xs font-medium" for="project-local-folder">
+                      Local folder
+                    </label>
+                    <input
+                      type="text"
+                      id="project-local-folder"
+                      name="local_folder"
+                      placeholder="/path/to/project"
+                      class={[
+                        "input input-bordered w-full",
+                        @errors[:location] && "input-error"
+                      ]}
+                    />
+                  </fieldset>
+
+                  <p :if={@errors[:location]} class="text-xs text-error">{@errors[:location]}</p>
+                </div>
 
                 <button type="submit" class="btn btn-primary w-full" id="create-and-select-btn">
                   <.icon name="hero-plus-micro" class="size-4" /> Create & Select
@@ -580,9 +634,13 @@ defmodule DestilaWeb.NewPromptLive do
                   name="initial_idea"
                   rows="5"
                   placeholder="Describe your idea in as much detail as you'd like..."
-                  class="textarea textarea-bordered w-full"
+                  class={[
+                    "textarea textarea-bordered w-full",
+                    @errors[:idea] && "textarea-error"
+                  ]}
                   phx-debounce="300"
                 />
+                <p :if={@errors[:idea]} class="text-xs text-error mt-1">{@errors[:idea]}</p>
               </fieldset>
 
               <div class="flex gap-3">

--- a/lib/destila_web/live/new_prompt_live.ex
+++ b/lib/destila_web/live/new_prompt_live.ex
@@ -525,7 +525,12 @@ defmodule DestilaWeb.NewPromptLive do
                 </p>
               </div>
 
-              <form phx-submit="create_and_select_project" class="space-y-4" id="inline-project-form">
+              <form
+                phx-submit="create_and_select_project"
+                class="space-y-4"
+                id="inline-project-form"
+                phx-hook="FocusFirstError"
+              >
                 <fieldset class="fieldset">
                   <label class="fieldset-label text-xs font-medium" for="project-name">
                     Project name <span class="text-error">*</span>
@@ -535,12 +540,15 @@ defmodule DestilaWeb.NewPromptLive do
                     id="project-name"
                     name="name"
                     placeholder="My Project"
+                    aria-invalid={@errors[:name] && "true"}
                     class={[
                       "input input-bordered w-full",
                       @errors[:name] && "input-error"
                     ]}
                   />
-                  <p :if={@errors[:name]} class="text-xs text-error mt-1">{@errors[:name]}</p>
+                  <p :if={@errors[:name]} class="text-xs text-error mt-1">
+                    {@errors[:name]}
+                  </p>
                 </fieldset>
 
                 <div class={[
@@ -564,6 +572,7 @@ defmodule DestilaWeb.NewPromptLive do
                       id="project-git-repo-url"
                       name="git_repo_url"
                       placeholder="https://github.com/org/repo"
+                      aria-invalid={@errors[:location] && "true"}
                       class={[
                         "input input-bordered w-full",
                         @errors[:location] && "input-error"
@@ -586,6 +595,7 @@ defmodule DestilaWeb.NewPromptLive do
                       id="project-local-folder"
                       name="local_folder"
                       placeholder="/path/to/project"
+                      aria-invalid={@errors[:location] && "true"}
                       class={[
                         "input input-bordered w-full",
                         @errors[:location] && "input-error"
@@ -593,7 +603,9 @@ defmodule DestilaWeb.NewPromptLive do
                     />
                   </fieldset>
 
-                  <p :if={@errors[:location]} class="text-xs text-error">{@errors[:location]}</p>
+                  <p :if={@errors[:location]} class="text-xs text-error">
+                    {@errors[:location]}
+                  </p>
                 </div>
 
                 <button type="submit" class="btn btn-primary w-full" id="create-and-select-btn">
@@ -623,6 +635,7 @@ defmodule DestilaWeb.NewPromptLive do
               id="initial-idea-form"
               phx-submit="save_and_continue"
               phx-change="update_idea"
+              phx-hook="FocusFirstError"
               class="space-y-4"
             >
               <fieldset class="fieldset">
@@ -634,13 +647,16 @@ defmodule DestilaWeb.NewPromptLive do
                   name="initial_idea"
                   rows="5"
                   placeholder="Describe your idea in as much detail as you'd like..."
+                  aria-invalid={@errors[:idea] && "true"}
                   class={[
                     "textarea textarea-bordered w-full",
                     @errors[:idea] && "textarea-error"
                   ]}
                   phx-debounce="300"
                 />
-                <p :if={@errors[:idea]} class="text-xs text-error mt-1">{@errors[:idea]}</p>
+                <p :if={@errors[:idea]} class="text-xs text-error mt-1">
+                  {@errors[:idea]}
+                </p>
               </fieldset>
 
               <div class="flex gap-3">

--- a/lib/destila_web/live/projects_live.ex
+++ b/lib/destila_web/live/projects_live.ex
@@ -17,6 +17,7 @@ defmodule DestilaWeb.ProjectsLive do
      |> assign(:creating, false)
      |> assign(:editing_project_id, nil)
      |> assign(:form, new_form())
+     |> assign(:errors, %{})
      |> assign(:delete_confirming_id, nil)}
   end
 
@@ -25,7 +26,8 @@ defmodule DestilaWeb.ProjectsLive do
      socket
      |> assign(:creating, true)
      |> assign(:editing_project_id, nil)
-     |> assign(:form, new_form())}
+     |> assign(:form, new_form())
+     |> assign(:errors, %{})}
   end
 
   def handle_event("cancel", _params, socket) do
@@ -37,6 +39,7 @@ defmodule DestilaWeb.ProjectsLive do
       |> assign(:creating, false)
       |> assign(:editing_project_id, nil)
       |> assign(:delete_confirming_id, nil)
+      |> assign(:errors, %{})
 
     {:noreply, socket}
   end
@@ -49,10 +52,11 @@ defmodule DestilaWeb.ProjectsLive do
         {:noreply,
          socket
          |> assign(:creating, false)
-         |> assign(:form, new_form())}
+         |> assign(:form, new_form())
+         |> assign(:errors, %{})}
 
-      {:error, message} ->
-        {:noreply, put_flash(socket, :error, message)}
+      {:error, errors} ->
+        {:noreply, assign(socket, :errors, errors)}
     end
   end
 
@@ -72,7 +76,8 @@ defmodule DestilaWeb.ProjectsLive do
        |> stream_insert(:projects, project)
        |> assign(:editing_project_id, id)
        |> assign(:creating, false)
-       |> assign(:form, form)}
+       |> assign(:form, form)
+       |> assign(:errors, %{})}
     else
       {:noreply, socket}
     end
@@ -88,10 +93,11 @@ defmodule DestilaWeb.ProjectsLive do
         {:noreply,
          socket
          |> assign(:editing_project_id, nil)
-         |> assign(:form, new_form())}
+         |> assign(:form, new_form())
+         |> assign(:errors, %{})}
 
-      {:error, message} ->
-        {:noreply, put_flash(socket, :error, message)}
+      {:error, errors} ->
+        {:noreply, assign(socket, :errors, errors)}
     end
   end
 
@@ -118,7 +124,7 @@ defmodule DestilaWeb.ProjectsLive do
          socket
          |> maybe_restream_project(id)
          |> assign(:delete_confirming_id, nil)
-         |> put_flash(:error, "Cannot delete project while it is linked to prompts")}
+         |> put_flash(:error, "Cannot delete this project while it is linked to prompts")}
 
       {:error, :not_found} ->
         {:noreply, assign(socket, :delete_confirming_id, nil)}
@@ -178,15 +184,21 @@ defmodule DestilaWeb.ProjectsLive do
     local_folder = params["local_folder"]
     local_folder = if local_folder && local_folder != "", do: local_folder, else: nil
 
-    cond do
-      name == "" ->
-        {:error, "Project name is required"}
+    errors = %{}
+    errors = if name == "", do: Map.put(errors, :name, "Name is required"), else: errors
 
-      git_repo_url == nil && local_folder == nil ->
-        {:error, "At least a git repository URL or local folder is required"}
+    errors =
+      if git_repo_url == nil && local_folder == nil do
+        errors
+        |> Map.put(:location, "Provide at least one")
+      else
+        errors
+      end
 
-      true ->
-        {:ok, %{name: name, git_repo_url: git_repo_url, local_folder: local_folder}}
+    if errors == %{} do
+      {:ok, %{name: name, git_repo_url: git_repo_url, local_folder: local_folder}}
+    else
+      {:error, errors}
     end
   end
 
@@ -226,7 +238,12 @@ defmodule DestilaWeb.ProjectsLive do
         >
           <div class="card-body">
             <h3 class="text-sm font-semibold mb-3">New Project</h3>
-            <.project_form form={@form} submit_event="create_project" submit_label="Create">
+            <.project_form
+              form={@form}
+              errors={@errors}
+              submit_event="create_project"
+              submit_label="Create"
+            >
               <button phx-click="cancel" type="button" class="btn btn-ghost btn-sm flex-1">
                 Cancel
               </button>
@@ -257,7 +274,12 @@ defmodule DestilaWeb.ProjectsLive do
             <%!-- Edit form --%>
             <div :if={@editing_project_id == project.id} class="card-body">
               <h3 class="text-sm font-semibold mb-3">Edit Project</h3>
-              <.project_form form={@form} submit_event="update_project" submit_label="Save">
+              <.project_form
+                form={@form}
+                errors={@errors}
+                submit_event="update_project"
+                submit_label="Save"
+              >
                 <button phx-click="cancel" type="button" class="btn btn-ghost btn-sm flex-1">
                   Cancel
                 </button>
@@ -331,6 +353,7 @@ defmodule DestilaWeb.ProjectsLive do
   end
 
   attr :form, :any, required: true
+  attr :errors, :map, required: true
   attr :submit_event, :string, required: true
   attr :submit_label, :string, required: true
   slot :inner_block
@@ -348,37 +371,65 @@ defmodule DestilaWeb.ProjectsLive do
           name="name"
           value={@form["name"].value}
           placeholder="My Project"
-          class="input input-bordered w-full input-sm"
+          class={[
+            "input input-bordered w-full input-sm",
+            @errors[:name] && "input-error"
+          ]}
         />
+        <p :if={@errors[:name]} class="text-xs text-error mt-1">{@errors[:name]}</p>
       </fieldset>
 
-      <fieldset class="fieldset">
-        <label class="fieldset-label text-xs font-medium" for="project-git-repo-url">
-          Git repository URL
-        </label>
-        <input
-          type="url"
-          id="project-git-repo-url"
-          name="git_repo_url"
-          value={@form["git_repo_url"].value}
-          placeholder="https://github.com/org/repo"
-          class="input input-bordered w-full input-sm"
-        />
-      </fieldset>
+      <div class={[
+        "rounded-lg p-3 space-y-3",
+        if(@errors[:location], do: "ring-1 ring-error/30 bg-error/5", else: "bg-base-200/50")
+      ]}>
+        <div class="flex items-center gap-2">
+          <span class="text-xs font-medium text-base-content/50">Location</span>
+          <span class="text-xs text-base-content/30">at least one required</span>
+        </div>
 
-      <fieldset class="fieldset">
-        <label class="fieldset-label text-xs font-medium" for="project-local-folder">
-          Local folder
-        </label>
-        <input
-          type="text"
-          id="project-local-folder"
-          name="local_folder"
-          value={@form["local_folder"].value}
-          placeholder="/path/to/project"
-          class="input input-bordered w-full input-sm"
-        />
-      </fieldset>
+        <fieldset class="fieldset">
+          <label class="fieldset-label text-xs font-medium" for="project-git-repo-url">
+            Git repository URL
+          </label>
+          <input
+            type="url"
+            id="project-git-repo-url"
+            name="git_repo_url"
+            value={@form["git_repo_url"].value}
+            placeholder="https://github.com/org/repo"
+            class={[
+              "input input-bordered w-full input-sm",
+              @errors[:location] && "input-error"
+            ]}
+          />
+        </fieldset>
+
+        <div class="flex items-center gap-3">
+          <div class="flex-1 h-px bg-base-300" />
+          <span class="text-xs text-base-content/30">or</span>
+          <div class="flex-1 h-px bg-base-300" />
+        </div>
+
+        <fieldset class="fieldset">
+          <label class="fieldset-label text-xs font-medium" for="project-local-folder">
+            Local folder
+          </label>
+          <input
+            type="text"
+            id="project-local-folder"
+            name="local_folder"
+            value={@form["local_folder"].value}
+            placeholder="/path/to/project"
+            class={[
+              "input input-bordered w-full input-sm",
+              @errors[:location] && "input-error"
+            ]}
+          />
+        </fieldset>
+
+        <p :if={@errors[:location]} class="text-xs text-error">{@errors[:location]}</p>
+      </div>
 
       <div class="flex gap-2">
         <button type="submit" class="btn btn-primary btn-sm flex-1">

--- a/lib/destila_web/live/projects_live.ex
+++ b/lib/destila_web/live/projects_live.ex
@@ -191,8 +191,15 @@ defmodule DestilaWeb.ProjectsLive do
   end
 
   defp linked_prompt_count(project_id) do
-    Destila.Store.list_prompts()
-    |> Enum.count(&(&1[:project_id] == project_id))
+    count =
+      Destila.Store.list_prompts()
+      |> Enum.count(&(&1[:project_id] == project_id))
+
+    case count do
+      0 -> "No prompts"
+      1 -> "1 prompt"
+      n -> "#{n} prompts"
+    end
   end
 
   def render(assigns) do
@@ -219,8 +226,11 @@ defmodule DestilaWeb.ProjectsLive do
         >
           <div class="card-body">
             <h3 class="text-sm font-semibold mb-3">New Project</h3>
-            <.project_form form={@form} submit_event="create_project" submit_label="Create" />
-            <button phx-click="cancel" class="btn btn-ghost btn-sm mt-2">Cancel</button>
+            <.project_form form={@form} submit_event="create_project" submit_label="Create">
+              <button phx-click="cancel" type="button" class="btn btn-ghost btn-sm flex-1">
+                Cancel
+              </button>
+            </.project_form>
           </div>
         </div>
 
@@ -242,38 +252,47 @@ defmodule DestilaWeb.ProjectsLive do
           <div
             :for={{id, project} <- @streams.projects}
             id={id}
-            class="card bg-base-100 shadow-sm mb-3"
+            class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow mb-3"
           >
             <%!-- Edit form --%>
             <div :if={@editing_project_id == project.id} class="card-body">
               <h3 class="text-sm font-semibold mb-3">Edit Project</h3>
-              <.project_form form={@form} submit_event="update_project" submit_label="Save" />
-              <button phx-click="cancel" class="btn btn-ghost btn-sm mt-2">Cancel</button>
+              <.project_form form={@form} submit_event="update_project" submit_label="Save">
+                <button phx-click="cancel" type="button" class="btn btn-ghost btn-sm flex-1">
+                  Cancel
+                </button>
+              </.project_form>
             </div>
 
             <%!-- Display --%>
-            <div :if={@editing_project_id != project.id} class="card-body">
+            <div :if={@editing_project_id != project.id} class="card-body p-4 gap-2">
               <div class="flex items-start justify-between">
                 <div class="min-w-0 flex-1">
-                  <h3 class="font-semibold">{project.name}</h3>
+                  <h4 class="text-sm font-medium leading-tight">{project.name}</h4>
                   <div class="flex flex-col gap-0.5 mt-1">
-                    <span :if={project.git_repo_url} class="text-xs text-base-content/40 truncate">
-                      <.icon name="hero-link-micro" class="size-3 inline" /> {project.git_repo_url}
+                    <span
+                      :if={project.git_repo_url}
+                      class="text-xs text-base-content/40 truncate"
+                    >
+                      <.icon name="hero-link-micro" class="size-3.5 inline" />
+                      {project.git_repo_url}
                     </span>
                     <span :if={project.local_folder} class="text-xs text-base-content/40 truncate">
-                      <.icon name="hero-folder-micro" class="size-3 inline" /> {project.local_folder}
+                      <.icon name="hero-folder-micro" class="size-3.5 inline" />
+                      {project.local_folder}
                     </span>
                   </div>
-                  <span class="text-xs text-base-content/30 mt-1">
-                    {linked_prompt_count(project.id)} linked prompt(s)
-                  </span>
                 </div>
 
                 <div class="flex items-center gap-1 ml-4 shrink-0">
+                  <span class="text-xs text-base-content/40">
+                    {linked_prompt_count(project.id)}
+                  </span>
+
                   <button
                     phx-click="edit_project"
                     phx-value-id={project.id}
-                    class="btn btn-ghost btn-xs"
+                    class="btn btn-ghost btn-xs opacity-60 hover:opacity-100 transition-opacity"
                     id={"edit-project-#{project.id}"}
                   >
                     <.icon name="hero-pencil-micro" class="size-4" />
@@ -286,7 +305,7 @@ defmodule DestilaWeb.ProjectsLive do
                       class="btn btn-error btn-xs"
                       id={"confirm-delete-#{project.id}"}
                     >
-                      Confirm
+                      Delete
                     </button>
                     <button phx-click="cancel" class="btn btn-ghost btn-xs">
                       Cancel
@@ -295,7 +314,7 @@ defmodule DestilaWeb.ProjectsLive do
                     <button
                       phx-click="confirm_delete"
                       phx-value-id={project.id}
-                      class="btn btn-ghost btn-xs text-error/60 hover:text-error"
+                      class="btn btn-ghost btn-xs opacity-60 hover:opacity-100 transition-opacity text-error/60 hover:text-error"
                       id={"delete-project-#{project.id}"}
                     >
                       <.icon name="hero-trash-micro" class="size-4" />
@@ -314,6 +333,7 @@ defmodule DestilaWeb.ProjectsLive do
   attr :form, :any, required: true
   attr :submit_event, :string, required: true
   attr :submit_label, :string, required: true
+  slot :inner_block
 
   defp project_form(assigns) do
     ~H"""
@@ -360,9 +380,12 @@ defmodule DestilaWeb.ProjectsLive do
         />
       </fieldset>
 
-      <button type="submit" class="btn btn-primary btn-sm w-full">
-        {@submit_label}
-      </button>
+      <div class="flex gap-2">
+        <button type="submit" class="btn btn-primary btn-sm flex-1">
+          {@submit_label}
+        </button>
+        {render_slot(@inner_block)}
+      </div>
     </form>
     """
   end

--- a/lib/destila_web/live/projects_live.ex
+++ b/lib/destila_web/live/projects_live.ex
@@ -29,11 +29,16 @@ defmodule DestilaWeb.ProjectsLive do
   end
 
   def handle_event("cancel", _params, socket) do
-    {:noreply,
-     socket
-     |> assign(:creating, false)
-     |> assign(:editing_project_id, nil)
-     |> assign(:delete_confirming_id, nil)}
+    # Re-stream affected projects so stream items re-render
+    socket =
+      socket
+      |> maybe_restream_project(socket.assigns.editing_project_id)
+      |> maybe_restream_project(socket.assigns.delete_confirming_id)
+      |> assign(:creating, false)
+      |> assign(:editing_project_id, nil)
+      |> assign(:delete_confirming_id, nil)
+
+    {:noreply, socket}
   end
 
   def handle_event("create_project", params, socket) do
@@ -64,6 +69,7 @@ defmodule DestilaWeb.ProjectsLive do
 
       {:noreply,
        socket
+       |> stream_insert(:projects, project)
        |> assign(:editing_project_id, id)
        |> assign(:creating, false)
        |> assign(:form, form)}
@@ -90,6 +96,15 @@ defmodule DestilaWeb.ProjectsLive do
   end
 
   def handle_event("confirm_delete", %{"id" => id}, socket) do
+    project = Destila.Store.get_project(id)
+
+    socket =
+      if project do
+        stream_insert(socket, :projects, project)
+      else
+        socket
+      end
+
     {:noreply, assign(socket, :delete_confirming_id, id)}
   end
 
@@ -101,6 +116,7 @@ defmodule DestilaWeb.ProjectsLive do
       {:error, :has_linked_prompts} ->
         {:noreply,
          socket
+         |> maybe_restream_project(id)
          |> assign(:delete_confirming_id, nil)
          |> put_flash(:error, "Cannot delete project while it is linked to prompts")}
 
@@ -141,6 +157,15 @@ defmodule DestilaWeb.ProjectsLive do
   def handle_info(_msg, socket), do: {:noreply, socket}
 
   # Helpers
+
+  defp maybe_restream_project(socket, nil), do: socket
+
+  defp maybe_restream_project(socket, project_id) do
+    case Destila.Store.get_project(project_id) do
+      nil -> socket
+      project -> stream_insert(socket, :projects, project)
+    end
+  end
 
   defp new_form do
     to_form(%{"name" => "", "git_repo_url" => "", "local_folder" => ""})

--- a/lib/destila_web/live/projects_live.ex
+++ b/lib/destila_web/live/projects_live.ex
@@ -198,7 +198,7 @@ defmodule DestilaWeb.ProjectsLive do
   def render(assigns) do
     ~H"""
     <Layouts.app flash={@flash} current_user={@current_user} page_title={@page_title}>
-      <div class="p-6 lg:p-8 max-w-3xl mx-auto">
+      <div class="p-6 lg:p-8">
         <div class="flex items-center justify-between mb-6">
           <h1 class="text-2xl font-bold tracking-tight">Projects</h1>
           <button

--- a/lib/destila_web/live/projects_live.ex
+++ b/lib/destila_web/live/projects_live.ex
@@ -366,7 +366,12 @@ defmodule DestilaWeb.ProjectsLive do
 
   defp project_form(assigns) do
     ~H"""
-    <form phx-submit={@submit_event} class="space-y-3" id={"project-form-#{@submit_event}"}>
+    <form
+      phx-submit={@submit_event}
+      class="space-y-3"
+      id={"project-form-#{@submit_event}"}
+      phx-hook="FocusFirstError"
+    >
       <fieldset class="fieldset">
         <label class="fieldset-label text-xs font-medium" for="project-name">
           Name <span class="text-error">*</span>
@@ -377,6 +382,8 @@ defmodule DestilaWeb.ProjectsLive do
           name="name"
           value={@form["name"].value}
           placeholder="My Project"
+          aria-invalid={@errors[:name] && "true"}
+          phx-mounted={JS.focus()}
           class={[
             "input input-bordered w-full input-sm",
             @errors[:name] && "input-error"
@@ -404,6 +411,7 @@ defmodule DestilaWeb.ProjectsLive do
             name="git_repo_url"
             value={@form["git_repo_url"].value}
             placeholder="https://github.com/org/repo"
+            aria-invalid={@errors[:location] && "true"}
             class={[
               "input input-bordered w-full input-sm",
               @errors[:location] && "input-error"
@@ -427,6 +435,7 @@ defmodule DestilaWeb.ProjectsLive do
             name="local_folder"
             value={@form["local_folder"].value}
             placeholder="/path/to/project"
+            aria-invalid={@errors[:location] && "true"}
             class={[
               "input input-bordered w-full input-sm",
               @errors[:location] && "input-error"

--- a/lib/destila_web/live/projects_live.ex
+++ b/lib/destila_web/live/projects_live.ex
@@ -56,7 +56,10 @@ defmodule DestilaWeb.ProjectsLive do
          |> assign(:errors, %{})}
 
       {:error, errors} ->
-        {:noreply, assign(socket, :errors, errors)}
+        {:noreply,
+         socket
+         |> assign(:form, to_form(params))
+         |> assign(:errors, errors)}
     end
   end
 
@@ -97,7 +100,10 @@ defmodule DestilaWeb.ProjectsLive do
          |> assign(:errors, %{})}
 
       {:error, errors} ->
-        {:noreply, assign(socket, :errors, errors)}
+        {:noreply,
+         socket
+         |> assign(:form, to_form(params))
+         |> assign(:errors, errors)}
     end
   end
 

--- a/lib/destila_web/live/projects_live.ex
+++ b/lib/destila_web/live/projects_live.ex
@@ -1,0 +1,349 @@
+defmodule DestilaWeb.ProjectsLive do
+  use DestilaWeb, :live_view
+
+  def mount(_params, session, socket) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Destila.PubSub, "store:updates")
+    end
+
+    projects = Destila.Store.list_projects()
+
+    {:ok,
+     socket
+     |> assign(:current_user, session["current_user"])
+     |> assign(:page_title, "Projects")
+     |> stream(:projects, projects)
+     |> assign(:projects_empty?, projects == [])
+     |> assign(:creating, false)
+     |> assign(:editing_project_id, nil)
+     |> assign(:form, new_form())
+     |> assign(:delete_confirming_id, nil)}
+  end
+
+  def handle_event("new_project", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:creating, true)
+     |> assign(:editing_project_id, nil)
+     |> assign(:form, new_form())}
+  end
+
+  def handle_event("cancel", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:creating, false)
+     |> assign(:editing_project_id, nil)
+     |> assign(:delete_confirming_id, nil)}
+  end
+
+  def handle_event("create_project", params, socket) do
+    case validate_project_params(params) do
+      {:ok, attrs} ->
+        Destila.Store.create_project(attrs)
+
+        {:noreply,
+         socket
+         |> assign(:creating, false)
+         |> assign(:form, new_form())}
+
+      {:error, message} ->
+        {:noreply, put_flash(socket, :error, message)}
+    end
+  end
+
+  def handle_event("edit_project", %{"id" => id}, socket) do
+    project = Destila.Store.get_project(id)
+
+    if project do
+      form =
+        to_form(%{
+          "name" => project.name,
+          "git_repo_url" => project.git_repo_url || "",
+          "local_folder" => project.local_folder || ""
+        })
+
+      {:noreply,
+       socket
+       |> assign(:editing_project_id, id)
+       |> assign(:creating, false)
+       |> assign(:form, form)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("update_project", params, socket) do
+    id = socket.assigns.editing_project_id
+
+    case validate_project_params(params) do
+      {:ok, attrs} ->
+        Destila.Store.update_project(id, attrs)
+
+        {:noreply,
+         socket
+         |> assign(:editing_project_id, nil)
+         |> assign(:form, new_form())}
+
+      {:error, message} ->
+        {:noreply, put_flash(socket, :error, message)}
+    end
+  end
+
+  def handle_event("confirm_delete", %{"id" => id}, socket) do
+    {:noreply, assign(socket, :delete_confirming_id, id)}
+  end
+
+  def handle_event("delete_project", %{"id" => id}, socket) do
+    case Destila.Store.delete_project(id) do
+      :ok ->
+        {:noreply, assign(socket, :delete_confirming_id, nil)}
+
+      {:error, :has_linked_prompts} ->
+        {:noreply,
+         socket
+         |> assign(:delete_confirming_id, nil)
+         |> put_flash(:error, "Cannot delete project while it is linked to prompts")}
+
+      {:error, :not_found} ->
+        {:noreply, assign(socket, :delete_confirming_id, nil)}
+    end
+  end
+
+  # PubSub handlers
+
+  def handle_info({:project_created, _project}, socket) do
+    projects = Destila.Store.list_projects()
+
+    {:noreply,
+     socket
+     |> stream(:projects, projects, reset: true)
+     |> assign(:projects_empty?, projects == [])}
+  end
+
+  def handle_info({:project_updated, _project}, socket) do
+    projects = Destila.Store.list_projects()
+
+    {:noreply,
+     socket
+     |> stream(:projects, projects, reset: true)
+     |> assign(:projects_empty?, projects == [])}
+  end
+
+  def handle_info({:project_deleted, _project}, socket) do
+    projects = Destila.Store.list_projects()
+
+    {:noreply,
+     socket
+     |> stream(:projects, projects, reset: true)
+     |> assign(:projects_empty?, projects == [])}
+  end
+
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
+  # Helpers
+
+  defp new_form do
+    to_form(%{"name" => "", "git_repo_url" => "", "local_folder" => ""})
+  end
+
+  defp validate_project_params(params) do
+    name = String.trim(params["name"] || "")
+    git_repo_url = params["git_repo_url"]
+    git_repo_url = if git_repo_url && git_repo_url != "", do: git_repo_url, else: nil
+    local_folder = params["local_folder"]
+    local_folder = if local_folder && local_folder != "", do: local_folder, else: nil
+
+    cond do
+      name == "" ->
+        {:error, "Project name is required"}
+
+      git_repo_url == nil && local_folder == nil ->
+        {:error, "At least a git repository URL or local folder is required"}
+
+      true ->
+        {:ok, %{name: name, git_repo_url: git_repo_url, local_folder: local_folder}}
+    end
+  end
+
+  defp linked_prompt_count(project_id) do
+    Destila.Store.list_prompts()
+    |> Enum.count(&(&1[:project_id] == project_id))
+  end
+
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_user={@current_user} page_title={@page_title}>
+      <div class="max-w-3xl mx-auto px-6 py-10">
+        <div class="flex items-center justify-between mb-8">
+          <div>
+            <h1 class="text-2xl font-bold">Projects</h1>
+            <p class="text-sm text-base-content/50 mt-1">
+              Manage codebases that prompts operate against
+            </p>
+          </div>
+          <button
+            :if={!@creating}
+            phx-click="new_project"
+            class="btn btn-primary btn-sm"
+            id="new-project-btn"
+          >
+            <.icon name="hero-plus-micro" class="size-4" /> New Project
+          </button>
+        </div>
+
+        <%!-- Create form --%>
+        <div
+          :if={@creating}
+          class="card bg-base-200 border border-base-300 mb-6"
+          id="create-project-card"
+        >
+          <div class="card-body p-5">
+            <h3 class="font-semibold mb-3">New Project</h3>
+            <.project_form form={@form} submit_event="create_project" submit_label="Create" />
+            <button phx-click="cancel" class="btn btn-ghost btn-sm mt-2">Cancel</button>
+          </div>
+        </div>
+
+        <%!-- Project list --%>
+        <div id="projects" phx-update="stream">
+          <div class="hidden only:block text-center py-16" id="projects-empty">
+            <.icon name="hero-folder" class="size-16 text-base-content/10 mx-auto mb-4" />
+            <p class="text-base-content/40 mb-4">No projects yet</p>
+            <button
+              :if={!@creating}
+              phx-click="new_project"
+              class="btn btn-primary"
+              id="create-first-project-btn"
+            >
+              <.icon name="hero-plus-micro" class="size-4" /> Create your first project
+            </button>
+          </div>
+
+          <div
+            :for={{id, project} <- @streams.projects}
+            id={id}
+            class="card bg-base-100 border border-base-300 mb-3"
+          >
+            <%!-- Edit form --%>
+            <div :if={@editing_project_id == project.id} class="card-body p-5">
+              <h3 class="font-semibold mb-3">Edit Project</h3>
+              <.project_form form={@form} submit_event="update_project" submit_label="Save" />
+              <button phx-click="cancel" class="btn btn-ghost btn-sm mt-2">Cancel</button>
+            </div>
+
+            <%!-- Display --%>
+            <div :if={@editing_project_id != project.id} class="card-body p-5">
+              <div class="flex items-start justify-between">
+                <div class="min-w-0 flex-1">
+                  <h3 class="font-semibold">{project.name}</h3>
+                  <div class="flex flex-col gap-0.5 mt-1">
+                    <span :if={project.git_repo_url} class="text-xs text-base-content/40 truncate">
+                      <.icon name="hero-link-micro" class="size-3 inline" /> {project.git_repo_url}
+                    </span>
+                    <span :if={project.local_folder} class="text-xs text-base-content/40 truncate">
+                      <.icon name="hero-folder-micro" class="size-3 inline" /> {project.local_folder}
+                    </span>
+                  </div>
+                  <span class="text-xs text-base-content/30 mt-1">
+                    {linked_prompt_count(project.id)} linked prompt(s)
+                  </span>
+                </div>
+
+                <div class="flex items-center gap-1 ml-4 shrink-0">
+                  <button
+                    phx-click="edit_project"
+                    phx-value-id={project.id}
+                    class="btn btn-ghost btn-xs"
+                    id={"edit-project-#{project.id}"}
+                  >
+                    <.icon name="hero-pencil-micro" class="size-4" />
+                  </button>
+
+                  <%= if @delete_confirming_id == project.id do %>
+                    <button
+                      phx-click="delete_project"
+                      phx-value-id={project.id}
+                      class="btn btn-error btn-xs"
+                      id={"confirm-delete-#{project.id}"}
+                    >
+                      Confirm
+                    </button>
+                    <button phx-click="cancel" class="btn btn-ghost btn-xs">
+                      Cancel
+                    </button>
+                  <% else %>
+                    <button
+                      phx-click="confirm_delete"
+                      phx-value-id={project.id}
+                      class="btn btn-ghost btn-xs text-error/60 hover:text-error"
+                      id={"delete-project-#{project.id}"}
+                    >
+                      <.icon name="hero-trash-micro" class="size-4" />
+                    </button>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Layouts.app>
+    """
+  end
+
+  attr :form, :any, required: true
+  attr :submit_event, :string, required: true
+  attr :submit_label, :string, required: true
+
+  defp project_form(assigns) do
+    ~H"""
+    <form phx-submit={@submit_event} class="space-y-3" id={"project-form-#{@submit_event}"}>
+      <fieldset class="fieldset">
+        <label class="fieldset-label text-xs font-medium" for="project-name">
+          Name <span class="text-error">*</span>
+        </label>
+        <input
+          type="text"
+          id="project-name"
+          name="name"
+          value={@form["name"].value}
+          placeholder="My Project"
+          class="input input-bordered w-full input-sm"
+        />
+      </fieldset>
+
+      <fieldset class="fieldset">
+        <label class="fieldset-label text-xs font-medium" for="project-git-repo-url">
+          Git repository URL
+        </label>
+        <input
+          type="url"
+          id="project-git-repo-url"
+          name="git_repo_url"
+          value={@form["git_repo_url"].value}
+          placeholder="https://github.com/org/repo"
+          class="input input-bordered w-full input-sm"
+        />
+      </fieldset>
+
+      <fieldset class="fieldset">
+        <label class="fieldset-label text-xs font-medium" for="project-local-folder">
+          Local folder
+        </label>
+        <input
+          type="text"
+          id="project-local-folder"
+          name="local_folder"
+          value={@form["local_folder"].value}
+          placeholder="/path/to/project"
+          class="input input-bordered w-full input-sm"
+        />
+      </fieldset>
+
+      <button type="submit" class="btn btn-primary btn-sm w-full">
+        {@submit_label}
+      </button>
+    </form>
+    """
+  end
+end

--- a/lib/destila_web/live/projects_live.ex
+++ b/lib/destila_web/live/projects_live.ex
@@ -198,14 +198,9 @@ defmodule DestilaWeb.ProjectsLive do
   def render(assigns) do
     ~H"""
     <Layouts.app flash={@flash} current_user={@current_user} page_title={@page_title}>
-      <div class="max-w-3xl mx-auto px-6 py-10">
-        <div class="flex items-center justify-between mb-8">
-          <div>
-            <h1 class="text-2xl font-bold">Projects</h1>
-            <p class="text-sm text-base-content/50 mt-1">
-              Manage codebases that prompts operate against
-            </p>
-          </div>
+      <div class="p-6 lg:p-8 max-w-3xl mx-auto">
+        <div class="flex items-center justify-between mb-6">
+          <h1 class="text-2xl font-bold tracking-tight">Projects</h1>
           <button
             :if={!@creating}
             phx-click="new_project"
@@ -219,11 +214,11 @@ defmodule DestilaWeb.ProjectsLive do
         <%!-- Create form --%>
         <div
           :if={@creating}
-          class="card bg-base-200 border border-base-300 mb-6"
+          class="card bg-base-100 shadow-sm mb-4"
           id="create-project-card"
         >
-          <div class="card-body p-5">
-            <h3 class="font-semibold mb-3">New Project</h3>
+          <div class="card-body">
+            <h3 class="text-sm font-semibold mb-3">New Project</h3>
             <.project_form form={@form} submit_event="create_project" submit_label="Create" />
             <button phx-click="cancel" class="btn btn-ghost btn-sm mt-2">Cancel</button>
           </div>
@@ -231,9 +226,9 @@ defmodule DestilaWeb.ProjectsLive do
 
         <%!-- Project list --%>
         <div id="projects" phx-update="stream">
-          <div class="hidden only:block text-center py-16" id="projects-empty">
-            <.icon name="hero-folder" class="size-16 text-base-content/10 mx-auto mb-4" />
-            <p class="text-base-content/40 mb-4">No projects yet</p>
+          <div class="hidden only:block text-center py-12" id="projects-empty">
+            <.icon name="hero-folder" class="size-10 text-base-content/20 mx-auto mb-3" />
+            <p class="text-sm text-base-content/30 mb-4">No projects yet</p>
             <button
               :if={!@creating}
               phx-click="new_project"
@@ -247,17 +242,17 @@ defmodule DestilaWeb.ProjectsLive do
           <div
             :for={{id, project} <- @streams.projects}
             id={id}
-            class="card bg-base-100 border border-base-300 mb-3"
+            class="card bg-base-100 shadow-sm mb-3"
           >
             <%!-- Edit form --%>
-            <div :if={@editing_project_id == project.id} class="card-body p-5">
-              <h3 class="font-semibold mb-3">Edit Project</h3>
+            <div :if={@editing_project_id == project.id} class="card-body">
+              <h3 class="text-sm font-semibold mb-3">Edit Project</h3>
               <.project_form form={@form} submit_event="update_project" submit_label="Save" />
               <button phx-click="cancel" class="btn btn-ghost btn-sm mt-2">Cancel</button>
             </div>
 
             <%!-- Display --%>
-            <div :if={@editing_project_id != project.id} class="card-body p-5">
+            <div :if={@editing_project_id != project.id} class="card-body">
               <div class="flex items-start justify-between">
                 <div class="min-w-0 flex-1">
                   <h3 class="font-semibold">{project.name}</h3>

--- a/lib/destila_web/live/prompt_detail_live.ex
+++ b/lib/destila_web/live/prompt_detail_live.ex
@@ -39,6 +39,7 @@ defmodule DestilaWeb.PromptDetailLive do
        socket
        |> assign(:current_user, session["current_user"])
        |> assign(:prompt, Destila.Store.get_prompt(id) || prompt)
+       |> assign(:project, lookup_project(prompt))
        |> assign(:messages, Destila.Store.list_messages(id))
        |> assign(:current_step, current_step)
        |> assign(:editing_title, false)
@@ -565,6 +566,10 @@ defmodule DestilaWeb.PromptDetailLive do
   defp ai_workflow?(%{workflow_type: :chore_task}), do: true
   defp ai_workflow?(_), do: false
 
+  defp lookup_project(prompt) do
+    if prompt[:project_id], do: Destila.Store.get_project(prompt[:project_id])
+  end
+
   defp start_workflow(prompt) do
     steps = Destila.Workflows.steps(prompt.workflow_type)
     first = List.first(steps)
@@ -731,8 +736,16 @@ defmodule DestilaWeb.PromptDetailLive do
 
                 <div class="flex items-center gap-3 mt-1">
                   <.workflow_badge type={@prompt.workflow_type} />
-                  <span :if={@prompt.repo_url} class="text-xs text-base-content/40">
-                    {@prompt.repo_url}
+                  <span :if={@project} class="text-xs text-base-content/40">
+                    <.link
+                      navigate={~p"/projects"}
+                      class="hover:text-base-content/60 transition-colors"
+                    >
+                      {@project.name}
+                    </.link>
+                    <span :if={@project.git_repo_url} class="ml-1">
+                      ({@project.git_repo_url})
+                    </span>
                   </span>
                 </div>
               </div>

--- a/lib/destila_web/router.ex
+++ b/lib/destila_web/router.ex
@@ -30,6 +30,7 @@ defmodule DestilaWeb.Router do
     live "/", DashboardLive
     live "/crafting", CraftingBoardLive
     live "/implementation", ImplementationBoardLive
+    live "/projects", ProjectsLive
     live "/prompts/new", NewPromptLive
     live "/prompts/:id", PromptDetailLive
   end

--- a/test/destila_web/live/chore_task_workflow_live_test.exs
+++ b/test/destila_web/live/chore_task_workflow_live_test.exs
@@ -36,7 +36,7 @@ defmodule DestilaWeb.ChoreTaskWorkflowLiveTest do
       Destila.Store.create_prompt(%{
         title: "Test Chore Task",
         workflow_type: :chore_task,
-        repo_url: "https://github.com/owner/repo",
+        project_id: nil,
         board: :crafting,
         column: column,
         steps_completed: phase,

--- a/test/destila_web/live/generated_prompt_viewing_live_test.exs
+++ b/test/destila_web/live/generated_prompt_viewing_live_test.exs
@@ -48,7 +48,7 @@ defmodule DestilaWeb.GeneratedPromptViewingLiveTest do
       Destila.Store.create_prompt(%{
         title: "Test Prompt",
         workflow_type: :chore_task,
-        repo_url: "https://github.com/owner/repo",
+        project_id: nil,
         board: :crafting,
         column: :done,
         steps_completed: 4,

--- a/test/destila_web/live/new_prompt_live_test.exs
+++ b/test/destila_web/live/new_prompt_live_test.exs
@@ -77,7 +77,7 @@ defmodule DestilaWeb.NewPromptLiveTest do
       view |> element("button[phx-value-type='chore_task']") |> render_click()
       view |> element("#continue-project-btn") |> render_click()
 
-      assert render(view) =~ "Please select a project"
+      assert render(view) =~ "select a project"
     end
 
     @tag feature: @feature, scenario: "Skip project for Project workflow type"

--- a/test/destila_web/live/new_prompt_live_test.exs
+++ b/test/destila_web/live/new_prompt_live_test.exs
@@ -194,6 +194,103 @@ defmodule DestilaWeb.NewPromptLiveTest do
     end
   end
 
+  describe "inline project creation" do
+    @tag feature: "project_inline_creation",
+         scenario: "Create a project with a git repository URL"
+    test "creates and selects a project with git URL", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/prompts/new")
+
+      view |> element("button[phx-value-type='feature_request']") |> render_click()
+      view |> element("#create-new-project-btn") |> render_click()
+
+      assert has_element?(view, "#inline-project-form")
+
+      view
+      |> form("#inline-project-form", %{
+        "name" => "Git Project",
+        "git_repo_url" => "https://github.com/inline/repo"
+      })
+      |> render_submit()
+
+      assert render(view) =~ "Git Project"
+      assert has_element?(view, "#continue-project-btn")
+    end
+
+    @tag feature: "project_inline_creation",
+         scenario: "Create a project with a local folder only"
+    test "creates and selects a project with local folder only", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/prompts/new")
+
+      view |> element("button[phx-value-type='feature_request']") |> render_click()
+      view |> element("#create-new-project-btn") |> render_click()
+
+      view
+      |> form("#inline-project-form", %{
+        "name" => "Local Project",
+        "local_folder" => "/path/to/local"
+      })
+      |> render_submit()
+
+      assert render(view) =~ "Local Project"
+      assert has_element?(view, "#continue-project-btn")
+    end
+
+    @tag feature: "project_inline_creation",
+         scenario: "Create a project with both git URL and local folder"
+    test "creates and selects a project with both git URL and local folder", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/prompts/new")
+
+      view |> element("button[phx-value-type='feature_request']") |> render_click()
+      view |> element("#create-new-project-btn") |> render_click()
+
+      view
+      |> form("#inline-project-form", %{
+        "name" => "Full Project",
+        "git_repo_url" => "https://github.com/full/repo",
+        "local_folder" => "/path/to/full"
+      })
+      |> render_submit()
+
+      assert render(view) =~ "Full Project"
+      assert has_element?(view, "#continue-project-btn")
+    end
+
+    @tag feature: "project_inline_creation",
+         scenario: "Cannot create a project without git URL or local folder"
+    test "shows error when neither git URL nor local folder provided", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/prompts/new")
+
+      view |> element("button[phx-value-type='feature_request']") |> render_click()
+      view |> element("#create-new-project-btn") |> render_click()
+
+      view
+      |> form("#inline-project-form", %{"name" => "Incomplete"})
+      |> render_submit()
+
+      assert render(view) =~ "Provide at least one"
+      assert has_element?(view, "#inline-project-form")
+    end
+
+    @tag feature: "project_inline_creation",
+         scenario: "Cannot create a project without a name"
+    test "shows error when name is empty", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/prompts/new")
+
+      view |> element("button[phx-value-type='feature_request']") |> render_click()
+      view |> element("#create-new-project-btn") |> render_click()
+
+      view
+      |> form("#inline-project-form", %{
+        "name" => "",
+        "git_repo_url" => "https://github.com/test/repo"
+      })
+      |> render_submit()
+
+      assert render(view) =~ "Name is required"
+      assert has_element?(view, "#inline-project-form")
+    end
+  end
+
   describe "navigation" do
     @tag feature: @feature, scenario: "Navigate back from step 2 to step 1"
     test "back from step 2 returns to step 1", %{conn: conn} do

--- a/test/destila_web/live/new_prompt_live_test.exs
+++ b/test/destila_web/live/new_prompt_live_test.exs
@@ -22,7 +22,15 @@ defmodule DestilaWeb.NewPromptLiveTest do
 
     # Log in to establish session
     conn = post(conn, "/login", %{"email" => "test@example.com"})
-    {:ok, conn: conn}
+
+    # Create a test project for selection tests
+    project =
+      Destila.Store.create_project(%{
+        name: "Test Project",
+        git_repo_url: "https://github.com/test/repo"
+      })
+
+    {:ok, conn: conn, project: project}
   end
 
   describe "step 1 - workflow type selection" do
@@ -40,63 +48,100 @@ defmodule DestilaWeb.NewPromptLiveTest do
     end
   end
 
-  describe "step 2 - repository URL" do
+  describe "step 2 - project selection" do
     @tag feature: @feature, scenario: "Complete the wizard with Save & Continue"
-    test "shows repository URL input after selecting a workflow type", %{conn: conn} do
+    test "shows project selection after selecting a workflow type", %{
+      conn: conn,
+      project: project
+    } do
       {:ok, view, _html} = live(conn, ~p"/prompts/new")
 
       view |> element("button[phx-value-type='feature_request']") |> render_click()
 
-      assert has_element?(view, "#repo_url")
+      assert has_element?(view, "#project-#{project.id}")
     end
 
-    @tag feature: @feature, scenario: "Repository URL can only be skipped for Project type"
+    @tag feature: @feature, scenario: "Project is required for non-Project workflow types"
     test "skip button is not available for non-Project types", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/prompts/new")
 
       view |> element("button[phx-value-type='feature_request']") |> render_click()
 
-      refute has_element?(view, "button[phx-click='skip_repo']")
+      refute has_element?(view, "#skip-project-btn")
     end
 
-    @tag feature: @feature, scenario: "Repository URL can only be skipped for Project type"
-    test "shows error when continuing without a URL for non-Project type", %{conn: conn} do
+    @tag feature: @feature, scenario: "Project is required for non-Project workflow types"
+    test "shows error when continuing without selecting a project", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/prompts/new")
 
       view |> element("button[phx-value-type='chore_task']") |> render_click()
-      view |> form("form", %{"repo_url" => ""}) |> render_submit()
+      view |> element("#continue-project-btn") |> render_click()
 
-      assert has_element?(view, "#repo_url")
-      assert render(view) =~ "Repository URL is required"
+      assert render(view) =~ "Please select a project"
     end
 
-    @tag feature: @feature, scenario: "Skip repository URL for Project type"
+    @tag feature: @feature, scenario: "Skip project for Project workflow type"
     test "skip button is available for Project type", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/prompts/new")
 
       view |> element("button[phx-value-type='project']") |> render_click()
 
-      assert has_element?(view, "button[phx-click='skip_repo']")
+      assert has_element?(view, "#skip-project-btn")
     end
 
-    @tag feature: @feature, scenario: "Skip repository URL for Project type"
-    test "skipping repo URL for Project advances to step 3", %{conn: conn} do
+    @tag feature: @feature, scenario: "Skip project for Project workflow type"
+    test "skipping project for Project type advances to step 3", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/prompts/new")
 
       view |> element("button[phx-value-type='project']") |> render_click()
-      view |> element("button[phx-click='skip_repo']") |> render_click()
+      view |> element("#skip-project-btn") |> render_click()
 
       assert has_element?(view, "#initial_idea")
+    end
+
+    @tag feature: @feature, scenario: "Complete the wizard with Save & Continue"
+    test "selecting a project and continuing advances to step 3", %{conn: conn, project: project} do
+      {:ok, view, _html} = live(conn, ~p"/prompts/new")
+
+      view |> element("button[phx-value-type='feature_request']") |> render_click()
+      view |> element("#project-#{project.id}") |> render_click()
+      view |> element("#continue-project-btn") |> render_click()
+
+      assert has_element?(view, "#initial_idea")
+    end
+
+    @tag feature: @feature, scenario: "Create a new project inline during step 2"
+    test "inline project creation creates and selects the project", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/prompts/new")
+
+      view |> element("button[phx-value-type='feature_request']") |> render_click()
+      view |> element("#create-new-project-btn") |> render_click()
+
+      assert has_element?(view, "#inline-project-form")
+
+      view
+      |> form("#inline-project-form", %{
+        "name" => "New Inline Project",
+        "git_repo_url" => "https://github.com/new/repo"
+      })
+      |> render_submit()
+
+      # Should be back on select view with new project selected
+      assert render(view) =~ "New Inline Project"
     end
   end
 
   describe "step 3 - initial idea" do
     @tag feature: @feature, scenario: "Complete the wizard with Save & Continue"
-    test "shows initial idea textarea after completing repo URL step", %{conn: conn} do
+    test "shows initial idea textarea after completing project step", %{
+      conn: conn,
+      project: project
+    } do
       {:ok, view, _html} = live(conn, ~p"/prompts/new")
 
       view |> element("button[phx-value-type='feature_request']") |> render_click()
-      view |> form("form", %{"repo_url" => "https://github.com/owner/repo"}) |> render_submit()
+      view |> element("#project-#{project.id}") |> render_click()
+      view |> element("#continue-project-btn") |> render_click()
 
       assert has_element?(view, "#initial_idea")
     end
@@ -106,7 +151,7 @@ defmodule DestilaWeb.NewPromptLiveTest do
       {:ok, view, _html} = live(conn, ~p"/prompts/new")
 
       view |> element("button[phx-value-type='project']") |> render_click()
-      view |> element("button[phx-click='skip_repo']") |> render_click()
+      view |> element("#skip-project-btn") |> render_click()
       view |> form("#initial-idea-form", %{"initial_idea" => ""}) |> render_submit()
 
       assert has_element?(view, "#initial_idea")
@@ -114,11 +159,15 @@ defmodule DestilaWeb.NewPromptLiveTest do
     end
 
     @tag feature: @feature, scenario: "Complete the wizard with Save & Continue"
-    test "save & continue creates prompt and redirects to detail page", %{conn: conn} do
+    test "save & continue creates prompt and redirects to detail page", %{
+      conn: conn,
+      project: project
+    } do
       {:ok, view, _html} = live(conn, ~p"/prompts/new")
 
       view |> element("button[phx-value-type='feature_request']") |> render_click()
-      view |> form("form", %{"repo_url" => "https://github.com/owner/repo"}) |> render_submit()
+      view |> element("#project-#{project.id}") |> render_click()
+      view |> element("#continue-project-btn") |> render_click()
 
       view
       |> form("#initial-idea-form", %{"initial_idea" => "Add PDF export for reports"})
@@ -133,7 +182,7 @@ defmodule DestilaWeb.NewPromptLiveTest do
       {:ok, view, _html} = live(conn, ~p"/prompts/new")
 
       view |> element("button[phx-value-type='project']") |> render_click()
-      view |> element("button[phx-click='skip_repo']") |> render_click()
+      view |> element("#skip-project-btn") |> render_click()
 
       view
       |> form("#initial-idea-form", %{"initial_idea" => "A task management app"})
@@ -152,7 +201,8 @@ defmodule DestilaWeb.NewPromptLiveTest do
 
       view |> element("button[phx-value-type='feature_request']") |> render_click()
 
-      assert has_element?(view, "#repo_url")
+      assert has_element?(view, "#project-list") or
+               has_element?(view, "#create-first-project-btn")
 
       view |> element("button[phx-click='back']") |> render_click()
 
@@ -166,13 +216,13 @@ defmodule DestilaWeb.NewPromptLiveTest do
       {:ok, view, _html} = live(conn, ~p"/prompts/new")
 
       view |> element("button[phx-value-type='project']") |> render_click()
-      view |> element("button[phx-click='skip_repo']") |> render_click()
+      view |> element("#skip-project-btn") |> render_click()
 
       assert has_element?(view, "#initial_idea")
 
-      view |> element("button[phx-click='back_to_repo']") |> render_click()
+      view |> element("button[phx-click='back_to_project']") |> render_click()
 
-      assert has_element?(view, "#repo_url")
+      assert has_element?(view, "#continue-project-btn")
     end
   end
 end

--- a/test/destila_web/live/projects_live_test.exs
+++ b/test/destila_web/live/projects_live_test.exs
@@ -83,7 +83,7 @@ defmodule DestilaWeb.ProjectsLiveTest do
       |> form("#project-form-create_project", %{"name" => "Incomplete"})
       |> render_submit()
 
-      assert render(view) =~ "At least a git repository URL or local folder is required"
+      assert render(view) =~ "Provide at least one"
     end
 
     @tag feature: @feature, scenario: "Cannot create a project without a name"
@@ -99,7 +99,7 @@ defmodule DestilaWeb.ProjectsLiveTest do
       })
       |> render_submit()
 
-      assert render(view) =~ "Project name is required"
+      assert render(view) =~ "Name is required"
     end
   end
 
@@ -163,7 +163,7 @@ defmodule DestilaWeb.ProjectsLiveTest do
       view |> element("#delete-project-#{project.id}") |> render_click()
       view |> element("#confirm-delete-#{project.id}") |> render_click()
 
-      assert render(view) =~ "Cannot delete project while it is linked to prompts"
+      assert render(view) =~ "Cannot delete this project while it is linked to prompts"
       assert render(view) =~ "Linked Project"
     end
   end

--- a/test/destila_web/live/projects_live_test.exs
+++ b/test/destila_web/live/projects_live_test.exs
@@ -73,6 +73,23 @@ defmodule DestilaWeb.ProjectsLiveTest do
       assert render(view) =~ "Local Project"
     end
 
+    @tag feature: @feature, scenario: "Create a new project with both git URL and local folder"
+    test "creates a project with both git URL and local folder", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      view |> element("#new-project-btn") |> render_click()
+
+      view
+      |> form("#project-form-create_project", %{
+        "name" => "Full Project",
+        "git_repo_url" => "https://github.com/full/repo",
+        "local_folder" => "/path/to/full"
+      })
+      |> render_submit()
+
+      assert render(view) =~ "Full Project"
+    end
+
     @tag feature: @feature, scenario: "Cannot create a project without git URL or local folder"
     test "shows error when neither git URL nor local folder provided", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/projects")

--- a/test/destila_web/live/projects_live_test.exs
+++ b/test/destila_web/live/projects_live_test.exs
@@ -1,0 +1,170 @@
+defmodule DestilaWeb.ProjectsLiveTest do
+  @moduledoc """
+  LiveView tests for Project Management.
+  Feature: features/project_management.feature
+  """
+  use DestilaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  @feature "project_management"
+
+  setup %{conn: conn} do
+    conn = post(conn, "/login", %{"email" => "test@example.com"})
+    {:ok, conn: conn}
+  end
+
+  describe "project list" do
+    @tag feature: @feature, scenario: "View list of projects"
+    test "shows existing projects", %{conn: conn} do
+      project =
+        Destila.Store.create_project(%{
+          name: "My Project",
+          git_repo_url: "https://github.com/test/repo"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      assert render(view) =~ "My Project"
+      assert render(view) =~ "https://github.com/test/repo"
+      assert has_element?(view, "#edit-project-#{project.id}")
+    end
+
+    @tag feature: @feature, scenario: "View list of projects"
+    test "shows empty state when no projects exist", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      assert render(view) =~ "No projects yet"
+    end
+  end
+
+  describe "create project" do
+    @tag feature: @feature, scenario: "Create a new project with git repository URL"
+    test "creates a project with git URL", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      view |> element("#new-project-btn") |> render_click()
+      assert has_element?(view, "#create-project-card")
+
+      view
+      |> form("#project-form-create_project", %{
+        "name" => "New Project",
+        "git_repo_url" => "https://github.com/new/repo"
+      })
+      |> render_submit()
+
+      assert render(view) =~ "New Project"
+      refute has_element?(view, "#create-project-card")
+    end
+
+    @tag feature: @feature, scenario: "Create a new project with local folder only"
+    test "creates a project with local folder only", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      view |> element("#new-project-btn") |> render_click()
+
+      view
+      |> form("#project-form-create_project", %{
+        "name" => "Local Project",
+        "local_folder" => "/path/to/project"
+      })
+      |> render_submit()
+
+      assert render(view) =~ "Local Project"
+    end
+
+    @tag feature: @feature, scenario: "Cannot create a project without git URL or local folder"
+    test "shows error when neither git URL nor local folder provided", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      view |> element("#new-project-btn") |> render_click()
+
+      view
+      |> form("#project-form-create_project", %{"name" => "Incomplete"})
+      |> render_submit()
+
+      assert render(view) =~ "At least a git repository URL or local folder is required"
+    end
+
+    @tag feature: @feature, scenario: "Cannot create a project without a name"
+    test "shows error when name is empty", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      view |> element("#new-project-btn") |> render_click()
+
+      view
+      |> form("#project-form-create_project", %{
+        "name" => "",
+        "git_repo_url" => "https://github.com/test/repo"
+      })
+      |> render_submit()
+
+      assert render(view) =~ "Project name is required"
+    end
+  end
+
+  describe "edit project" do
+    @tag feature: @feature, scenario: "Edit an existing project"
+    test "edits an existing project", %{conn: conn} do
+      project =
+        Destila.Store.create_project(%{
+          name: "Original Name",
+          git_repo_url: "https://github.com/test/repo"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      view |> element("#edit-project-#{project.id}") |> render_click()
+      assert has_element?(view, "#project-form-update_project")
+
+      view
+      |> form("#project-form-update_project", %{"name" => "Updated Name"})
+      |> render_submit()
+
+      assert render(view) =~ "Updated Name"
+    end
+  end
+
+  describe "delete project" do
+    @tag feature: @feature, scenario: "Delete a project not linked to any prompts"
+    test "deletes a project not linked to prompts", %{conn: conn} do
+      project =
+        Destila.Store.create_project(%{
+          name: "Deletable Project",
+          git_repo_url: "https://github.com/test/repo"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      assert render(view) =~ "Deletable Project"
+
+      view |> element("#delete-project-#{project.id}") |> render_click()
+      view |> element("#confirm-delete-#{project.id}") |> render_click()
+
+      refute render(view) =~ "Deletable Project"
+    end
+
+    @tag feature: @feature, scenario: "Cannot delete a project linked to prompts"
+    test "cannot delete a project linked to prompts", %{conn: conn} do
+      project =
+        Destila.Store.create_project(%{
+          name: "Linked Project",
+          git_repo_url: "https://github.com/test/repo"
+        })
+
+      Destila.Store.create_prompt(%{
+        title: "Test Prompt",
+        project_id: project.id,
+        workflow_type: :feature_request
+      })
+
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      view |> element("#delete-project-#{project.id}") |> render_click()
+      view |> element("#confirm-delete-#{project.id}") |> render_click()
+
+      assert render(view) =~ "Cannot delete project while it is linked to prompts"
+      assert render(view) =~ "Linked Project"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Replace the `repo_url` string field on prompts with a first-class **Project** entity. Projects represent codebases that prompts operate against, with a name, optional git repository URL, and optional local folder path (at least one required).

- Add Project CRUD to `Destila.Store` with PubSub events
- Create `/projects` management page with list, inline create/edit, delete with confirmation
- Projects cannot be deleted while linked to prompts
- Rework wizard step 2: project selection + inline creation (replaces repo URL text input)
- `feature_request` and `chore_task` require a project; `project` workflow type can skip
- Update AI phase 2 context to resolve full project details (name, git URL, local folder)
- Update seeds with 10 deduplicated project entities
- Add "Projects" link to sidebar navigation

### Form validation
- Inline field-level errors with `input-error` styling and `aria-invalid` for accessibility
- Location fields (git URL / local folder) grouped with visual "or" divider and shared error ring
- `FocusFirstError` hook auto-focuses first errored field on validation failure
- Form values preserved on validation failure
- Flash toasts reserved for system-level errors only (e.g. delete protection)

### Design normalization
- Shadow cards, consistent padding, hover states matching board/dashboard patterns
- Polished card density, action button transitions, proper pluralization

## Testing

- 64 tests, 0 failures
- All Gherkin scenarios have linked `@tag` tests (100% coverage)
- Updated `NewPromptLiveTest` for project selection flow + 5 inline creation tests
- Added `ProjectsLiveTest` covering CRUD, validation, and delete protection
- Updated `ChoreTaskWorkflowLiveTest` and `GeneratedPromptViewingLiveTest` for `project_id`
- Feature files: updated `create_prompt_wizard.feature`, added `project_management.feature` and `project_inline_creation.feature`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: ETS-backed prototype with no external dependencies.

---

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>