### PR TITLE
feat: Redesign Crafting Board with sectioned list, workflow grouping, and project filter

### DIFF
--- a/docs/plans/2026-03-23-feat-crafting-board-redesign-plan.md
+++ b/docs/plans/2026-03-23-feat-crafting-board-redesign-plan.md
@@ -1,0 +1,358 @@
+---
+title: "feat: Redesign Crafting Board with Sectioned List, Workflow Grouping, and Project Filter"
+type: feat
+date: 2026-03-23
+---
+
+# Redesign Crafting Board
+
+## Overview
+
+Replace the current 3-column kanban board on `/crafting` with a **sectioned list view** (default), a **"Group by Workflow" toggle** showing read-only per-workflow boards, and a **project filter**. Remove drag-and-drop from this page entirely — section/column assignment is derived from prompt state.
+
+## Problem Statement
+
+The current kanban board (Request → Distill → Done) provides a flat view of all crafting prompts with no way to filter by project or see prompts grouped by workflow phase. The column names (Request, Distill) don't convey meaningful status to the user. As the number of prompts grows, the board becomes hard to scan.
+
+## Proposed Solution
+
+### Default View: Sectioned List
+
+Four computed sections based on prompt state:
+
+| Section | Criteria | Notes |
+|---------|----------|-------|
+| **Setup** | `phase_status == :setup` | Only chore_task prompts during Phase 0 (git/worktree setup, title generation). Static workflows skip this state. |
+| **Waiting for Reply** | `phase_status in [:generating, :conversing, :advance_suggested]` | Only chore_task prompts. `:generating` included because the user is waiting for the AI. |
+| **In Progress** | Everything else with `column != :done` | All active prompts not in Setup or Waiting for Reply. |
+| **Done** | `column == :done` | Prompt crafting is complete, ready for implementation board. |
+
+**Why not `steps_completed == 0` for Setup?** Prompts are created with `steps_completed: 1` in `new_prompt_live.ex:166`. The value 0 never occurs in the current data model. The actual "setup" state is `phase_status == :setup`, set only for chore_task workflows during Phase 0.
+
+**Why include `:generating` in Waiting for Reply?** From the user's perspective, the AI is processing their input — they are waiting for a reply. Placing it in "In Progress" would be misleading since the user cannot take action.
+
+### Group by Workflow Toggle
+
+When toggled, display a separate board per workflow type (hide empty ones). Each board has columns corresponding to the workflow's phase names, plus a "Done" column at the end.
+
+**Phase name definitions:**
+
+| Workflow | Phase 0 | Phase 1 | Phase 2 | Phase 3 | Phase 4 | Done |
+|----------|---------|---------|---------|---------|---------|------|
+| **Chore/Task** | Setup | Task Description | Gherkin Review | Technical Concerns | Prompt Generation | Done |
+| **Feature Request** | — | Problem | Feature Type | Affected Areas | Mockups | Done |
+| **Project** | — | Project Idea | Tech Stack | V1 Features | — | Done |
+
+- Chore/Task Phase 0 ("Setup") is included as a column because it represents active git/worktree setup
+- Feature Request and Project have no Phase 0 (static workflows skip setup)
+- Prompts are placed in columns by `steps_completed` value
+- Done prompts (`column == :done`) go in the "Done" column regardless of `steps_completed`
+
+**Unified phase name interface:** Create `Destila.Workflows.phase_name/2` that accepts `(workflow_type, phase_number)` and returns the phase name. Delegates to `ChoreTaskPhases.phase_name/1` for `:chore_task`, implements directly for static workflows.
+
+### Project Filter
+
+- Dropdown lists all projects that have at least one prompt on the crafting board
+- Includes an "All projects" option to clear the filter
+- Clicking a project name on any card activates the filter for that project
+- Prompts without a project appear when no filter is active, hidden when a filter is active
+- Filter state persisted in URL query params via `handle_params/3`
+
+### URL State
+
+Persist both filter and toggle in query params:
+
+```
+/crafting                           → default list view, no filter
+/crafting?project=<id>              → filtered by project
+/crafting?view=workflow             → grouped by workflow
+/crafting?view=workflow&project=<id> → grouped + filtered
+```
+
+Use `push_patch/2` for filter/toggle changes so the LiveView stays mounted.
+
+## Technical Approach
+
+### Phase 1: Data Layer Changes
+
+**File: `lib/destila/prompts.ex`**
+
+Modify `list_prompts/1` to always preload `:project`:
+
+```elixir
+# lib/destila/prompts.ex
+def list_prompts(board) do
+  from(p in Prompt, where: p.board == ^board, order_by: [asc: :position])
+  |> preload(:project)
+  |> Repo.all()
+end
+```
+
+This benefits all call sites (CraftingBoardLive, ImplementationBoardLive, DashboardLive) since project context is useful everywhere.
+
+**File: `lib/destila/workflows.ex`**
+
+Add unified phase name interface:
+
+```elixir
+# lib/destila/workflows.ex
+
+def phase_name(:chore_task, phase), do: ChoreTaskPhases.phase_name(phase)
+
+def phase_name(:feature_request, 1), do: "Problem"
+def phase_name(:feature_request, 2), do: "Feature Type"
+def phase_name(:feature_request, 3), do: "Affected Areas"
+def phase_name(:feature_request, 4), do: "Mockups"
+
+def phase_name(:project, 1), do: "Project Idea"
+def phase_name(:project, 2), do: "Tech Stack"
+def phase_name(:project, 3), do: "V1 Features"
+
+def phase_name(_type, _phase), do: nil
+
+def phase_columns(workflow_type) do
+  # Returns list of {phase_number, phase_name} tuples for board columns
+  range = case workflow_type do
+    :chore_task -> 0..total_steps(workflow_type)
+    _ -> 1..total_steps(workflow_type)
+  end
+
+  columns =
+    range
+    |> Enum.map(fn n -> {n, phase_name(workflow_type, n)} end)
+    |> Enum.reject(fn {_, name} -> is_nil(name) end)
+
+  columns ++ [{:done, "Done"}]
+end
+```
+
+### Phase 2: Rewrite CraftingBoardLive
+
+**File: `lib/destila_web/live/crafting_board_live.ex`**
+
+Complete rewrite. Key changes:
+
+1. **Use `handle_params/3`** instead of only `mount/3` for URL-driven state
+2. **Remove `card_moved` event handler** — no drag-and-drop
+3. **Add `toggle_view`, `filter_project`, `clear_filter` events**
+4. **Compute sections/boards from prompt list + current view mode**
+
+```elixir
+# Simplified structure
+
+defmodule DestilaWeb.CraftingBoardLive do
+  use DestilaWeb, :live_view
+
+  @impl true
+  def mount(_params, session, socket) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Destila.PubSub, "store:updates")
+    end
+
+    {:ok,
+     socket
+     |> assign(:current_user, session["current_user"])
+     |> assign(:page_title, "Crafting Board")}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    prompts = Destila.Prompts.list_prompts(:crafting)
+    view_mode = if params["view"] == "workflow", do: :workflow, else: :list
+    project_filter = params["project"]
+
+    {:noreply,
+     socket
+     |> assign(:view_mode, view_mode)
+     |> assign(:project_filter, project_filter)
+     |> assign(:all_prompts, prompts)
+     |> assign_derived_state()}
+  end
+end
+```
+
+**Section classification function** (pure function, easily testable):
+
+```elixir
+def classify_prompt(prompt) do
+  cond do
+    prompt.column == :done -> :done
+    prompt.phase_status == :setup -> :setup
+    prompt.phase_status in [:generating, :conversing, :advance_suggested] -> :waiting
+    true -> :in_progress
+  end
+end
+```
+
+**Derived state computation:**
+
+```elixir
+defp assign_derived_state(socket) do
+  prompts = socket.assigns.all_prompts
+  project_filter = socket.assigns.project_filter
+
+  # Filter by project if active
+  filtered = if project_filter do
+    Enum.filter(prompts, &(&1.project_id == project_filter))
+  else
+    prompts
+  end
+
+  # Collect unique projects for dropdown
+  projects =
+    prompts
+    |> Enum.map(& &1.project)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq_by(& &1.id)
+    |> Enum.sort_by(& &1.name)
+
+  socket
+  |> assign(:filtered_prompts, filtered)
+  |> assign(:projects, projects)
+  |> assign_view_data(filtered)
+end
+```
+
+For the **list view**, group filtered prompts into `%{setup: [...], waiting: [...], in_progress: [...], done: [...]}`.
+
+For the **workflow view**, group by `workflow_type` first, then by phase column within each type. Only include workflow types that have at least one prompt.
+
+### Phase 3: Template and Components
+
+**Template structure:**
+
+```heex
+<Layouts.app flash={@flash} current_user={@current_user} page_title={@page_title}>
+  <!-- Header with title, project filter dropdown, view toggle, New Prompt button -->
+  <div id="crafting-board-header">
+    <h1>Crafting Board</h1>
+    <.project_filter projects={@projects} selected={@project_filter} />
+    <.view_toggle mode={@view_mode} />
+    <.link navigate={~p"/prompts/new?from=/crafting"}>New Prompt</.link>
+  </div>
+
+  <!-- Conditional view rendering -->
+  <%= if @view_mode == :list do %>
+    <.sectioned_list sections={@sections} project_filter={@project_filter} />
+  <% else %>
+    <.workflow_boards boards={@workflow_boards} project_filter={@project_filter} />
+  <% end %>
+</Layouts.app>
+```
+
+**Card component** — adapted from existing `board_card/1` in `board_components.ex`:
+- Shows: title (link to `/prompts/:id`), project name (clickable, triggers filter), phase number
+- No `data-id` or Sortable hook attributes
+- Preserves `title_generating` pulse animation
+
+**Project filter** — a `<select>` element with `phx-change="filter_project"`:
+- "All projects" option (empty value)
+- List of projects with prompts on the crafting board
+
+**View toggle** — a button/checkbox with `phx-click="toggle_view"`
+
+**Sortable hook** — remains in codebase, still used by ImplementationBoardLive. No changes needed.
+
+### Phase 4: Update Feature File and Tests
+
+**File: `features/crafting_board.feature`** — new file with the Gherkin scenarios (updated from spec to match corrected classification logic).
+
+**Test file: `test/destila_web/live/crafting_board_live_test.exs`** — new file.
+
+Test cases:
+1. **Section assignment** — create prompts with various states, verify they appear in correct sections
+2. **Card content** — verify title, project name, phase number render
+3. **Project filter via dropdown** — select project, verify only matching prompts shown
+4. **Project filter via card click** — click project name, verify filter activates
+5. **Clear filter** — clear selection, verify all prompts shown
+6. **Toggle workflow view** — toggle on, verify boards with phase columns appear
+7. **Empty workflow boards hidden** — verify boards with no prompts don't render
+8. **Combined filter + grouping** — filter + toggle, verify both apply
+9. **URL state** — verify query params update on filter/toggle changes
+10. **PubSub refresh** — verify board updates when prompts change
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [x] Default view shows four sections: Setup, Waiting for Reply, In Progress, Done
+- [x] Section assignment is computed from prompt state (`phase_status`, `column`)
+- [x] Each card shows title (navigable), project name (clickable filter), phase number
+- [x] Project filter dropdown lists projects with crafting prompts
+- [x] Clicking project name on card activates filter
+- [x] Filter can be cleared to show all prompts
+- [x] "Group by Workflow" toggle shows per-workflow boards with phase columns + Done
+- [x] Empty workflow boards are hidden
+- [x] Filter persists across view toggle
+- [x] Filter and toggle state persisted in URL query params
+- [x] Real-time updates via PubSub continue to work
+- [x] No drag-and-drop on this page
+- [x] `list_prompts/1` preloads `:project` association
+- [x] `Destila.Workflows.phase_name/2` provides phase names for all workflow types
+- [x] `Destila.Workflows.phase_columns/1` returns column definitions per workflow type
+
+### Quality Gates
+
+- [x] All sections in `classify_prompt/1` have dedicated test cases
+- [x] LiveView integration tests cover all Gherkin scenarios
+- [x] `mix precommit` passes
+- [x] Feature file `features/crafting_board.feature` created and linked to tests
+
+## Sort Order
+
+Within each section (list view) and each column (workflow view), prompts are sorted by `position` ascending (preserving existing order). This is the current behavior and requires no changes.
+
+## Empty States
+
+- **Sectioned list**: All four sections always visible. Empty sections show a subtle "No prompts" placeholder.
+- **Workflow view**: Only boards with prompts are shown. If all boards are empty (e.g., filter yields zero results), show a single "No prompts match your filter" message.
+- **Zero prompts total**: Show all four empty sections with a prominent "Create your first prompt" CTA.
+
+## Implementation Phases
+
+### Phase 1: Data Layer (low risk)
+1. Add `:project` preload to `list_prompts/1` in `lib/destila/prompts.ex`
+2. Add `phase_name/2` and `phase_columns/1` to `lib/destila/workflows.ex`
+3. Verify no regressions in existing board views
+
+### Phase 2: LiveView Rewrite (medium risk)
+4. Rewrite `lib/destila_web/live/crafting_board_live.ex` with new mount/handle_params/render
+5. Add `classify_prompt/1` helper (private function or in a shared module)
+6. Implement filter and toggle event handlers with `push_patch`
+7. Add new components for sectioned list, workflow boards, project filter, view toggle
+
+### Phase 3: Feature File + Tests (low risk)
+8. Create `features/crafting_board.feature`
+9. Create `test/destila_web/live/crafting_board_live_test.exs`
+10. Run `mix precommit` and fix any issues
+
+## Files Changed
+
+| File | Action | Description |
+|------|--------|-------------|
+| `lib/destila/prompts.ex` | Modify | Add `:project` preload to `list_prompts/1` |
+| `lib/destila/workflows.ex` | Modify | Add `phase_name/2`, `phase_columns/1` |
+| `lib/destila_web/live/crafting_board_live.ex` | Rewrite | New sectioned list + workflow grouping + project filter |
+| `lib/destila_web/components/board_components.ex` | Modify | Add/adapt card component for new design (no Sortable attrs) |
+| `features/crafting_board.feature` | Create | Gherkin scenarios for all crafting board behavior |
+| `test/destila_web/live/crafting_board_live_test.exs` | Create | LiveView integration tests |
+
+## References
+
+### Internal References
+- `lib/destila_web/live/crafting_board_live.ex` — current implementation (69 lines)
+- `lib/destila_web/components/board_components.ex` — existing board components (123 lines)
+- `lib/destila/prompts.ex` — prompts context (68 lines)
+- `lib/destila/prompts/prompt.ex` — prompt schema (54 lines)
+- `lib/destila/workflows/chore_task_phases.ex` — existing phase names (170 lines)
+- `lib/destila/workflows.ex` — workflow step definitions (118 lines)
+- `lib/destila_web/live/new_prompt_live.ex:155-169` — prompt creation (steps_completed starts at 1)
+- `assets/js/hooks/sortable.js` — Sortable hook (stays, used by implementation board)
+
+### Spec Flow Analysis Gaps Addressed
+- **Setup section**: Corrected from `steps_completed == 0` (never occurs) to `phase_status == :setup`
+- **`:generating` classification**: Placed in "Waiting for Reply" (user is waiting for AI)
+- **Done column in workflow view**: Added explicit "Done" column per workflow board
+- **URL state persistence**: Filter and toggle stored in query params
+- **Sort order**: Preserved existing `position` ordering
+- **Empty states**: Defined for all views

--- a/features/crafting_board.feature
+++ b/features/crafting_board.feature
@@ -23,7 +23,7 @@ Feature: Crafting Board
     When I navigate to the crafting board
     Then the prompt card should show the title "Fix login bug"
     And the card should show the project name "destila"
-    And the card should show the current phase "2"
+    And the card should show the current phase name (e.g. "Feature Type" for step 2 of Feature Request)
 
   Scenario: Click prompt card to navigate to detail page
     Given there is a prompt on the crafting board

--- a/features/crafting_board.feature
+++ b/features/crafting_board.feature
@@ -1,0 +1,75 @@
+Feature: Crafting Board
+  The Crafting Board displays all prompts in the crafting stage. By default,
+  prompts are shown as a sectioned list: Setup, Waiting for Reply, In Progress,
+  and Done. Users can toggle "Group by Workflow" to see a read-only board per
+  workflow type with phase-based columns. A project filter narrows the view.
+
+  Background:
+    Given I am logged in
+
+  # --- Default List View ---
+
+  Scenario: View prompts in sectioned list
+    Given there are prompts in various phases and statuses
+    When I navigate to the crafting board
+    Then I should see four sections: "Setup", "Waiting for Reply", "In Progress", and "Done"
+    And prompts with phase_status "setup" should appear under "Setup"
+    And prompts with phase_status "conversing" or "advance_suggested" should appear under "Waiting for Reply"
+    And prompts marked as done should appear under "Done"
+    And remaining prompts should appear under "In Progress"
+
+  Scenario: Prompt card displays title, project, and phase
+    Given there is a prompt with title "Fix login bug", project "destila", and steps completed 2
+    When I navigate to the crafting board
+    Then the prompt card should show the title "Fix login bug"
+    And the card should show the project name "destila"
+    And the card should show the current phase "2"
+
+  Scenario: Click prompt card to navigate to detail page
+    Given there is a prompt on the crafting board
+    When I click the prompt title on the card
+    Then I should be navigated to the prompt detail page
+
+  Scenario: Click project name on card to filter by project
+    Given there are prompts for projects "destila" and "other-project"
+    When I click the project name "destila" on a prompt card
+    Then only prompts belonging to project "destila" should be shown
+    And the project filter should show "destila" as selected
+
+  # --- Project Filter ---
+
+  Scenario: Filter prompts by project
+    Given there are prompts for projects "destila" and "other-project"
+    When I select "destila" from the project filter
+    Then only prompts belonging to project "destila" should be shown
+
+  Scenario: Clear project filter
+    Given the project filter is set to "destila"
+    When I clear the project filter
+    Then prompts from all projects should be shown
+
+  # --- Group by Workflow ---
+
+  Scenario: Toggle group by workflow
+    Given there are prompts with different workflow types
+    When I toggle "Group by Workflow"
+    Then I should see a separate board for each workflow type with prompts
+    And each board should have columns matching the phase names of its workflow type
+    And prompts should appear in the column matching their current phase
+
+  Scenario: Boards are read-only (no drag and drop)
+    Given "Group by Workflow" is active
+    Then I should not see any drag-and-drop handles on the boards
+
+  Scenario: Empty workflow boards are hidden
+    Given there are only chore_task prompts on the crafting board
+    When I toggle "Group by Workflow"
+    Then I should see only the "Chore/Task" workflow board
+    And I should not see "Feature Request" or "Project" boards
+
+  Scenario: Filter by project with group by workflow active
+    Given "Group by Workflow" is active
+    And there are prompts for projects "destila" and "other-project"
+    When I select "destila" from the project filter
+    Then only prompts belonging to "destila" should be shown across all workflow boards
+    And workflow boards with no matching prompts should be hidden

--- a/lib/destila/prompts.ex
+++ b/lib/destila/prompts.ex
@@ -5,11 +5,15 @@ defmodule Destila.Prompts do
   alias Destila.Prompts.Prompt
 
   def list_prompts do
-    Repo.all(from(p in Prompt, order_by: p.position))
+    from(p in Prompt, order_by: p.position)
+    |> preload(:project)
+    |> Repo.all()
   end
 
   def list_prompts(board) do
-    Repo.all(from(p in Prompt, where: p.board == ^board, order_by: p.position))
+    from(p in Prompt, where: p.board == ^board, order_by: p.position)
+    |> preload(:project)
+    |> Repo.all()
   end
 
   def get_prompt(id) do

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -104,6 +104,41 @@ defmodule Destila.Workflows do
   def total_steps(:project), do: 3
   def total_steps(:chore_task), do: 4
 
+  @doc """
+  Returns the human-readable phase name for a workflow type and phase number.
+  """
+  def phase_name(:chore_task, phase), do: Destila.Workflows.ChoreTaskPhases.phase_name(phase)
+
+  def phase_name(:feature_request, 1), do: "Problem"
+  def phase_name(:feature_request, 2), do: "Feature Type"
+  def phase_name(:feature_request, 3), do: "Affected Areas"
+  def phase_name(:feature_request, 4), do: "Mockups"
+
+  def phase_name(:project, 1), do: "Project Idea"
+  def phase_name(:project, 2), do: "Tech Stack"
+  def phase_name(:project, 3), do: "V1 Features"
+
+  def phase_name(_type, _phase), do: nil
+
+  @doc """
+  Returns the list of {phase_number, phase_name} column definitions for a workflow type,
+  including a final {:done, "Done"} column.
+  """
+  def phase_columns(workflow_type) do
+    range =
+      case workflow_type do
+        :chore_task -> 0..total_steps(workflow_type)
+        _ -> 1..total_steps(workflow_type)
+      end
+
+    columns =
+      range
+      |> Enum.map(fn n -> {n, phase_name(workflow_type, n)} end)
+      |> Enum.reject(fn {_, name} -> is_nil(name) end)
+
+    columns ++ [{:done, "Done"}]
+  end
+
   def completion_message(:feature_request) do
     "Your feature request prompt is ready! I've gathered all the details needed to create a comprehensive, actionable prompt for your coding agent. You can now move this to the Implementation Board to start building."
   end

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -125,6 +125,8 @@ defmodule Destila.Workflows do
   including a final {:done, "Done"} column.
   """
   def phase_columns(workflow_type) do
+    # chore_task starts at phase 0 (Setup — git/worktree init) while
+    # static workflows (feature_request, project) have no phase 0.
     range =
       case workflow_type do
         :chore_task -> 0..total_steps(workflow_type)

--- a/lib/destila_web/components/board_components.ex
+++ b/lib/destila_web/components/board_components.ex
@@ -211,9 +211,9 @@ defmodule DestilaWeb.BoardComponents do
   defp column_label(:qa), do: "QA"
   defp column_label(:impl_done), do: "Done"
 
-  defp workflow_label(:feature_request), do: "Feature Request"
-  defp workflow_label(:project), do: "Project"
-  defp workflow_label(:chore_task), do: "Chore/Task"
+  def workflow_label(:feature_request), do: "Feature Request"
+  def workflow_label(:project), do: "Project"
+  def workflow_label(:chore_task), do: "Chore/Task"
 
   defp workflow_badge_class(:feature_request), do: "badge-info"
   defp workflow_badge_class(:project), do: "badge-secondary"

--- a/lib/destila_web/components/board_components.ex
+++ b/lib/destila_web/components/board_components.ex
@@ -104,6 +104,7 @@ defmodule DestilaWeb.BoardComponents do
 
   attr :card, :map, required: true
   attr :project_filter, :string, default: nil
+  attr :compact, :boolean, default: false
 
   def crafting_card(assigns) do
     ~H"""
@@ -111,19 +112,22 @@ defmodule DestilaWeb.BoardComponents do
       id={"crafting-card-#{@card.id}"}
       class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow"
     >
-      <div class="card-body p-4 gap-2">
-        <.link
-          navigate={"/prompts/#{@card.id}"}
-          class="text-sm font-medium leading-tight hover:text-primary transition-colors"
-        >
-          <span class={[
-            @card.title_generating && "animate-pulse text-base-content/50"
-          ]}>
-            {@card.title}
-          </span>
-        </.link>
+      <div class={["card-body gap-2", if(@compact, do: "p-3", else: "p-4")]}>
+        <div class="flex items-center gap-2">
+          <.link
+            navigate={"/prompts/#{@card.id}"}
+            class="text-sm font-medium leading-tight hover:text-primary transition-colors flex-1 min-w-0 truncate"
+          >
+            <span class={[
+              @card.title_generating && "animate-pulse text-base-content/50"
+            ]}>
+              {@card.title}
+            </span>
+          </.link>
+          <.status_dot :if={@compact} card={@card} />
+        </div>
 
-        <div class="flex items-center justify-between gap-2">
+        <div :if={!@compact} class="flex items-center justify-between gap-2">
           <div class="flex items-center gap-2">
             <.workflow_badge type={@card.workflow_type} />
             <%= if @card.project do %>
@@ -146,11 +150,34 @@ defmodule DestilaWeb.BoardComponents do
         </div>
 
         <.progress_indicator
+          :if={!@compact}
           completed={@card.steps_completed}
           total={@card.steps_total}
         />
       </div>
     </div>
+    """
+  end
+
+  attr :card, :map, required: true
+
+  defp status_dot(assigns) do
+    ~H"""
+    <span
+      :if={@card.phase_status in [:conversing, :advance_suggested]}
+      title="Waiting for your reply"
+      class="inline-flex size-2 shrink-0 rounded-full bg-warning"
+    />
+    <span
+      :if={@card.phase_status in [:generating]}
+      title="AI is responding"
+      class="inline-flex size-2 shrink-0 rounded-full bg-info animate-pulse"
+    />
+    <span
+      :if={@card.phase_status == :setup}
+      title="Setting up"
+      class="inline-flex size-2 shrink-0 rounded-full bg-base-content/20"
+    />
     """
   end
 

--- a/lib/destila_web/components/board_components.ex
+++ b/lib/destila_web/components/board_components.ex
@@ -140,7 +140,8 @@ defmodule DestilaWeb.BoardComponents do
             <% end %>
           </div>
           <span class="text-xs text-base-content/40 whitespace-nowrap">
-            Phase {@card.steps_completed}
+            {Destila.Workflows.phase_name(@card.workflow_type, @card.steps_completed) ||
+              "Phase #{@card.steps_completed}"}
           </span>
         </div>
 

--- a/lib/destila_web/components/board_components.ex
+++ b/lib/destila_web/components/board_components.ex
@@ -130,27 +130,32 @@ defmodule DestilaWeb.BoardComponents do
           <.status_dot :if={@compact} card={@card} />
         </div>
 
-        <div :if={!@compact} class="flex items-center justify-between gap-2">
-          <div class="flex items-center gap-2">
-            <.workflow_badge type={@card.workflow_type} />
-            <%= if @card.project do %>
-              <.link
-                patch={
-                  if @project_filter == @card.project_id,
-                    do: "/crafting",
-                    else: "/crafting?project=#{@card.project_id}"
-                }
-                class="text-xs text-base-content/60 hover:text-primary transition-colors truncate max-w-[120px]"
-              >
-                {@card.project.name}
-              </.link>
-            <% end %>
-          </div>
-          <span class="text-xs text-base-content/40 whitespace-nowrap">
-            {Destila.Workflows.phase_name(@card.workflow_type, @card.steps_completed) ||
-              "Phase #{@card.steps_completed}"}
+        <%= if @compact do %>
+          <span :if={@card.project} class="text-xs text-base-content/50 truncate">
+            {@card.project.name}
           </span>
-        </div>
+        <% else %>
+          <div class="flex items-center justify-between gap-2">
+            <div class="flex items-center gap-2">
+              <.workflow_badge type={@card.workflow_type} />
+              <%= if @card.project do %>
+                <.link
+                  patch={
+                    if @project_filter == @card.project_id,
+                      do: "/crafting",
+                      else: "/crafting?project=#{@card.project_id}"
+                  }
+                  class="text-xs text-base-content/60 hover:text-primary transition-colors truncate max-w-[120px]"
+                >
+                  {@card.project.name}
+                </.link>
+              <% end %>
+            </div>
+            <span class="text-xs text-base-content/40 whitespace-nowrap">
+              {phase_label(@card)}
+            </span>
+          </div>
+        <% end %>
 
         <.progress_indicator
           :if={!@compact}
@@ -187,6 +192,13 @@ defmodule DestilaWeb.BoardComponents do
 
   defp status_dot_style(_card),
     do: {"bg-primary/40", "In progress"}
+
+  defp phase_label(%{column: :done}), do: "Done"
+
+  defp phase_label(card),
+    do:
+      Destila.Workflows.phase_name(card.workflow_type, card.steps_completed) ||
+        "Phase #{card.steps_completed}"
 
   # Helpers
 

--- a/lib/destila_web/components/board_components.ex
+++ b/lib/destila_web/components/board_components.ex
@@ -113,10 +113,13 @@ defmodule DestilaWeb.BoardComponents do
       class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow"
     >
       <div class={["card-body gap-2", if(@compact, do: "p-3", else: "p-4")]}>
-        <div class="flex items-center gap-2">
+        <div class={["flex gap-2", if(@compact, do: "items-start", else: "items-center")]}>
           <.link
             navigate={"/prompts/#{@card.id}"}
-            class="text-sm font-medium leading-tight hover:text-primary transition-colors flex-1 min-w-0 truncate"
+            class={[
+              "text-sm font-medium leading-tight hover:text-primary transition-colors flex-1 min-w-0",
+              if(@compact, do: "line-clamp-3", else: "truncate")
+            ]}
           >
             <span class={[
               @card.title_generating && "animate-pulse text-base-content/50"

--- a/lib/destila_web/components/board_components.ex
+++ b/lib/destila_web/components/board_components.ex
@@ -162,24 +162,28 @@ defmodule DestilaWeb.BoardComponents do
   attr :card, :map, required: true
 
   defp status_dot(assigns) do
+    {color, title} = status_dot_style(assigns.card)
+    assigns = assigns |> assign(:dot_color, color) |> assign(:dot_title, title)
+
     ~H"""
-    <span
-      :if={@card.phase_status in [:conversing, :advance_suggested]}
-      title="Waiting for your reply"
-      class="inline-flex size-2 shrink-0 rounded-full bg-warning"
-    />
-    <span
-      :if={@card.phase_status in [:generating]}
-      title="AI is responding"
-      class="inline-flex size-2 shrink-0 rounded-full bg-info animate-pulse"
-    />
-    <span
-      :if={@card.phase_status == :setup}
-      title="Setting up"
-      class="inline-flex size-2 shrink-0 rounded-full bg-base-content/20"
-    />
+    <span title={@dot_title} class={["inline-flex size-2 shrink-0 rounded-full", @dot_color]} />
     """
   end
+
+  defp status_dot_style(%{phase_status: s}) when s in [:conversing, :advance_suggested],
+    do: {"bg-warning", "Waiting for your reply"}
+
+  defp status_dot_style(%{phase_status: :generating}),
+    do: {"bg-info animate-pulse", "AI is responding"}
+
+  defp status_dot_style(%{phase_status: :setup}),
+    do: {"bg-base-content/20", "Setting up"}
+
+  defp status_dot_style(%{column: :done}),
+    do: {"bg-success", "Done"}
+
+  defp status_dot_style(_card),
+    do: {"bg-primary/40", "In progress"}
 
   # Helpers
 

--- a/lib/destila_web/components/board_components.ex
+++ b/lib/destila_web/components/board_components.ex
@@ -102,6 +102,57 @@ defmodule DestilaWeb.BoardComponents do
     """
   end
 
+  attr :card, :map, required: true
+  attr :project_filter, :string, default: nil
+
+  def crafting_card(assigns) do
+    ~H"""
+    <div
+      id={"crafting-card-#{@card.id}"}
+      class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow"
+    >
+      <div class="card-body p-4 gap-2">
+        <.link
+          navigate={"/prompts/#{@card.id}"}
+          class="text-sm font-medium leading-tight hover:text-primary transition-colors"
+        >
+          <span class={[
+            @card.title_generating && "animate-pulse text-base-content/50"
+          ]}>
+            {@card.title}
+          </span>
+        </.link>
+
+        <div class="flex items-center justify-between gap-2">
+          <div class="flex items-center gap-2">
+            <.workflow_badge type={@card.workflow_type} />
+            <%= if @card.project do %>
+              <.link
+                patch={
+                  if @project_filter == @card.project_id,
+                    do: "/crafting",
+                    else: "/crafting?project=#{@card.project_id}"
+                }
+                class="text-xs text-base-content/60 hover:text-primary transition-colors truncate max-w-[120px]"
+              >
+                {@card.project.name}
+              </.link>
+            <% end %>
+          </div>
+          <span class="text-xs text-base-content/40 whitespace-nowrap">
+            Phase {@card.steps_completed}
+          </span>
+        </div>
+
+        <.progress_indicator
+          completed={@card.steps_completed}
+          total={@card.steps_total}
+        />
+      </div>
+    </div>
+    """
+  end
+
   # Helpers
 
   defp column_label(:request), do: "Request"

--- a/lib/destila_web/live/crafting_board_live.ex
+++ b/lib/destila_web/live/crafting_board_live.ex
@@ -162,12 +162,28 @@ defmodule DestilaWeb.CraftingBoardLive do
 
   # --- Render ---
 
+  @section_icons %{
+    setup: "hero-cog-6-tooth-micro",
+    waiting: "hero-clock-micro",
+    in_progress: "hero-bolt-micro",
+    done: "hero-check-circle-micro"
+  }
+
+  @section_empty_messages %{
+    setup: "No prompts being set up",
+    waiting: "No prompts awaiting a reply",
+    in_progress: "No prompts in progress",
+    done: "No completed prompts yet"
+  }
+
   @impl true
   def render(assigns) do
     assigns =
       assigns
       |> assign(:section_keys, @sections)
       |> assign(:section_labels, @section_labels)
+      |> assign(:section_icons, @section_icons)
+      |> assign(:section_empty_messages, @section_empty_messages)
 
     ~H"""
     <Layouts.app flash={@flash} current_user={@current_user} page_title={@page_title}>
@@ -237,9 +253,10 @@ defmodule DestilaWeb.CraftingBoardLive do
 
               <div
                 :if={@sections[section] == []}
-                class="flex items-center justify-center h-16 text-base-content/30 text-sm bg-base-200/30 rounded-xl"
+                class="flex items-center justify-center gap-2 h-16 text-base-content/20 text-sm bg-base-200/20 rounded-xl border border-dashed border-base-300/50"
               >
-                No prompts
+                <.icon name={@section_icons[section]} class="size-4" />
+                {@section_empty_messages[section]}
               </div>
             </div>
           </div>
@@ -248,8 +265,8 @@ defmodule DestilaWeb.CraftingBoardLive do
         <% else %>
           <div id="crafting-workflow-boards" class="space-y-8">
             <%= if @workflow_boards == [] do %>
-              <div class="flex items-center justify-center h-32 text-base-content/30 text-sm bg-base-200/30 rounded-xl">
-                No prompts match your filter
+              <div class="flex flex-col items-center justify-center h-32 gap-2 text-base-content/20 text-sm bg-base-200/20 rounded-xl border border-dashed border-base-300/50">
+                <.icon name="hero-funnel-micro" class="size-5" /> No prompts match your filter
               </div>
             <% else %>
               <div

--- a/lib/destila_web/live/crafting_board_live.ex
+++ b/lib/destila_web/live/crafting_board_live.ex
@@ -293,6 +293,7 @@ defmodule DestilaWeb.CraftingBoardLive do
                         :for={card <- col_prompts}
                         card={card}
                         project_filter={@project_filter}
+                        compact
                       />
                       <div
                         :if={col_prompts == []}

--- a/lib/destila_web/live/crafting_board_live.ex
+++ b/lib/destila_web/live/crafting_board_live.ex
@@ -190,7 +190,12 @@ defmodule DestilaWeb.CraftingBoardLive do
       <div class="p-6 lg:p-8">
         <%!-- Header --%>
         <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
-          <h1 class="text-2xl font-bold tracking-tight">Crafting Board</h1>
+          <div class="flex items-center gap-4">
+            <h1 class="text-2xl font-bold tracking-tight">Prompt Crafting</h1>
+            <.link navigate={~p"/prompts/new?from=/crafting"} class="btn btn-primary btn-sm">
+              <.icon name="hero-plus-micro" class="size-4" /> New Prompt
+            </.link>
+          </div>
 
           <div class="flex items-center gap-3">
             <%!-- Project filter --%>
@@ -211,6 +216,8 @@ defmodule DestilaWeb.CraftingBoardLive do
               </select>
             </form>
 
+            <div class="w-px h-5 bg-base-300" />
+
             <%!-- View toggle --%>
             <label id="view-toggle" class="flex items-center gap-2 cursor-pointer select-none">
               <span class="text-xs text-base-content/60">Group by Workflow</span>
@@ -221,11 +228,6 @@ defmodule DestilaWeb.CraftingBoardLive do
                 phx-click="toggle_view"
               />
             </label>
-
-            <%!-- New Prompt --%>
-            <.link navigate={~p"/prompts/new?from=/crafting"} class="btn btn-primary btn-sm">
-              <.icon name="hero-plus-micro" class="size-4" /> New Prompt
-            </.link>
           </div>
         </div>
 

--- a/lib/destila_web/live/crafting_board_live.ex
+++ b/lib/destila_web/live/crafting_board_live.ex
@@ -216,13 +216,13 @@ defmodule DestilaWeb.CraftingBoardLive do
           </form>
 
           <label id="view-toggle" class="flex items-center gap-2 cursor-pointer select-none">
-            <span class="text-xs text-base-content/60">Group by Workflow</span>
             <input
               type="checkbox"
               class="toggle toggle-sm toggle-primary"
               checked={@view_mode == :workflow}
               phx-click="toggle_view"
             />
+            <span class="text-xs text-base-content/60">Group by Workflow</span>
           </label>
         </div>
 

--- a/lib/destila_web/live/crafting_board_live.ex
+++ b/lib/destila_web/live/crafting_board_live.ex
@@ -3,67 +3,299 @@ defmodule DestilaWeb.CraftingBoardLive do
 
   import DestilaWeb.BoardComponents
 
-  @columns [:request, :distill, :done]
+  alias Destila.Workflows
 
+  @sections [:setup, :waiting, :in_progress, :done]
+  @section_labels %{
+    setup: "Setup",
+    waiting: "Waiting for Reply",
+    in_progress: "In Progress",
+    done: "Done"
+  }
+
+  @impl true
   def mount(_params, session, socket) do
     if connected?(socket) do
       Phoenix.PubSub.subscribe(Destila.PubSub, "store:updates")
     end
 
-    prompts = Destila.Prompts.list_prompts(:crafting)
-
     {:ok,
      socket
      |> assign(:current_user, session["current_user"])
-     |> assign(:page_title, "Prompt Crafting")
-     |> assign(:columns, @columns)
-     |> assign_columns(prompts)}
+     |> assign(:page_title, "Crafting Board")}
   end
 
-  def handle_event("card_moved", %{"id" => id, "to" => to_column, "index" => index}, socket) do
-    column = String.to_existing_atom(to_column)
-    prompt = Destila.Prompts.get_prompt!(id)
-    Destila.Prompts.move_card(prompt, column, index)
+  @impl true
+  def handle_params(params, _uri, socket) do
     prompts = Destila.Prompts.list_prompts(:crafting)
-    {:noreply, assign_columns(socket, prompts)}
+    view_mode = if params["view"] == "workflow", do: :workflow, else: :list
+    project_filter = params["project"]
+
+    {:noreply,
+     socket
+     |> assign(:view_mode, view_mode)
+     |> assign(:project_filter, project_filter)
+     |> assign(:all_prompts, prompts)
+     |> assign_derived_state()}
   end
 
+  @impl true
+  def handle_event("toggle_view", _params, socket) do
+    new_mode = if socket.assigns.view_mode == :list, do: :workflow, else: :list
+    {:noreply, push_patch(socket, to: build_path(new_mode, socket.assigns.project_filter))}
+  end
+
+  def handle_event("filter_project", %{"project" => ""}, socket) do
+    {:noreply, push_patch(socket, to: build_path(socket.assigns.view_mode, nil))}
+  end
+
+  def handle_event("filter_project", %{"project" => project_id}, socket) do
+    {:noreply, push_patch(socket, to: build_path(socket.assigns.view_mode, project_id))}
+  end
+
+  @impl true
   def handle_info({_event, _data}, socket) do
     prompts = Destila.Prompts.list_prompts(:crafting)
-    {:noreply, assign_columns(socket, prompts)}
+
+    {:noreply,
+     socket
+     |> assign(:all_prompts, prompts)
+     |> assign_derived_state()}
   end
 
-  defp assign_columns(socket, prompts) do
-    grouped = Enum.group_by(prompts, & &1.column)
+  # --- Classification ---
 
-    Enum.reduce(@columns, socket, fn col, acc ->
-      assign(acc, col, Map.get(grouped, col, []))
-    end)
+  def classify_prompt(prompt) do
+    cond do
+      prompt.column == :done -> :done
+      prompt.phase_status == :setup -> :setup
+      prompt.phase_status in [:generating, :conversing, :advance_suggested] -> :waiting
+      true -> :in_progress
+    end
   end
 
+  # --- Derived State ---
+
+  defp assign_derived_state(socket) do
+    prompts = socket.assigns.all_prompts
+    project_filter = socket.assigns.project_filter
+
+    filtered =
+      if project_filter do
+        Enum.filter(prompts, &(&1.project_id == project_filter))
+      else
+        prompts
+      end
+
+    projects =
+      prompts
+      |> Enum.map(& &1.project)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq_by(& &1.id)
+      |> Enum.sort_by(& &1.name)
+
+    socket
+    |> assign(:filtered_prompts, filtered)
+    |> assign(:projects, projects)
+    |> assign_view_data(filtered)
+  end
+
+  defp assign_view_data(socket, filtered) do
+    sections =
+      filtered
+      |> Enum.group_by(&classify_prompt/1)
+      |> then(fn grouped ->
+        Map.new(@sections, fn s -> {s, Map.get(grouped, s, [])} end)
+      end)
+
+    workflow_boards =
+      filtered
+      |> Enum.group_by(& &1.workflow_type)
+      |> Enum.map(fn {wf_type, wf_prompts} ->
+        columns = Workflows.phase_columns(wf_type)
+
+        column_data =
+          Enum.map(columns, fn {phase, name} ->
+            matching =
+              case phase do
+                :done ->
+                  Enum.filter(wf_prompts, &(&1.column == :done))
+
+                n when is_integer(n) ->
+                  Enum.filter(wf_prompts, &(&1.column != :done && &1.steps_completed == n))
+              end
+
+            {phase, name, matching}
+          end)
+
+        {wf_type, column_data}
+      end)
+      |> Enum.reject(fn {_wf_type, column_data} ->
+        Enum.all?(column_data, fn {_, _, prompts_in_col} -> prompts_in_col == [] end)
+      end)
+      |> Enum.sort_by(fn {wf_type, _} ->
+        case wf_type do
+          :chore_task -> 0
+          :feature_request -> 1
+          :project -> 2
+        end
+      end)
+
+    socket
+    |> assign(:sections, sections)
+    |> assign(:workflow_boards, workflow_boards)
+  end
+
+  # --- URL helpers ---
+
+  defp build_path(view_mode, project_filter) do
+    params =
+      %{}
+      |> then(fn p -> if view_mode == :workflow, do: Map.put(p, "view", "workflow"), else: p end)
+      |> then(fn p -> if project_filter, do: Map.put(p, "project", project_filter), else: p end)
+
+    case URI.encode_query(params) do
+      "" -> "/crafting"
+      qs -> "/crafting?#{qs}"
+    end
+  end
+
+  # --- Render ---
+
+  @impl true
   def render(assigns) do
+    assigns =
+      assigns
+      |> assign(:section_keys, @sections)
+      |> assign(:section_labels, @section_labels)
+
     ~H"""
     <Layouts.app flash={@flash} current_user={@current_user} page_title={@page_title}>
       <div class="p-6 lg:p-8">
-        <div class="flex items-center justify-between mb-6">
-          <h1 class="text-2xl font-bold tracking-tight">Prompt Crafting</h1>
-          <.link navigate={~p"/prompts/new?from=/crafting"} class="btn btn-primary btn-sm">
-            <.icon name="hero-plus-micro" class="size-4" /> New Prompt
-          </.link>
+        <%!-- Header --%>
+        <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
+          <h1 class="text-2xl font-bold tracking-tight">Crafting Board</h1>
+
+          <div class="flex items-center gap-3">
+            <%!-- Project filter --%>
+            <form phx-change="filter_project" id="project-filter-form">
+              <select
+                name="project"
+                id="project-filter"
+                class="select select-sm select-bordered"
+              >
+                <option value="">All projects</option>
+                <option
+                  :for={project <- @projects}
+                  value={project.id}
+                  selected={@project_filter == project.id}
+                >
+                  {project.name}
+                </option>
+              </select>
+            </form>
+
+            <%!-- View toggle --%>
+            <button
+              id="view-toggle"
+              phx-click="toggle_view"
+              class={[
+                "btn btn-sm gap-1",
+                if(@view_mode == :workflow, do: "btn-primary", else: "btn-ghost")
+              ]}
+            >
+              <.icon name="hero-view-columns-micro" class="size-4" /> Group by Workflow
+            </button>
+
+            <%!-- New Prompt --%>
+            <.link navigate={~p"/prompts/new?from=/crafting"} class="btn btn-primary btn-sm">
+              <.icon name="hero-plus-micro" class="size-4" /> New Prompt
+            </.link>
+          </div>
         </div>
 
-        <div class="flex gap-4 overflow-x-auto pb-4" data-board-group="crafting">
-          <.board_column
-            :for={col <- @columns}
-            title={Atom.to_string(col)}
-            column={col}
-            cards={assigns[col]}
-            id={"crafting-#{col}"}
-            sortable
-          />
-        </div>
+        <%!-- List View --%>
+        <%= if @view_mode == :list do %>
+          <div id="crafting-sections" class="space-y-6">
+            <div :for={section <- @section_keys} id={"section-#{section}"}>
+              <div class="flex items-center gap-2 mb-3 px-1">
+                <h3 class="text-xs font-medium text-base-content/50 uppercase">
+                  {@section_labels[section]}
+                </h3>
+                <span class="badge badge-sm badge-ghost">
+                  {length(@sections[section])}
+                </span>
+              </div>
+
+              <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+                <.crafting_card
+                  :for={card <- @sections[section]}
+                  card={card}
+                  project_filter={@project_filter}
+                />
+              </div>
+
+              <div
+                :if={@sections[section] == []}
+                class="flex items-center justify-center h-16 text-base-content/30 text-sm bg-base-200/30 rounded-xl"
+              >
+                No prompts
+              </div>
+            </div>
+          </div>
+
+          <%!-- Workflow View --%>
+        <% else %>
+          <div id="crafting-workflow-boards" class="space-y-8">
+            <%= if @workflow_boards == [] do %>
+              <div class="flex items-center justify-center h-32 text-base-content/30 text-sm bg-base-200/30 rounded-xl">
+                No prompts match your filter
+              </div>
+            <% else %>
+              <div
+                :for={{wf_type, column_data} <- @workflow_boards}
+                id={"workflow-board-#{wf_type}"}
+                class="space-y-3"
+              >
+                <div class="flex items-center gap-2 px-1">
+                  <.workflow_badge type={wf_type} />
+                  <h3 class="text-sm font-semibold">{workflow_label(wf_type)}</h3>
+                </div>
+
+                <div class="flex gap-4 overflow-x-auto pb-4">
+                  <div
+                    :for={{_phase, name, col_prompts} <- column_data}
+                    class="flex flex-col min-w-[240px] max-w-[280px] w-full"
+                  >
+                    <div class="flex items-center gap-2 mb-2 px-1">
+                      <h4 class="text-xs font-medium text-base-content/50 uppercase">{name}</h4>
+                      <span class="badge badge-sm badge-ghost">{length(col_prompts)}</span>
+                    </div>
+                    <div class="flex flex-col gap-2 min-h-[120px] p-2 bg-base-200/50 rounded-xl">
+                      <.crafting_card
+                        :for={card <- col_prompts}
+                        card={card}
+                        project_filter={@project_filter}
+                      />
+                      <div
+                        :if={col_prompts == []}
+                        class="flex items-center justify-center h-16 text-base-content/30 text-sm"
+                      >
+                        No prompts
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
       </div>
     </Layouts.app>
     """
   end
+
+  defp workflow_label(:feature_request), do: "Feature Request"
+  defp workflow_label(:project), do: "Project"
+  defp workflow_label(:chore_task), do: "Chore/Task"
 end

--- a/lib/destila_web/live/crafting_board_live.ex
+++ b/lib/destila_web/live/crafting_board_live.ex
@@ -13,7 +13,6 @@ defmodule DestilaWeb.CraftingBoardLive do
     done: "Done"
   }
 
-  @impl true
   def mount(_params, session, socket) do
     if connected?(socket) do
       Phoenix.PubSub.subscribe(Destila.PubSub, "store:updates")
@@ -25,9 +24,8 @@ defmodule DestilaWeb.CraftingBoardLive do
      |> assign(:page_title, "Prompt Crafting")}
   end
 
-  @impl true
   def handle_params(params, _uri, socket) do
-    prompts = Destila.Prompts.list_prompts(:crafting)
+    prompts = socket.assigns[:all_prompts] || Destila.Prompts.list_prompts(:crafting)
     view_mode = if params["view"] == "workflow", do: :workflow, else: :list
     project_filter = params["project"]
 
@@ -39,7 +37,6 @@ defmodule DestilaWeb.CraftingBoardLive do
      |> assign_derived_state()}
   end
 
-  @impl true
   def handle_event("toggle_view", %{"mode" => mode}, socket) do
     new_mode = if mode == "workflow", do: :workflow, else: :list
     {:noreply, push_patch(socket, to: build_path(new_mode, socket.assigns.project_filter))}
@@ -53,7 +50,6 @@ defmodule DestilaWeb.CraftingBoardLive do
     {:noreply, push_patch(socket, to: build_path(socket.assigns.view_mode, project_id))}
   end
 
-  @impl true
   def handle_info({_event, _data}, socket) do
     prompts = Destila.Prompts.list_prompts(:crafting)
 
@@ -65,7 +61,7 @@ defmodule DestilaWeb.CraftingBoardLive do
 
   # --- Classification ---
 
-  def classify_prompt(prompt) do
+  defp classify_prompt(prompt) do
     cond do
       prompt.column == :done -> :done
       prompt.phase_status == :setup -> :setup
@@ -101,49 +97,53 @@ defmodule DestilaWeb.CraftingBoardLive do
   end
 
   defp assign_view_data(socket, filtered) do
-    sections =
-      filtered
-      |> Enum.group_by(&classify_prompt/1)
-      |> then(fn grouped ->
-        Map.new(@sections, fn s -> {s, Map.get(grouped, s, [])} end)
-      end)
-
-    workflow_boards =
-      filtered
-      |> Enum.group_by(& &1.workflow_type)
-      |> Enum.map(fn {wf_type, wf_prompts} ->
-        columns = Workflows.phase_columns(wf_type)
-
-        column_data =
-          Enum.map(columns, fn {phase, name} ->
-            matching =
-              case phase do
-                :done ->
-                  Enum.filter(wf_prompts, &(&1.column == :done))
-
-                n when is_integer(n) ->
-                  Enum.filter(wf_prompts, &(&1.column != :done && &1.steps_completed == n))
-              end
-
-            {phase, name, matching}
+    case socket.assigns.view_mode do
+      :list ->
+        sections =
+          filtered
+          |> Enum.group_by(&classify_prompt/1)
+          |> then(fn grouped ->
+            Map.new(@sections, fn s -> {s, Map.get(grouped, s, [])} end)
           end)
 
-        {wf_type, column_data}
-      end)
-      |> Enum.reject(fn {_wf_type, column_data} ->
-        Enum.all?(column_data, fn {_, _, prompts_in_col} -> prompts_in_col == [] end)
-      end)
-      |> Enum.sort_by(fn {wf_type, _} ->
-        case wf_type do
-          :chore_task -> 0
-          :feature_request -> 1
-          :project -> 2
-        end
-      end)
+        assign(socket, :sections, sections)
 
-    socket
-    |> assign(:sections, sections)
-    |> assign(:workflow_boards, workflow_boards)
+      :workflow ->
+        workflow_boards =
+          filtered
+          |> Enum.group_by(& &1.workflow_type)
+          |> Enum.map(fn {wf_type, wf_prompts} ->
+            columns = Workflows.phase_columns(wf_type)
+
+            column_data =
+              Enum.map(columns, fn {phase, name} ->
+                matching =
+                  case phase do
+                    :done ->
+                      Enum.filter(wf_prompts, &(&1.column == :done))
+
+                    n when is_integer(n) ->
+                      Enum.filter(wf_prompts, &(&1.column != :done && &1.steps_completed == n))
+                  end
+
+                {phase, name, matching}
+              end)
+
+            {wf_type, column_data}
+          end)
+          |> Enum.reject(fn {_wf_type, column_data} ->
+            Enum.all?(column_data, fn {_, _, prompts_in_col} -> prompts_in_col == [] end)
+          end)
+          |> Enum.sort_by(fn {wf_type, _} ->
+            case wf_type do
+              :chore_task -> 0
+              :feature_request -> 1
+              :project -> 2
+            end
+          end)
+
+        assign(socket, :workflow_boards, workflow_boards)
+    end
   end
 
   # --- URL helpers ---
@@ -176,7 +176,6 @@ defmodule DestilaWeb.CraftingBoardLive do
     done: "No completed prompts yet"
   }
 
-  @impl true
   def render(assigns) do
     assigns =
       assigns
@@ -321,8 +320,4 @@ defmodule DestilaWeb.CraftingBoardLive do
     </Layouts.app>
     """
   end
-
-  defp workflow_label(:feature_request), do: "Feature Request"
-  defp workflow_label(:project), do: "Project"
-  defp workflow_label(:chore_task), do: "Chore/Task"
 end

--- a/lib/destila_web/live/crafting_board_live.ex
+++ b/lib/destila_web/live/crafting_board_live.ex
@@ -217,7 +217,7 @@ defmodule DestilaWeb.CraftingBoardLive do
 
           <label
             id="view-toggle"
-            class="flex items-center gap-2 cursor-pointer select-none border border-base-300 rounded-lg px-3 py-1.5"
+            class="flex items-center gap-2 cursor-pointer select-none border border-base-content/20 rounded-[var(--radius-field)] px-3 py-1.5"
           >
             <input
               type="checkbox"

--- a/lib/destila_web/live/crafting_board_live.ex
+++ b/lib/destila_web/live/crafting_board_live.ex
@@ -22,7 +22,7 @@ defmodule DestilaWeb.CraftingBoardLive do
     {:ok,
      socket
      |> assign(:current_user, session["current_user"])
-     |> assign(:page_title, "Crafting Board")}
+     |> assign(:page_title, "Prompt Crafting")}
   end
 
   @impl true

--- a/lib/destila_web/live/crafting_board_live.ex
+++ b/lib/destila_web/live/crafting_board_live.ex
@@ -212,16 +212,15 @@ defmodule DestilaWeb.CraftingBoardLive do
             </form>
 
             <%!-- View toggle --%>
-            <button
-              id="view-toggle"
-              phx-click="toggle_view"
-              class={[
-                "btn btn-sm gap-1",
-                if(@view_mode == :workflow, do: "btn-primary", else: "btn-ghost")
-              ]}
-            >
-              <.icon name="hero-view-columns-micro" class="size-4" /> Group by Workflow
-            </button>
+            <label id="view-toggle" class="flex items-center gap-2 cursor-pointer select-none">
+              <span class="text-xs text-base-content/60">Group by Workflow</span>
+              <input
+                type="checkbox"
+                class="toggle toggle-sm toggle-primary"
+                checked={@view_mode == :workflow}
+                phx-click="toggle_view"
+              />
+            </label>
 
             <%!-- New Prompt --%>
             <.link navigate={~p"/prompts/new?from=/crafting"} class="btn btn-primary btn-sm">

--- a/lib/destila_web/live/crafting_board_live.ex
+++ b/lib/destila_web/live/crafting_board_live.ex
@@ -40,8 +40,8 @@ defmodule DestilaWeb.CraftingBoardLive do
   end
 
   @impl true
-  def handle_event("toggle_view", _params, socket) do
-    new_mode = if socket.assigns.view_mode == :list, do: :workflow, else: :list
+  def handle_event("toggle_view", %{"mode" => mode}, socket) do
+    new_mode = if mode == "workflow", do: :workflow, else: :list
     {:noreply, push_patch(socket, to: build_path(new_mode, socket.assigns.project_filter))}
   end
 
@@ -215,18 +215,28 @@ defmodule DestilaWeb.CraftingBoardLive do
             </select>
           </form>
 
-          <label
-            id="view-toggle"
-            class="flex items-center gap-2 cursor-pointer select-none border border-base-content/20 rounded-[var(--radius-field)] px-3 py-1.5"
-          >
-            <input
-              type="checkbox"
-              class="toggle toggle-sm toggle-primary"
-              checked={@view_mode == :workflow}
+          <div id="view-toggle" class="join">
+            <button
               phx-click="toggle_view"
-            />
-            <span class="text-xs text-base-content/60">Group by Workflow</span>
-          </label>
+              phx-value-mode="list"
+              class={[
+                "join-item btn btn-sm",
+                if(@view_mode == :list, do: "btn-active", else: "")
+              ]}
+            >
+              <.icon name="hero-list-bullet-micro" class="size-4" /> List
+            </button>
+            <button
+              phx-click="toggle_view"
+              phx-value-mode="workflow"
+              class={[
+                "join-item btn btn-sm",
+                if(@view_mode == :workflow, do: "btn-active", else: "")
+              ]}
+            >
+              <.icon name="hero-view-columns-micro" class="size-4" /> Workflow
+            </button>
+          </div>
         </div>
 
         <%!-- List View --%>

--- a/lib/destila_web/live/crafting_board_live.ex
+++ b/lib/destila_web/live/crafting_board_live.ex
@@ -215,7 +215,10 @@ defmodule DestilaWeb.CraftingBoardLive do
             </select>
           </form>
 
-          <label id="view-toggle" class="flex items-center gap-2 cursor-pointer select-none">
+          <label
+            id="view-toggle"
+            class="flex items-center gap-2 cursor-pointer select-none border border-base-300 rounded-lg px-3 py-1.5"
+          >
             <input
               type="checkbox"
               class="toggle toggle-sm toggle-primary"

--- a/lib/destila_web/live/crafting_board_live.ex
+++ b/lib/destila_web/live/crafting_board_live.ex
@@ -189,46 +189,41 @@ defmodule DestilaWeb.CraftingBoardLive do
     <Layouts.app flash={@flash} current_user={@current_user} page_title={@page_title}>
       <div class="p-6 lg:p-8">
         <%!-- Header --%>
-        <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
-          <div class="flex items-center gap-4">
-            <h1 class="text-2xl font-bold tracking-tight">Prompt Crafting</h1>
-            <.link navigate={~p"/prompts/new?from=/crafting"} class="btn btn-primary btn-sm">
-              <.icon name="hero-plus-micro" class="size-4" /> New Prompt
-            </.link>
-          </div>
+        <div class="flex items-center justify-between mb-4">
+          <h1 class="text-2xl font-bold tracking-tight">Prompt Crafting</h1>
+          <.link navigate={~p"/prompts/new?from=/crafting"} class="btn btn-primary btn-sm">
+            <.icon name="hero-plus-micro" class="size-4" /> New Prompt
+          </.link>
+        </div>
 
-          <div class="flex items-center gap-3">
-            <%!-- Project filter --%>
-            <form phx-change="filter_project" id="project-filter-form">
-              <select
-                name="project"
-                id="project-filter"
-                class="select select-sm select-bordered"
+        <%!-- View controls --%>
+        <div class="flex items-center gap-3 mb-6">
+          <form phx-change="filter_project" id="project-filter-form">
+            <select
+              name="project"
+              id="project-filter"
+              class="select select-sm select-bordered"
+            >
+              <option value="">All projects</option>
+              <option
+                :for={project <- @projects}
+                value={project.id}
+                selected={@project_filter == project.id}
               >
-                <option value="">All projects</option>
-                <option
-                  :for={project <- @projects}
-                  value={project.id}
-                  selected={@project_filter == project.id}
-                >
-                  {project.name}
-                </option>
-              </select>
-            </form>
+                {project.name}
+              </option>
+            </select>
+          </form>
 
-            <div class="w-px h-5 bg-base-300" />
-
-            <%!-- View toggle --%>
-            <label id="view-toggle" class="flex items-center gap-2 cursor-pointer select-none">
-              <span class="text-xs text-base-content/60">Group by Workflow</span>
-              <input
-                type="checkbox"
-                class="toggle toggle-sm toggle-primary"
-                checked={@view_mode == :workflow}
-                phx-click="toggle_view"
-              />
-            </label>
-          </div>
+          <label id="view-toggle" class="flex items-center gap-2 cursor-pointer select-none">
+            <span class="text-xs text-base-content/60">Group by Workflow</span>
+            <input
+              type="checkbox"
+              class="toggle toggle-sm toggle-primary"
+              checked={@view_mode == :workflow}
+              phx-click="toggle_view"
+            />
+          </label>
         </div>
 
         <%!-- List View --%>

--- a/lib/destila_web/live/dashboard_live.ex
+++ b/lib/destila_web/live/dashboard_live.ex
@@ -37,9 +37,28 @@ defmodule DestilaWeb.DashboardLive do
     end)
   end
 
-  defp column_label(:request), do: "Request"
-  defp column_label(:distill), do: "Distill"
-  defp column_label(:done), do: "Done"
+  defp crafting_summary(prompts) do
+    grouped = Enum.group_by(prompts, &classify_crafting_prompt/1)
+
+    Enum.map([:setup, :waiting, :in_progress, :done], fn section ->
+      {section, Map.get(grouped, section, [])}
+    end)
+  end
+
+  defp classify_crafting_prompt(prompt) do
+    cond do
+      prompt.column == :done -> :done
+      prompt.phase_status == :setup -> :setup
+      prompt.phase_status in [:generating, :conversing, :advance_suggested] -> :waiting
+      true -> :in_progress
+    end
+  end
+
+  defp section_label(:setup), do: "Setup"
+  defp section_label(:waiting), do: "Waiting"
+  defp section_label(:in_progress), do: "In Progress"
+  defp section_label(:done), do: "Done"
+
   defp column_label(:impl_done), do: "Done"
   defp column_label(:todo), do: "Todo"
   defp column_label(:in_progress), do: "In Progress"
@@ -47,7 +66,7 @@ defmodule DestilaWeb.DashboardLive do
   defp column_label(:qa), do: "QA"
 
   def render(assigns) do
-    crafting_summary = board_summary(assigns.crafting_prompts, [:request, :distill, :done])
+    crafting_summary = crafting_summary(assigns.crafting_prompts)
 
     implementation_summary =
       board_summary(assigns.implementation_prompts, [
@@ -80,8 +99,8 @@ defmodule DestilaWeb.DashboardLive do
               <h2 class="card-title text-lg mb-1">Prompt Crafting</h2>
 
               <div class="flex gap-3 text-xs text-base-content/50 mb-3">
-                <span :for={{col, cards} <- @crafting_summary}>
-                  {length(cards)} {column_label(col)}
+                <span :for={{section, cards} <- @crafting_summary}>
+                  {length(cards)} {section_label(section)}
                 </span>
               </div>
 

--- a/test/destila_web/live/crafting_board_live_test.exs
+++ b/test/destila_web/live/crafting_board_live_test.exs
@@ -1,0 +1,440 @@
+defmodule DestilaWeb.CraftingBoardLiveTest do
+  @moduledoc """
+  LiveView tests for the Crafting Board.
+  Feature: features/crafting_board.feature
+  """
+  use DestilaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  @feature "crafting_board"
+
+  setup %{conn: conn} do
+    conn = post(conn, "/login", %{"email" => "test@example.com"})
+
+    {:ok, project_a} =
+      Destila.Projects.create_project(%{
+        name: "destila",
+        git_repo_url: "https://github.com/test/destila"
+      })
+
+    {:ok, project_b} =
+      Destila.Projects.create_project(%{
+        name: "other-project",
+        git_repo_url: "https://github.com/test/other"
+      })
+
+    {:ok, conn: conn, project_a: project_a, project_b: project_b}
+  end
+
+  defp create_prompt(attrs) do
+    defaults = %{
+      title: "Test Prompt",
+      workflow_type: :chore_task,
+      board: :crafting,
+      column: :request,
+      steps_completed: 1,
+      steps_total: 4,
+      position: System.unique_integer([:positive])
+    }
+
+    {:ok, prompt} = Destila.Prompts.create_prompt(Map.merge(defaults, attrs))
+    prompt
+  end
+
+  # --- Default List View ---
+
+  describe "sectioned list view" do
+    @tag feature: @feature, scenario: "View prompts in sectioned list"
+    test "shows four sections", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/crafting")
+
+      assert has_element?(view, "#section-setup")
+      assert has_element?(view, "#section-waiting")
+      assert has_element?(view, "#section-in_progress")
+      assert has_element?(view, "#section-done")
+    end
+
+    @tag feature: @feature, scenario: "View prompts in sectioned list"
+    test "classifies prompts into correct sections", %{conn: conn, project_a: project} do
+      setup_prompt =
+        create_prompt(%{
+          title: "Setup Prompt",
+          phase_status: :setup,
+          project_id: project.id
+        })
+
+      waiting_prompt =
+        create_prompt(%{
+          title: "Waiting Prompt",
+          phase_status: :conversing,
+          project_id: project.id
+        })
+
+      generating_prompt =
+        create_prompt(%{
+          title: "Generating Prompt",
+          phase_status: :generating,
+          project_id: project.id
+        })
+
+      in_progress_prompt =
+        create_prompt(%{
+          title: "Active Prompt",
+          phase_status: nil,
+          workflow_type: :feature_request,
+          project_id: project.id
+        })
+
+      done_prompt =
+        create_prompt(%{
+          title: "Done Prompt",
+          column: :done,
+          project_id: project.id
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/crafting")
+
+      # Setup section
+      assert has_element?(view, "#section-setup #crafting-card-#{setup_prompt.id}")
+
+      # Waiting section (both conversing and generating)
+      assert has_element?(view, "#section-waiting #crafting-card-#{waiting_prompt.id}")
+      assert has_element?(view, "#section-waiting #crafting-card-#{generating_prompt.id}")
+
+      # In Progress section
+      assert has_element?(view, "#section-in_progress #crafting-card-#{in_progress_prompt.id}")
+
+      # Done section
+      assert has_element?(view, "#section-done #crafting-card-#{done_prompt.id}")
+    end
+
+    @tag feature: @feature, scenario: "View prompts in sectioned list"
+    test "advance_suggested appears in waiting section", %{conn: conn, project_a: project} do
+      prompt =
+        create_prompt(%{
+          title: "Advance Prompt",
+          phase_status: :advance_suggested,
+          project_id: project.id
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/crafting")
+      assert has_element?(view, "#section-waiting #crafting-card-#{prompt.id}")
+    end
+  end
+
+  describe "card content" do
+    @tag feature: @feature, scenario: "Prompt card displays title, project, and phase"
+    test "card shows title, project name, and phase number", %{conn: conn, project_a: project} do
+      create_prompt(%{
+        title: "Fix login bug",
+        project_id: project.id,
+        steps_completed: 2,
+        workflow_type: :feature_request
+      })
+
+      {:ok, _view, html} = live(conn, ~p"/crafting")
+
+      assert html =~ "Fix login bug"
+      assert html =~ "destila"
+      assert html =~ "Phase 2"
+    end
+
+    @tag feature: @feature, scenario: "Click prompt card to navigate to detail page"
+    test "card title links to prompt detail page", %{conn: conn, project_a: project} do
+      prompt =
+        create_prompt(%{
+          title: "Clickable Prompt",
+          project_id: project.id
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/crafting")
+
+      assert has_element?(view, "a[href='/prompts/#{prompt.id}']", "Clickable Prompt")
+    end
+  end
+
+  # --- Project Filter ---
+
+  describe "project filter" do
+    @tag feature: @feature, scenario: "Filter prompts by project"
+    test "filters prompts by project via dropdown", %{
+      conn: conn,
+      project_a: project_a,
+      project_b: project_b
+    } do
+      prompt_a = create_prompt(%{title: "Prompt A", project_id: project_a.id})
+      prompt_b = create_prompt(%{title: "Prompt B", project_id: project_b.id})
+
+      {:ok, view, _html} = live(conn, ~p"/crafting")
+
+      # Both visible initially
+      assert has_element?(view, "#crafting-card-#{prompt_a.id}")
+      assert has_element?(view, "#crafting-card-#{prompt_b.id}")
+
+      # Filter to project_a
+      view
+      |> form("#project-filter-form", %{"project" => project_a.id})
+      |> render_change()
+
+      assert has_element?(view, "#crafting-card-#{prompt_a.id}")
+      refute has_element?(view, "#crafting-card-#{prompt_b.id}")
+    end
+
+    @tag feature: @feature, scenario: "Clear project filter"
+    test "clearing filter shows all prompts", %{
+      conn: conn,
+      project_a: project_a,
+      project_b: project_b
+    } do
+      prompt_a = create_prompt(%{title: "Prompt A", project_id: project_a.id})
+      prompt_b = create_prompt(%{title: "Prompt B", project_id: project_b.id})
+
+      # Start with filter active
+      {:ok, view, _html} = live(conn, "/crafting?project=#{project_a.id}")
+      refute has_element?(view, "#crafting-card-#{prompt_b.id}")
+
+      # Clear filter
+      view
+      |> form("#project-filter-form", %{"project" => ""})
+      |> render_change()
+
+      assert has_element?(view, "#crafting-card-#{prompt_a.id}")
+      assert has_element?(view, "#crafting-card-#{prompt_b.id}")
+    end
+
+    @tag feature: @feature, scenario: "Click project name on card to filter by project"
+    test "clicking project name on card activates filter", %{
+      conn: conn,
+      project_a: project_a,
+      project_b: project_b
+    } do
+      prompt_a = create_prompt(%{title: "Prompt A", project_id: project_a.id})
+      prompt_b = create_prompt(%{title: "Prompt B", project_id: project_b.id})
+
+      {:ok, view, _html} = live(conn, ~p"/crafting")
+
+      # Click the project name link on prompt_a's card
+      view
+      |> element("#crafting-card-#{prompt_a.id} a", "destila")
+      |> render_click()
+
+      # Should filter to project_a only
+      assert has_element?(view, "#crafting-card-#{prompt_a.id}")
+      refute has_element?(view, "#crafting-card-#{prompt_b.id}")
+    end
+
+    @tag feature: @feature, scenario: "Filter prompts by project"
+    test "prompts without project appear only when no filter active", %{
+      conn: conn,
+      project_a: project_a
+    } do
+      with_project = create_prompt(%{title: "With Project", project_id: project_a.id})
+
+      without_project =
+        create_prompt(%{title: "No Project", project_id: nil, workflow_type: :project})
+
+      {:ok, view, _html} = live(conn, ~p"/crafting")
+
+      # Both visible when no filter
+      assert has_element?(view, "#crafting-card-#{with_project.id}")
+      assert has_element?(view, "#crafting-card-#{without_project.id}")
+
+      # Filter to project_a — prompt without project disappears
+      view
+      |> form("#project-filter-form", %{"project" => project_a.id})
+      |> render_change()
+
+      assert has_element?(view, "#crafting-card-#{with_project.id}")
+      refute has_element?(view, "#crafting-card-#{without_project.id}")
+    end
+  end
+
+  # --- Group by Workflow ---
+
+  describe "group by workflow" do
+    @tag feature: @feature, scenario: "Toggle group by workflow"
+    test "toggle shows workflow boards with phase columns", %{conn: conn, project_a: project} do
+      create_prompt(%{
+        title: "Chore Prompt",
+        workflow_type: :chore_task,
+        steps_completed: 2,
+        project_id: project.id
+      })
+
+      create_prompt(%{
+        title: "Feature Prompt",
+        workflow_type: :feature_request,
+        steps_completed: 1,
+        steps_total: 4,
+        project_id: project.id
+      })
+
+      {:ok, view, _html} = live(conn, ~p"/crafting")
+
+      # Toggle to workflow view
+      view |> element("#view-toggle") |> render_click()
+
+      # Should see workflow boards
+      assert has_element?(view, "#workflow-board-chore_task")
+      assert has_element?(view, "#workflow-board-feature_request")
+
+      # Chore/Task board should have phase columns
+      html = render(view)
+      assert html =~ "Task Description"
+      assert html =~ "Gherkin Review"
+
+      # Feature Request board should have its columns
+      assert html =~ "Problem"
+      assert html =~ "Feature Type"
+    end
+
+    @tag feature: @feature, scenario: "Empty workflow boards are hidden"
+    test "hides workflow boards with no prompts", %{conn: conn, project_a: project} do
+      create_prompt(%{
+        title: "Chore Only",
+        workflow_type: :chore_task,
+        project_id: project.id
+      })
+
+      {:ok, view, _html} = live(conn, "/crafting?view=workflow")
+
+      assert has_element?(view, "#workflow-board-chore_task")
+      refute has_element?(view, "#workflow-board-feature_request")
+      refute has_element?(view, "#workflow-board-project")
+    end
+
+    @tag feature: @feature, scenario: "Boards are read-only (no drag and drop)"
+    test "no sortable hooks on workflow boards", %{conn: conn, project_a: project} do
+      create_prompt(%{
+        title: "Test Prompt",
+        workflow_type: :chore_task,
+        project_id: project.id
+      })
+
+      {:ok, view, _html} = live(conn, "/crafting?view=workflow")
+
+      html = render(view)
+      refute html =~ "phx-hook=\"Sortable\""
+    end
+
+    @tag feature: @feature, scenario: "Toggle group by workflow"
+    test "toggling back returns to list view", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/crafting?view=workflow")
+
+      view |> element("#view-toggle") |> render_click()
+
+      assert has_element?(view, "#crafting-sections")
+      refute has_element?(view, "#crafting-workflow-boards")
+    end
+  end
+
+  # --- Combined filter + grouping ---
+
+  describe "filter with workflow grouping" do
+    @tag feature: @feature, scenario: "Filter by project with group by workflow active"
+    test "project filter works in workflow view", %{
+      conn: conn,
+      project_a: project_a,
+      project_b: project_b
+    } do
+      prompt_a =
+        create_prompt(%{
+          title: "Chore A",
+          workflow_type: :chore_task,
+          project_id: project_a.id
+        })
+
+      prompt_b =
+        create_prompt(%{
+          title: "Chore B",
+          workflow_type: :chore_task,
+          project_id: project_b.id
+        })
+
+      {:ok, view, _html} = live(conn, "/crafting?view=workflow")
+
+      # Both visible initially
+      assert has_element?(view, "#crafting-card-#{prompt_a.id}")
+      assert has_element?(view, "#crafting-card-#{prompt_b.id}")
+
+      # Filter to project_a
+      view
+      |> form("#project-filter-form", %{"project" => project_a.id})
+      |> render_change()
+
+      assert has_element?(view, "#crafting-card-#{prompt_a.id}")
+      refute has_element?(view, "#crafting-card-#{prompt_b.id}")
+    end
+
+    @tag feature: @feature, scenario: "Filter by project with group by workflow active"
+    test "filter persists when toggling view mode", %{conn: conn, project_a: project_a} do
+      create_prompt(%{title: "Prompt A", project_id: project_a.id})
+
+      # Start with filter active in list view
+      {:ok, view, _html} = live(conn, "/crafting?project=#{project_a.id}")
+
+      # Toggle to workflow view — filter should persist
+      view |> element("#view-toggle") |> render_click()
+
+      # Should still be filtered (URL should have both params)
+      assert has_element?(view, "#crafting-workflow-boards")
+      assert has_element?(view, "#project-filter")
+    end
+  end
+
+  # --- URL State ---
+
+  describe "URL state" do
+    test "filter updates URL query params", %{conn: conn, project_a: project_a} do
+      create_prompt(%{title: "Test", project_id: project_a.id})
+
+      {:ok, view, _html} = live(conn, ~p"/crafting")
+
+      view
+      |> form("#project-filter-form", %{"project" => project_a.id})
+      |> render_change()
+
+      assert_patch(view, "/crafting?project=#{project_a.id}")
+    end
+
+    test "toggle updates URL query params", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/crafting")
+
+      view |> element("#view-toggle") |> render_click()
+
+      assert_patch(view, "/crafting?view=workflow")
+    end
+
+    test "loads state from URL on mount", %{
+      conn: conn,
+      project_a: project_a,
+      project_b: project_b
+    } do
+      prompt_a = create_prompt(%{title: "A", project_id: project_a.id})
+      prompt_b = create_prompt(%{title: "B", project_id: project_b.id})
+
+      {:ok, view, _html} = live(conn, "/crafting?project=#{project_a.id}&view=workflow")
+
+      # Should be in workflow mode with filter active
+      assert has_element?(view, "#crafting-workflow-boards")
+      assert has_element?(view, "#crafting-card-#{prompt_a.id}")
+      refute has_element?(view, "#crafting-card-#{prompt_b.id}")
+    end
+  end
+
+  # --- PubSub ---
+
+  describe "real-time updates" do
+    @tag feature: @feature, scenario: "View prompts in sectioned list"
+    test "board updates when a prompt is created", %{conn: conn, project_a: project} do
+      {:ok, view, _html} = live(conn, ~p"/crafting")
+
+      # Create a new prompt — triggers PubSub broadcast
+      prompt = create_prompt(%{title: "New Prompt", project_id: project.id})
+
+      # The PubSub handler will refresh the view
+      assert has_element?(view, "#crafting-card-#{prompt.id}")
+    end
+  end
+end

--- a/test/destila_web/live/crafting_board_live_test.exs
+++ b/test/destila_web/live/crafting_board_live_test.exs
@@ -273,7 +273,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
       {:ok, view, _html} = live(conn, ~p"/crafting")
 
       # Toggle to workflow view
-      view |> element("#view-toggle") |> render_click()
+      view |> element("#view-toggle input") |> render_click()
 
       # Should see workflow boards
       assert has_element?(view, "#workflow-board-chore_task")
@@ -322,7 +322,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
     test "toggling back returns to list view", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/crafting?view=workflow")
 
-      view |> element("#view-toggle") |> render_click()
+      view |> element("#view-toggle input") |> render_click()
 
       assert has_element?(view, "#crafting-sections")
       refute has_element?(view, "#crafting-workflow-boards")
@@ -375,7 +375,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
       {:ok, view, _html} = live(conn, "/crafting?project=#{project_a.id}")
 
       # Toggle to workflow view — filter should persist
-      view |> element("#view-toggle") |> render_click()
+      view |> element("#view-toggle input") |> render_click()
 
       # Should still be filtered (URL should have both params)
       assert has_element?(view, "#crafting-workflow-boards")
@@ -401,7 +401,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
     test "toggle updates URL query params", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/crafting")
 
-      view |> element("#view-toggle") |> render_click()
+      view |> element("#view-toggle input") |> render_click()
 
       assert_patch(view, "/crafting?view=workflow")
     end

--- a/test/destila_web/live/crafting_board_live_test.exs
+++ b/test/destila_web/live/crafting_board_live_test.exs
@@ -137,7 +137,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
 
       assert html =~ "Fix login bug"
       assert html =~ "destila"
-      assert html =~ "Phase 2"
+      assert html =~ "Feature Type"
     end
 
     @tag feature: @feature, scenario: "Click prompt card to navigate to detail page"

--- a/test/destila_web/live/crafting_board_live_test.exs
+++ b/test/destila_web/live/crafting_board_live_test.exs
@@ -273,7 +273,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
       {:ok, view, _html} = live(conn, ~p"/crafting")
 
       # Toggle to workflow view
-      view |> element("#view-toggle input") |> render_click()
+      view |> element("#view-toggle button[phx-value-mode=workflow]") |> render_click()
 
       # Should see workflow boards
       assert has_element?(view, "#workflow-board-chore_task")
@@ -322,7 +322,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
     test "toggling back returns to list view", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/crafting?view=workflow")
 
-      view |> element("#view-toggle input") |> render_click()
+      view |> element("#view-toggle button[phx-value-mode=list]") |> render_click()
 
       assert has_element?(view, "#crafting-sections")
       refute has_element?(view, "#crafting-workflow-boards")
@@ -375,7 +375,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
       {:ok, view, _html} = live(conn, "/crafting?project=#{project_a.id}")
 
       # Toggle to workflow view — filter should persist
-      view |> element("#view-toggle input") |> render_click()
+      view |> element("#view-toggle button[phx-value-mode=workflow]") |> render_click()
 
       # Should still be filtered (URL should have both params)
       assert has_element?(view, "#crafting-workflow-boards")
@@ -401,7 +401,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
     test "toggle updates URL query params", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/crafting")
 
-      view |> element("#view-toggle input") |> render_click()
+      view |> element("#view-toggle button[phx-value-mode=workflow]") |> render_click()
 
       assert_patch(view, "/crafting?view=workflow")
     end


### PR DESCRIPTION
## Summary

- Replace the 3-column kanban board on `/crafting` with a **sectioned list view** (Setup, Waiting for Reply, In Progress, Done) as the default
- Add **"Group by Workflow"** segmented toggle showing read-only per-workflow boards with phase-name columns and compact cards
- Add **project filter** dropdown with URL state persistence via query params
- Remove drag-and-drop from the crafting board (Sortable hook preserved for Implementation board)

## Key changes

- `list_prompts/1` now preloads `:project` association
- `Workflows.phase_name/2` and `phase_columns/1` provide unified phase names across all workflow types
- New `crafting_card` component with full and compact modes
- Compact cards show title (up to 3 lines), project name, and a status dot (waiting/generating/setup/done/in-progress)
- Full cards show workflow badge, clickable project name (activates filter), phase name, and progress bar
- Cards in Done section show "Done" label instead of the last phase name
- Contextual empty states with section-appropriate icons and messages
- Two-row header: title + action button (matches app-wide pattern), filter dropdown + segmented view toggle below
- Dashboard crafting summary updated to use new section-based classification
- `handle_params` reuses cached prompts on `push_patch` to avoid redundant DB queries
- `assign_view_data` only computes the active view's data

## Code review fixes applied

- Removed `@impl true` annotations (inconsistent with codebase)
- Made `workflow_label/1` public in `BoardComponents`, removed duplicate
- Made `classify_prompt/1` private
- Optimized `handle_params` to skip DB fetch when data exists
- Updated dashboard to match new section model
- Only compute active view data in `assign_view_data`
- Documented `phase_columns` range asymmetry

## Test plan

- [x] 19 new LiveView integration tests covering section assignment, card content, project filter, workflow toggle, URL state, PubSub refresh
- [x] 96 total tests pass (`mix precommit`)
- [x] Gherkin feature file created at `features/crafting_board.feature`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>