### PR TITLE
feat: Add archive and unarchive workflow sessions

### DIFF
--- a/docs/plans/2026-03-24-feat-archive-workflow-sessions-plan.md
+++ b/docs/plans/2026-03-24-feat-archive-workflow-sessions-plan.md
@@ -1,0 +1,241 @@
+---
+title: "feat: Archive and Unarchive Workflow Sessions"
+type: feat
+date: 2026-03-24
+---
+
+# Archive and Unarchive Workflow Sessions
+
+## Overview
+
+Add soft-delete archiving for workflow sessions. Archiving hides sessions from the crafting board and dashboard while preserving all data. Users can restore archived sessions at any time. A dedicated archived sessions page lists all archived sessions.
+
+## Problem Statement
+
+As the number of workflow sessions grows, the crafting board and dashboard become cluttered with completed or abandoned sessions. Users need a way to declutter their workspace without permanently losing session data.
+
+## Proposed Solution
+
+Add an `archived_at` (UTC datetime, nullable) field to the `WorkflowSession` schema. A non-null value means the session is archived. Filter archived sessions from the crafting board and dashboard by default. Provide an archive/unarchive toggle on the session detail page and a dedicated page to browse archived sessions.
+
+## Technical Approach
+
+### 1. Schema & Migration
+
+**File:** `lib/destila/workflow_sessions/workflow_session.ex`
+
+Add `archived_at` field to the schema and changeset:
+
+```elixir
+field(:archived_at, :utc_datetime)
+```
+
+Cast `:archived_at` in the changeset's `cast/3` field list.
+
+**Migration:** Since the app is early-stage, reset the DB. Add `archived_at` to the `create table(:workflow_sessions)` block in the existing migration:
+
+```elixir
+add :archived_at, :utc_datetime
+```
+
+### 2. Context Functions
+
+**File:** `lib/destila/workflow_sessions.ex`
+
+**Modify `list_workflow_sessions/0`** to exclude archived sessions:
+
+```elixir
+def list_workflow_sessions do
+  from(ws in WorkflowSession,
+    where: is_nil(ws.archived_at),
+    order_by: ws.position
+  )
+  |> preload(:project)
+  |> Repo.all()
+end
+```
+
+**Add `list_archived_workflow_sessions/0`** for the archived page:
+
+```elixir
+def list_archived_workflow_sessions do
+  from(ws in WorkflowSession,
+    where: not is_nil(ws.archived_at),
+    order_by: [desc: ws.archived_at]
+  )
+  |> preload(:project)
+  |> Repo.all()
+end
+```
+
+**Add `archive_workflow_session/1`** — sets `archived_at` and stops the AI GenServer:
+
+```elixir
+def archive_workflow_session(%WorkflowSession{} = ws) do
+  stop_ai_session(ws.id)
+
+  ws
+  |> WorkflowSession.changeset(%{archived_at: DateTime.utc_now()})
+  |> Repo.update()
+  |> broadcast(:workflow_session_updated)
+end
+```
+
+**Add `unarchive_workflow_session/1`** — clears `archived_at`:
+
+```elixir
+def unarchive_workflow_session(%WorkflowSession{} = ws) do
+  ws
+  |> WorkflowSession.changeset(%{archived_at: nil})
+  |> Repo.update()
+  |> broadcast(:workflow_session_updated)
+end
+```
+
+**Add `stop_ai_session/1`** private helper:
+
+```elixir
+defp stop_ai_session(workflow_session_id) do
+  name = {:via, Registry, {Destila.AI.SessionRegistry, workflow_session_id}}
+
+  case GenServer.whereis(name) do
+    nil -> :ok
+    pid -> Destila.AI.Session.stop(pid)
+  end
+end
+```
+
+**Leave `count_by_project/1` and `count_by_projects/0` unchanged** — archived sessions still count toward project totals and block project deletion.
+
+### 3. Session Detail Page — Archive/Unarchive Button
+
+**File:** `lib/destila_web/live/session_detail_live.ex`
+
+**Add event handlers:**
+
+```elixir
+def handle_event("archive_session", _params, socket) do
+  {:ok, ws} = Destila.WorkflowSessions.archive_workflow_session(socket.assigns.workflow_session)
+
+  {:noreply,
+   socket
+   |> assign(:workflow_session, ws)
+   |> put_flash(:info, "Session archived")}
+end
+
+def handle_event("unarchive_session", _params, socket) do
+  {:ok, ws} = Destila.WorkflowSessions.unarchive_workflow_session(socket.assigns.workflow_session)
+
+  {:noreply,
+   socket
+   |> assign(:workflow_session, ws)
+   |> put_flash(:info, "Session restored")}
+end
+```
+
+**Add button in the header** (next to the "Mark as Done" button area):
+
+```heex
+<button
+  :if={is_nil(@workflow_session.archived_at)}
+  phx-click="archive_session"
+  id="archive-btn"
+  class="btn btn-ghost btn-sm"
+  data-confirm="Archive this session? It will be hidden from the crafting board."
+>
+  <.icon name="hero-archive-box-micro" class="size-4" /> Archive
+</button>
+<button
+  :if={@workflow_session.archived_at}
+  phx-click="unarchive_session"
+  id="unarchive-btn"
+  class="btn btn-ghost btn-sm"
+>
+  <.icon name="hero-archive-box-arrow-down-micro" class="size-4" /> Unarchive
+</button>
+```
+
+### 4. Archived Sessions Page
+
+**File:** `lib/destila_web/live/archived_sessions_live.ex` (new)
+
+A simple LiveView listing all archived sessions with title, project name, and workflow type. Each row links to the session detail page. Shows an empty-state message when no sessions are archived.
+
+Subscribes to `"store:updates"` PubSub and refetches on `:workflow_session_updated` to reflect unarchive actions in real time.
+
+**Route:** Add to the authenticated scope in `lib/destila_web/router.ex`:
+
+```elixir
+live "/sessions/archived", ArchivedSessionsLive
+```
+
+Place this route **before** `live "/sessions/:id", SessionDetailLive` to avoid the `:id` param capturing "archived" as an ID.
+
+### 5. Crafting Board — "View Archived" Link
+
+**File:** `lib/destila_web/live/crafting_board_live.ex`
+
+Add a subtle link in the header area (near the "New Session" button or below the view controls):
+
+```heex
+<.link navigate={~p"/sessions/archived"} class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">
+  View archived
+</.link>
+```
+
+### 6. PubSub — No Changes Needed
+
+Both `archive_workflow_session/1` and `unarchive_workflow_session/1` broadcast `:workflow_session_updated` via the existing `broadcast/2` helper. The crafting board and dashboard already handle this event by refetching via `list_workflow_sessions/0`, which will now exclude archived sessions. No new PubSub events or handlers needed.
+
+### 7. AI Session GenServer — Stopped on Archive
+
+When a session is archived, `stop_ai_session/1` checks the Registry for a running GenServer and stops it gracefully. This frees resources immediately rather than waiting for the 5-minute inactivity timeout. On unarchive, the GenServer restarts naturally when the user next interacts with the session (via `for_workflow_session/2`).
+
+## Acceptance Criteria
+
+- [x] `archived_at` field added to WorkflowSession schema and migration
+- [x] `list_workflow_sessions/0` excludes archived sessions
+- [x] `list_archived_workflow_sessions/0` returns only archived sessions ordered by `archived_at` desc
+- [x] `archive_workflow_session/1` sets `archived_at`, stops AI GenServer, broadcasts update
+- [x] `unarchive_workflow_session/1` clears `archived_at`, broadcasts update
+- [x] `count_by_project/1` still counts archived sessions (no filter change)
+- [x] Session detail page shows "Archive" button for active sessions
+- [x] Session detail page shows "Unarchive" button for archived sessions
+- [x] Flash messages confirm archive/unarchive actions
+- [x] Archived sessions hidden from crafting board (both list and workflow views)
+- [x] Archived sessions hidden from dashboard
+- [x] Archived sessions page at `/sessions/archived` lists all archived sessions
+- [x] Archived sessions page shows title, project, workflow type per session
+- [x] Archived sessions page shows empty state when none archived
+- [x] Clicking a session on the archived page navigates to its detail page
+- [x] "View archived" link on crafting board navigates to archived page
+- [x] PubSub updates reflect archive/unarchive in real time on crafting board and dashboard
+- [x] Gherkin feature file created at `features/session_archiving.feature`
+- [x] Tests link to Gherkin scenarios via `@tag feature:` and `@tag scenario:`
+
+## Files to Create or Modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `lib/destila/workflow_sessions/workflow_session.ex` | Modify | Add `archived_at` field and cast |
+| `lib/destila/workflow_sessions.ex` | Modify | Add archive/unarchive functions, filter `list_workflow_sessions` |
+| `lib/destila_web/live/session_detail_live.ex` | Modify | Add archive/unarchive button and event handlers |
+| `lib/destila_web/live/archived_sessions_live.ex` | Create | New LiveView for archived sessions page |
+| `lib/destila_web/live/crafting_board_live.ex` | Modify | Add "View archived" link |
+| `lib/destila_web/router.ex` | Modify | Add `/sessions/archived` route |
+| `priv/repo/migrations/*_create_workflow_sessions.exs` | Modify | Add `archived_at` column (DB reset) |
+| `features/session_archiving.feature` | Create | Gherkin scenarios |
+| `test/destila_web/live/session_detail_live_test.exs` | Modify | Add archive/unarchive tests |
+| `test/destila_web/live/archived_sessions_live_test.exs` | Create | Tests for archived sessions page |
+| `test/destila_web/live/crafting_board_live_test.exs` | Modify | Test that archived sessions are hidden |
+| `test/destila_web/live/dashboard_live_test.exs` | Modify | Test that archived sessions are hidden |
+
+## Gherkin Feature File
+
+Create `features/session_archiving.feature` with the scenarios from the implementation prompt (provided in the feature description).
+
+## Dependencies & Risks
+
+- **DB reset required** — early-stage app, so this is acceptable per project conventions
+- **Route ordering** — `/sessions/archived` must be defined before `/sessions/:id` to avoid Phoenix matching "archived" as a session ID
+- **No data loss risk** — archiving only sets a timestamp, all session data preserved

--- a/features/session_archiving.feature
+++ b/features/session_archiving.feature
@@ -1,0 +1,56 @@
+Feature: Session Archiving
+  Users can archive workflow sessions to hide them from the crafting board and
+  dashboard. Archived sessions are accessible from a dedicated archived sessions
+  page and can be restored.
+
+  Background:
+    Given I am logged in
+
+  # --- Archiving ---
+
+  Scenario: Archive a session from the session detail page
+    Given I am viewing a session titled "Fix login bug"
+    When I click the "Archive" button
+    Then I should see a flash message confirming the session was archived
+    And the button label should change to "Unarchive"
+
+  Scenario: Archived session is hidden from the crafting board
+    Given I have archived a session titled "Fix login bug"
+    When I navigate to the crafting board
+    Then I should not see the session "Fix login bug"
+
+  Scenario: Archived session is hidden from the dashboard
+    Given I have archived a session titled "Fix login bug"
+    When I navigate to the dashboard
+    Then I should not see the session "Fix login bug"
+
+  # --- Unarchiving ---
+
+  Scenario: Unarchive a session from the session detail page
+    Given I am viewing an archived session titled "Fix login bug"
+    And the button label shows "Unarchive"
+    When I click the "Unarchive" button
+    Then I should see a flash message confirming the session was restored
+    And the button label should change to "Archive"
+
+  Scenario: Restored session reappears on the crafting board
+    Given I have restored a previously archived session titled "Fix login bug"
+    When I navigate to the crafting board
+    Then I should see the session "Fix login bug"
+
+  # --- Archived Sessions Page ---
+
+  Scenario: View archived sessions on a dedicated page
+    Given I have archived sessions "Fix login bug" and "Refactor auth"
+    When I navigate to the archived sessions page
+    Then I should see "Fix login bug" and "Refactor auth" in the list
+
+  Scenario: Navigate to archived session detail from archived page
+    Given I am on the archived sessions page
+    When I click on the session "Fix login bug"
+    Then I should be navigated to the session detail page for "Fix login bug"
+
+  Scenario: Archived page is empty when no sessions are archived
+    Given no sessions are archived
+    When I navigate to the archived sessions page
+    Then I should see a message indicating there are no archived sessions

--- a/lib/destila/ai/session.ex
+++ b/lib/destila/ai/session.ex
@@ -113,6 +113,18 @@ defmodule Destila.AI.Session do
     GenServer.stop(session, :normal)
   end
 
+  @doc """
+  Stops the AI session for a workflow session, if one is running.
+  """
+  def stop_for_workflow_session(workflow_session_id) do
+    name = {:via, Registry, {Destila.AI.SessionRegistry, workflow_session_id}}
+
+    case GenServer.whereis(name) do
+      nil -> :ok
+      pid -> stop(pid)
+    end
+  end
+
   # Server callbacks
 
   @impl true

--- a/lib/destila/workflow_sessions.ex
+++ b/lib/destila/workflow_sessions.ex
@@ -5,7 +5,19 @@ defmodule Destila.WorkflowSessions do
   alias Destila.WorkflowSessions.WorkflowSession
 
   def list_workflow_sessions do
-    from(ws in WorkflowSession, order_by: ws.position)
+    from(ws in WorkflowSession,
+      where: is_nil(ws.archived_at),
+      order_by: ws.position
+    )
+    |> preload(:project)
+    |> Repo.all()
+  end
+
+  def list_archived_workflow_sessions do
+    from(ws in WorkflowSession,
+      where: not is_nil(ws.archived_at),
+      order_by: [desc: ws.archived_at]
+    )
     |> preload(:project)
     |> Repo.all()
   end
@@ -63,6 +75,29 @@ defmodule Destila.WorkflowSessions do
       )
     )
     |> Map.new()
+  end
+
+  def archive_workflow_session(%WorkflowSession{} = ws) do
+    Destila.AI.Session.stop_for_workflow_session(ws.id)
+
+    ws
+    |> WorkflowSession.changeset(%{archived_at: DateTime.utc_now()})
+    |> Repo.update()
+    |> broadcast(:workflow_session_updated)
+  end
+
+  def unarchive_workflow_session(%WorkflowSession{} = ws) do
+    # If the session was archived mid-generation, reset to :conversing
+    # so the user can retry instead of seeing a stuck typing indicator.
+    attrs =
+      if ws.phase_status == :generating,
+        do: %{archived_at: nil, phase_status: :conversing},
+        else: %{archived_at: nil}
+
+    ws
+    |> WorkflowSession.changeset(attrs)
+    |> Repo.update()
+    |> broadcast(:workflow_session_updated)
   end
 
   defdelegate broadcast(result, event), to: Destila.PubSubHelper

--- a/lib/destila/workflow_sessions/workflow_session.ex
+++ b/lib/destila/workflow_sessions/workflow_session.ex
@@ -24,6 +24,7 @@ defmodule Destila.WorkflowSessions.WorkflowSession do
     field(:ai_session_id, :string)
     field(:worktree_path, :string)
     field(:position, :integer)
+    field(:archived_at, :utc_datetime)
 
     belongs_to(:project, Destila.Projects.Project)
     has_many(:messages, Destila.Messages.Message)
@@ -44,7 +45,8 @@ defmodule Destila.WorkflowSessions.WorkflowSession do
       :title_generating,
       :ai_session_id,
       :worktree_path,
-      :position
+      :position,
+      :archived_at
     ])
     |> validate_required([:title, :workflow_type, :column])
   end

--- a/lib/destila_web/live/archived_sessions_live.ex
+++ b/lib/destila_web/live/archived_sessions_live.ex
@@ -1,0 +1,88 @@
+defmodule DestilaWeb.ArchivedSessionsLive do
+  use DestilaWeb, :live_view
+
+  import DestilaWeb.BoardComponents, only: [workflow_badge: 1, progress_indicator: 1]
+
+  def mount(_params, session, socket) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Destila.PubSub, "store:updates")
+    end
+
+    sessions = Destila.WorkflowSessions.list_archived_workflow_sessions()
+
+    {:ok,
+     socket
+     |> assign(:current_user, session["current_user"])
+     |> assign(:page_title, "Archived Sessions")
+     |> assign(:sessions, sessions)}
+  end
+
+  def handle_info({event, _data}, socket)
+      when event in [
+             :workflow_session_created,
+             :workflow_session_updated
+           ] do
+    sessions = Destila.WorkflowSessions.list_archived_workflow_sessions()
+    {:noreply, assign(socket, :sessions, sessions)}
+  end
+
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_user={@current_user} page_title={@page_title}>
+      <div class="p-6 lg:p-8">
+        <div class="flex items-center justify-between mb-6">
+          <h1 class="text-2xl font-bold tracking-tight">Archived Sessions</h1>
+          <.link
+            navigate={~p"/crafting"}
+            class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors flex items-center gap-1"
+          >
+            <.icon name="hero-arrow-left-micro" class="size-3.5" /> Back to Crafting Board
+          </.link>
+        </div>
+
+        <%= if @sessions == [] do %>
+          <div
+            id="archived-empty"
+            class="flex items-center justify-center gap-2 h-16 text-base-content/20 text-sm bg-base-200/20 rounded-xl border border-dashed border-base-300/50"
+          >
+            <.icon name="hero-archive-box-micro" class="size-4" /> No archived sessions
+          </div>
+        <% else %>
+          <div
+            id="archived-list"
+            class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3"
+          >
+            <.link
+              :for={ws <- @sessions}
+              navigate={~p"/sessions/#{ws.id}"}
+              id={"archived-session-#{ws.id}"}
+              class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow"
+            >
+              <div class="card-body p-4 gap-2">
+                <p class="text-sm font-medium leading-tight truncate">{ws.title}</p>
+                <div class="flex items-center justify-between gap-2">
+                  <div class="flex items-center gap-2">
+                    <.workflow_badge type={ws.workflow_type} />
+                    <span :if={ws.project} class="text-xs text-base-content/60 truncate max-w-[120px]">
+                      {ws.project.name}
+                    </span>
+                  </div>
+                  <span class="text-xs text-base-content/40 whitespace-nowrap">
+                    {ws.steps_completed}/{ws.steps_total}
+                  </span>
+                </div>
+                <.progress_indicator
+                  completed={ws.steps_completed}
+                  total={ws.steps_total}
+                />
+              </div>
+            </.link>
+          </div>
+        <% end %>
+      </div>
+    </Layouts.app>
+    """
+  end
+end

--- a/lib/destila_web/live/crafting_board_live.ex
+++ b/lib/destila_web/live/crafting_board_live.ex
@@ -190,9 +190,14 @@ defmodule DestilaWeb.CraftingBoardLive do
         <%!-- Header --%>
         <div class="flex items-center justify-between mb-4">
           <h1 class="text-2xl font-bold tracking-tight">Crafting Board</h1>
-          <.link navigate={~p"/sessions/new?from=/crafting"} class="btn btn-primary btn-sm">
-            <.icon name="hero-plus-micro" class="size-4" /> New Session
-          </.link>
+          <div class="flex items-center gap-3">
+            <.link navigate={~p"/sessions/archived"} class="btn btn-soft btn-sm">
+              <.icon name="hero-archive-box-micro" class="size-4" /> Archived
+            </.link>
+            <.link navigate={~p"/sessions/new?from=/crafting"} class="btn btn-primary btn-sm">
+              <.icon name="hero-plus-micro" class="size-4" /> New Session
+            </.link>
+          </div>
         </div>
 
         <%!-- View controls --%>

--- a/lib/destila_web/live/session_detail_live.ex
+++ b/lib/destila_web/live/session_detail_live.ex
@@ -159,6 +159,27 @@ defmodule DestilaWeb.SessionDetailLive do
     handle_static_response(socket, "Uploaded: mockup-screenshot.png", nil)
   end
 
+  # Archive / Unarchive
+  def handle_event("archive_session", _params, socket) do
+    {:ok, ws} =
+      Destila.WorkflowSessions.archive_workflow_session(socket.assigns.workflow_session)
+
+    {:noreply,
+     socket
+     |> assign(:workflow_session, ws)
+     |> put_flash(:info, "Session archived")}
+  end
+
+  def handle_event("unarchive_session", _params, socket) do
+    {:ok, ws} =
+      Destila.WorkflowSessions.unarchive_workflow_session(socket.assigns.workflow_session)
+
+    {:noreply,
+     socket
+     |> assign(:workflow_session, ws)
+     |> put_flash(:info, "Session restored")}
+  end
+
   # Title editing
   def handle_event("edit_title", _params, socket) do
     {:noreply, assign(socket, editing_title: true)}
@@ -634,6 +655,25 @@ defmodule DestilaWeb.SessionDetailLive do
                 class="btn btn-success btn-sm"
               >
                 <.icon name="hero-check-micro" class="size-4" /> Mark as Done
+              </button>
+
+              <%!-- Archive / Unarchive --%>
+              <button
+                :if={is_nil(@workflow_session.archived_at)}
+                phx-click="archive_session"
+                id="archive-btn"
+                class="btn btn-soft btn-sm"
+                data-confirm="Archive this session? It will be hidden from the crafting board."
+              >
+                <.icon name="hero-archive-box-micro" class="size-4" /> Archive
+              </button>
+              <button
+                :if={@workflow_session.archived_at}
+                phx-click="unarchive_session"
+                id="unarchive-btn"
+                class="btn btn-soft btn-sm"
+              >
+                <.icon name="hero-archive-box-arrow-down-micro" class="size-4" /> Unarchive
               </button>
             </div>
           </div>

--- a/lib/destila_web/router.ex
+++ b/lib/destila_web/router.ex
@@ -40,6 +40,7 @@ defmodule DestilaWeb.Router do
     live "/crafting", CraftingBoardLive
     live "/projects", ProjectsLive
     live "/sessions/new", NewSessionLive
+    live "/sessions/archived", ArchivedSessionsLive
     live "/sessions/:id", SessionDetailLive
   end
 end

--- a/priv/repo/migrations/20260324111938_create_projects_workflow_sessions_messages.exs
+++ b/priv/repo/migrations/20260324111938_create_projects_workflow_sessions_messages.exs
@@ -24,11 +24,13 @@ defmodule Destila.Repo.Migrations.CreateProjectsWorkflowSessionsMessages do
       add :ai_session_id, :string
       add :worktree_path, :string
       add :position, :integer, null: false
+      add :archived_at, :utc_datetime
 
       timestamps(type: :utc_datetime)
     end
 
     create index(:workflow_sessions, [:project_id])
+    create index(:workflow_sessions, [:archived_at])
 
     create table(:messages, primary_key: false) do
       add :id, :binary_id, primary_key: true

--- a/test/destila_web/live/archived_sessions_live_test.exs
+++ b/test/destila_web/live/archived_sessions_live_test.exs
@@ -1,0 +1,105 @@
+defmodule DestilaWeb.ArchivedSessionsLiveTest do
+  @moduledoc """
+  LiveView tests for the Archived Sessions page.
+  Feature: features/session_archiving.feature
+  """
+  use DestilaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  @feature "session_archiving"
+
+  setup %{conn: conn} do
+    conn = post(conn, "/login", %{"email" => "test@example.com"})
+
+    {:ok, project} =
+      Destila.Projects.create_project(%{
+        name: "destila",
+        git_repo_url: "https://github.com/test/destila"
+      })
+
+    {:ok, conn: conn, project: project}
+  end
+
+  defp create_session(attrs) do
+    defaults = %{
+      title: "Test Session",
+      workflow_type: :prompt_chore_task,
+      column: :request,
+      steps_completed: 1,
+      steps_total: 4,
+      position: System.unique_integer([:positive])
+    }
+
+    {:ok, session} = Destila.WorkflowSessions.create_workflow_session(Map.merge(defaults, attrs))
+    session
+  end
+
+  defp archive_session(session) do
+    {:ok, archived} = Destila.WorkflowSessions.archive_workflow_session(session)
+    archived
+  end
+
+  describe "archived sessions page" do
+    @tag feature: @feature, scenario: "View archived sessions on a dedicated page"
+    test "lists archived sessions with title, project, and workflow type", %{
+      conn: conn,
+      project: project
+    } do
+      ws1 = create_session(%{title: "Fix login bug", project_id: project.id})
+      ws2 = create_session(%{title: "Refactor auth", project_id: project.id})
+      archive_session(ws1)
+      archive_session(ws2)
+
+      {:ok, _view, html} = live(conn, ~p"/sessions/archived")
+
+      assert html =~ "Fix login bug"
+      assert html =~ "Refactor auth"
+      assert html =~ "destila"
+    end
+
+    @tag feature: @feature, scenario: "Archived page is empty when no sessions are archived"
+    test "shows empty state when no sessions are archived", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/sessions/archived")
+
+      assert has_element?(view, "#archived-empty")
+    end
+
+    @tag feature: @feature, scenario: "Navigate to archived session detail from archived page"
+    test "clicking a session navigates to detail page", %{conn: conn, project: project} do
+      ws = create_session(%{title: "Fix login bug", project_id: project.id})
+      archived = archive_session(ws)
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/archived")
+
+      assert has_element?(view, "a[href='/sessions/#{archived.id}']")
+    end
+
+    @tag feature: @feature, scenario: "View archived sessions on a dedicated page"
+    test "does not show non-archived sessions", %{conn: conn, project: project} do
+      _active = create_session(%{title: "Active Session", project_id: project.id})
+      archived = create_session(%{title: "Archived Session", project_id: project.id})
+      archive_session(archived)
+
+      {:ok, _view, html} = live(conn, ~p"/sessions/archived")
+
+      assert html =~ "Archived Session"
+      refute html =~ "Active Session"
+    end
+
+    @tag feature: @feature, scenario: "View archived sessions on a dedicated page"
+    test "updates in real time when a session is unarchived", %{conn: conn, project: project} do
+      ws = create_session(%{title: "Soon Restored", project_id: project.id})
+      archived = archive_session(ws)
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/archived")
+      assert has_element?(view, "#archived-session-#{archived.id}")
+
+      # Unarchive it
+      Destila.WorkflowSessions.unarchive_workflow_session(archived)
+
+      # Should disappear from the archived list
+      refute has_element?(view, "#archived-session-#{archived.id}")
+    end
+  end
+end

--- a/test/destila_web/live/session_archiving_live_test.exs
+++ b/test/destila_web/live/session_archiving_live_test.exs
@@ -1,0 +1,139 @@
+defmodule DestilaWeb.SessionArchivingLiveTest do
+  @moduledoc """
+  LiveView tests for archiving and unarchiving sessions from the detail page,
+  and verifying visibility on the crafting board and dashboard.
+  Feature: features/session_archiving.feature
+  """
+  use DestilaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  @feature "session_archiving"
+
+  setup %{conn: conn} do
+    conn = post(conn, "/login", %{"email" => "test@example.com"})
+
+    {:ok, project} =
+      Destila.Projects.create_project(%{
+        name: "destila",
+        git_repo_url: "https://github.com/test/destila"
+      })
+
+    {:ok, conn: conn, project: project}
+  end
+
+  defp create_session(attrs) do
+    defaults = %{
+      title: "Test Session",
+      workflow_type: :prompt_chore_task,
+      column: :request,
+      steps_completed: 1,
+      steps_total: 4,
+      phase_status: :conversing,
+      position: System.unique_integer([:positive])
+    }
+
+    {:ok, session} = Destila.WorkflowSessions.create_workflow_session(Map.merge(defaults, attrs))
+    session
+  end
+
+  # --- Archiving from session detail ---
+
+  describe "archive from session detail" do
+    @tag feature: @feature, scenario: "Archive a session from the session detail page"
+    test "shows Archive button and archives on click", %{conn: conn, project: project} do
+      ws = create_session(%{title: "Fix login bug", project_id: project.id})
+
+      # Add a message so mount doesn't try to start workflow
+      Destila.Messages.create_message(ws.id, %{
+        role: :system,
+        content: "Welcome",
+        phase: 1
+      })
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      # Archive button should be visible
+      assert has_element?(view, "#archive-btn")
+      refute has_element?(view, "#unarchive-btn")
+
+      # Click archive
+      view |> element("#archive-btn") |> render_click()
+
+      # Flash and button swap
+      assert has_element?(view, "#unarchive-btn")
+      refute has_element?(view, "#archive-btn")
+      assert render(view) =~ "Session archived"
+    end
+  end
+
+  # --- Unarchiving from session detail ---
+
+  describe "unarchive from session detail" do
+    @tag feature: @feature, scenario: "Unarchive a session from the session detail page"
+    test "shows Unarchive button and restores on click", %{conn: conn, project: project} do
+      ws = create_session(%{title: "Fix login bug", project_id: project.id})
+
+      Destila.Messages.create_message(ws.id, %{
+        role: :system,
+        content: "Welcome",
+        phase: 1
+      })
+
+      {:ok, archived} = Destila.WorkflowSessions.archive_workflow_session(ws)
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{archived.id}")
+
+      # Unarchive button should be visible
+      assert has_element?(view, "#unarchive-btn")
+      refute has_element?(view, "#archive-btn")
+
+      # Click unarchive
+      view |> element("#unarchive-btn") |> render_click()
+
+      # Flash and button swap
+      assert has_element?(view, "#archive-btn")
+      refute has_element?(view, "#unarchive-btn")
+      assert render(view) =~ "Session restored"
+    end
+  end
+
+  # --- Crafting board visibility ---
+
+  describe "crafting board visibility" do
+    @tag feature: @feature, scenario: "Archived session is hidden from the crafting board"
+    test "archived session is not shown on crafting board", %{conn: conn, project: project} do
+      ws = create_session(%{title: "Fix login bug", project_id: project.id})
+      Destila.WorkflowSessions.archive_workflow_session(ws)
+
+      {:ok, _view, html} = live(conn, ~p"/crafting")
+
+      refute html =~ "Fix login bug"
+    end
+
+    @tag feature: @feature, scenario: "Restored session reappears on the crafting board"
+    test "restored session reappears on crafting board", %{conn: conn, project: project} do
+      ws = create_session(%{title: "Fix login bug", project_id: project.id})
+      {:ok, archived} = Destila.WorkflowSessions.archive_workflow_session(ws)
+      Destila.WorkflowSessions.unarchive_workflow_session(archived)
+
+      {:ok, _view, html} = live(conn, ~p"/crafting")
+
+      assert html =~ "Fix login bug"
+    end
+  end
+
+  # --- Dashboard visibility ---
+
+  describe "dashboard visibility" do
+    @tag feature: @feature, scenario: "Archived session is hidden from the dashboard"
+    test "archived session is not shown on dashboard", %{conn: conn, project: project} do
+      ws = create_session(%{title: "Fix login bug", project_id: project.id})
+      Destila.WorkflowSessions.archive_workflow_session(ws)
+
+      {:ok, _view, html} = live(conn, ~p"/")
+
+      refute html =~ "Fix login bug"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add soft-delete archiving for workflow sessions via `archived_at` timestamp field
- Archived sessions are hidden from the crafting board and dashboard while preserving all data
- Dedicated archived sessions page at `/sessions/archived` reachable from the crafting board
- Archive/unarchive toggle button on the session detail page with flash confirmation
- AI GenServer stopped on archive, `phase_status` reset from `:generating` to `:conversing` on unarchive to prevent stuck UI state
- `stop_for_workflow_session/1` extracted into `AI.Session` module to avoid Registry name duplication
- Index added on `archived_at` column

## Test plan

- [x] 105 tests pass (`mix precommit` clean)
- [x] Archive button on session detail page sets `archived_at` and shows flash
- [x] Unarchive button clears `archived_at` and shows flash
- [x] Archived sessions hidden from crafting board (both list and workflow views)
- [x] Archived sessions hidden from dashboard
- [x] Archived sessions page lists archived sessions with title, project, workflow type
- [x] Empty state shown when no sessions are archived
- [x] PubSub updates reflect archive/unarchive in real time
- [x] Gherkin feature file with 8 scenarios, all linked to tests via `@tag`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>