### PR TITLE
feat: Add configurable ClaudeCode session options per workflow phase

### DIFF
--- a/docs/plans/2026-03-24-feat-configurable-session-options-per-workflow-phase-plan.md
+++ b/docs/plans/2026-03-24-feat-configurable-session-options-per-workflow-phase-plan.md
@@ -1,0 +1,356 @@
+---
+title: "feat: Configurable Claude Code Session Options per Workflow Phase"
+type: feat
+date: 2026-03-24
+---
+
+# feat: Configurable Claude Code Session Options per Workflow Phase
+
+## Overview
+
+Add a mechanism for workflow phase modules to define ClaudeCode session configuration on a per-phase basis. Currently all AI sessions start with a hardcoded restricted tool set (`Read`, `Grep`, `Glob`, limited `Bash`) and only the Destila MCP server. This change makes session configuration driven by the workflow phase module, enabling future workflows (e.g. code implementation) to opt into full Claude Code access with `dangerously_skip_permissions: true`.
+
+## Problem Statement / Motivation
+
+The existing system cannot support workflow types that need different levels of AI capability per phase. A future "implement" workflow needs full Claude Code access (file editing, arbitrary Bash, project MCP servers) while the current "chore task" workflow only needs read-only codebase access. The configuration is hardcoded in `Session.init/1` and cannot vary by workflow type or phase.
+
+## Proposed Solution
+
+Add a `session_strategy/1` callback to workflow phase modules that returns session lifecycle + configuration hints per phase. Wire this through the existing `SetupWorker`, `AiQueryWorker`, and `Setup` modules so session options are resolved from the workflow phase module rather than hardcoded.
+
+## Technical Approach
+
+### Step 1: Add `session_strategy/1` to `ChoreTaskPhases`
+
+**File:** `lib/destila/workflows/chore_task_phases.ex`
+
+Add a new function that returns the session strategy for each phase:
+
+```elixir
+@doc """
+Returns the session strategy for a given phase.
+
+Possible return values:
+  - `:resume` — continue the existing session (default behavior)
+  - `{:resume, claude_opts}` — continue with additional ClaudeCode options
+  - `:new` — start a fresh session with default options
+  - `{:new, claude_opts}` — start a fresh session with specific options
+"""
+def session_strategy(_phase), do: :resume
+```
+
+For `ChoreTaskPhases`, all phases return `:resume` — preserving current behavior exactly.
+
+### Step 2: Add dispatch in `Destila.Workflows`
+
+**File:** `lib/destila/workflows.ex`
+
+Add a dispatcher function that routes to the correct phase module based on `workflow_type`, following the existing pattern used by `phase_name/2`:
+
+```elixir
+def session_strategy(:prompt_chore_task, phase),
+  do: Destila.Workflows.ChoreTaskPhases.session_strategy(phase)
+
+# Default for non-AI workflow types
+def session_strategy(_type, _phase), do: :resume
+```
+
+### Step 3: Add `merge_phase_opts/2` to `Destila.AI.Session`
+
+**File:** `lib/destila/ai/session.ex`
+
+Add a helper function that merges phase-provided options with session defaults. The merge rules are:
+
+- **`mcp_servers`**: Map.merge — phase servers are added alongside the Destila MCP server (which is always injected via `put_new` in `init/1`)
+- **`allowed_tools`**: If the phase provides this key, it replaces the default entirely (callers wanting unrestricted access won't pass `allowed_tools` at all, so `put_new` in `init/1` will not apply the default)
+- **All other options**: Standard `Keyword.merge` (phase opts take precedence)
+
+```elixir
+@doc """
+Merges phase-provided ClaudeCode options with base session options.
+MCP servers are map-merged; all other options use standard keyword merge.
+"""
+def merge_phase_opts(base_opts, phase_opts) do
+  {phase_mcp, phase_rest} = Keyword.pop(phase_opts, :mcp_servers, %{})
+  {base_mcp, base_rest} = Keyword.pop(base_opts, :mcp_servers, %{})
+
+  merged = Keyword.merge(base_rest, phase_rest)
+
+  merged_mcp = Map.merge(base_mcp, phase_mcp)
+
+  if merged_mcp == %{} do
+    merged
+  else
+    Keyword.put(merged, :mcp_servers, merged_mcp)
+  end
+end
+```
+
+Note: `init/1` already uses `Keyword.put_new` for both `allowed_tools` and `mcp_servers`. If a phase passes these keys, `put_new` won't override them. If a phase uses `dangerously_skip_permissions: true` and doesn't pass `allowed_tools`, `put_new` will apply the default — which is fine because `dangerously_skip_permissions` bypasses tool restrictions regardless. However, to be clean, phases wanting unrestricted access should explicitly pass `allowed_tools: []` or omit it and let the default apply harmlessly.
+
+### Step 4: Update `SetupWorker.build_session_opts/1`
+
+**File:** `lib/destila/workers/setup_worker.ex`
+
+Update `build_session_opts/1` to resolve the session strategy from the workflow phase module and incorporate phase options:
+
+```elixir
+defp build_session_opts(workflow_session) do
+  strategy = Destila.Workflows.session_strategy(
+    workflow_session.workflow_type,
+    workflow_session.steps_completed
+  )
+
+  {action, phase_opts} = normalize_strategy(strategy)
+
+  opts = [timeout_ms: :timer.minutes(15)]
+
+  opts =
+    case action do
+      :resume ->
+        if workflow_session.ai_session_id do
+          Keyword.put(opts, :resume, workflow_session.ai_session_id)
+        else
+          opts
+        end
+
+      :new ->
+        # Don't pass :resume even if ai_session_id exists
+        opts
+    end
+
+  opts =
+    if workflow_session.worktree_path do
+      Keyword.put(opts, :cwd, workflow_session.worktree_path)
+    else
+      opts
+    end
+
+  Destila.AI.Session.merge_phase_opts(opts, phase_opts)
+end
+
+defp normalize_strategy(:resume), do: {:resume, []}
+defp normalize_strategy(:new), do: {:new, []}
+defp normalize_strategy({action, opts}) when action in [:resume, :new], do: {action, opts}
+```
+
+When `action` is `:new`, the existing session (if any) must be stopped first. Update `start_ai_session_and_trigger/1` to handle this:
+
+```elixir
+defp start_ai_session_and_trigger(workflow_session) do
+  broadcast_step(workflow_session.id, "ai_session", "in_progress", "Starting AI session...")
+
+  workflow_session = WorkflowSessions.get_workflow_session!(workflow_session.id)
+  {action, _} = normalize_strategy(
+    Destila.Workflows.session_strategy(
+      workflow_session.workflow_type,
+      workflow_session.steps_completed
+    )
+  )
+
+  # Stop existing session if strategy requires a new one
+  if action == :new do
+    Destila.AI.Session.stop_for_workflow_session(workflow_session.id)
+  end
+
+  session_opts = build_session_opts(workflow_session)
+  # ... rest unchanged
+end
+```
+
+### Step 5: Update `AiQueryWorker.build_session_opts/1`
+
+**File:** `lib/destila/workers/ai_query_worker.ex`
+
+Apply the same pattern. The worker receives `phase` in job args, so use that:
+
+```elixir
+defp build_session_opts(ws, phase) do
+  strategy = Destila.Workflows.session_strategy(ws.workflow_type, phase)
+  {action, phase_opts} = normalize_strategy(strategy)
+
+  opts = []
+
+  opts =
+    case action do
+      :resume ->
+        if ws.ai_session_id,
+          do: Keyword.put(opts, :resume, ws.ai_session_id),
+          else: opts
+
+      :new ->
+        opts
+    end
+
+  opts =
+    if ws.worktree_path,
+      do: Keyword.put(opts, :cwd, ws.worktree_path),
+      else: opts
+
+  Destila.AI.Session.merge_phase_opts(opts, phase_opts)
+end
+
+defp normalize_strategy(:resume), do: {:resume, []}
+defp normalize_strategy(:new), do: {:new, []}
+defp normalize_strategy({action, opts}) when action in [:resume, :new], do: {action, opts}
+```
+
+Update `perform/1` to handle `:new` strategy by stopping the existing session before creating a new one:
+
+```elixir
+def perform(%Oban.Job{args: %{...} = args}) do
+  ws = WorkflowSessions.get_workflow_session!(workflow_session_id)
+  strategy = Destila.Workflows.session_strategy(ws.workflow_type, phase)
+  {action, _} = normalize_strategy(strategy)
+
+  if action == :new do
+    Destila.AI.Session.stop_for_workflow_session(workflow_session_id)
+  end
+
+  session_opts = build_session_opts(ws, phase)
+  # ... rest unchanged, using session_opts
+end
+```
+
+Also update `handle_skip_phase/2` to use the dispatcher instead of hardcoding `ChoreTaskPhases`:
+
+```elixir
+defp handle_skip_phase(workflow_session_id, current_phase) do
+  next_phase = current_phase + 1
+
+  WorkflowSessions.update_workflow_session(workflow_session_id, %{
+    steps_completed: next_phase,
+    phase_status: :generating
+  })
+
+  workflow_session = WorkflowSessions.get_workflow_session!(workflow_session_id)
+
+  # Dispatch through Workflows module instead of hardcoding ChoreTaskPhases
+  phases_module = Destila.Workflows.phases_module(workflow_session.workflow_type)
+  phase_prompt = phases_module.system_prompt(next_phase, workflow_session)
+
+  # ... enqueue next job
+end
+```
+
+### Step 6: Update `Destila.Setup.trigger_phase1/1`
+
+**File:** `lib/destila/setup.ex`
+
+Replace the hardcoded `ChoreTaskPhases` reference with dispatcher:
+
+```elixir
+defp trigger_phase1(workflow_session) do
+  phase = 1
+
+  messages =
+    Messages.list_messages(workflow_session.id)
+    |> Enum.filter(&(&1.phase > 0))
+
+  phases_module = Destila.Workflows.phases_module(workflow_session.workflow_type)
+  system_prompt = phases_module.system_prompt(phase, workflow_session)
+  context = phases_module.build_conversation_context(messages)
+  query = system_prompt <> "\n\n" <> context
+
+  # ... rest unchanged
+end
+```
+
+### Step 7: Add `phases_module/1` to `Destila.Workflows`
+
+**File:** `lib/destila/workflows.ex`
+
+Add a dispatcher that maps workflow_type to the phases module:
+
+```elixir
+@doc """
+Returns the phases module for a given workflow type.
+"""
+def phases_module(:prompt_chore_task), do: Destila.Workflows.ChoreTaskPhases
+def phases_module(_type), do: nil
+```
+
+This is used by `Setup.trigger_phase1` and `AiQueryWorker.handle_skip_phase` to resolve system prompts and conversation context builders without hardcoding the module.
+
+### Step 8: Extract `normalize_strategy/1` to shared location
+
+Both `SetupWorker` and `AiQueryWorker` need `normalize_strategy/1`. Rather than duplicating it, add it to `Destila.Workflows`:
+
+```elixir
+@doc """
+Normalizes a session strategy to `{action, opts}` tuple form.
+"""
+def normalize_strategy(:resume), do: {:resume, []}
+def normalize_strategy(:new), do: {:new, []}
+def normalize_strategy({action, opts}) when action in [:resume, :new], do: {action, opts}
+```
+
+## Acceptance Criteria
+
+- [x] `ChoreTaskPhases.session_strategy/1` exists and returns `:resume` for all phases
+- [x] `Destila.Workflows.session_strategy/2` dispatches to the correct phases module
+- [x] `Destila.Workflows.phases_module/1` returns the correct module for each workflow type
+- [x] `Destila.Workflows.normalize_strategy/1` normalizes all strategy forms
+- [x] `Session.merge_phase_opts/2` correctly merges MCP servers and other options
+- [x] `SetupWorker.build_session_opts/1` resolves strategy from the workflow phase module
+- [x] `AiQueryWorker.build_session_opts/2` resolves strategy from the workflow phase module (now takes `phase` arg)
+- [x] `AiQueryWorker.handle_skip_phase/2` uses `Workflows.phases_module/1` instead of hardcoded `ChoreTaskPhases`
+- [x] `Setup.trigger_phase1/1` uses `Workflows.phases_module/1` instead of hardcoded `ChoreTaskPhases`
+- [x] Existing `ChoreTaskPhases` workflow behavior is unchanged (all phases resume, same tools, same MCP)
+- [x] When strategy is `:new`, existing session is stopped before starting a fresh one
+- [x] Destila MCP server (`"destila" => Destila.AI.Tools`) is always present regardless of phase options (guaranteed by `put_new` in `Session.init/1`)
+
+## SDK Options Reference
+
+From `ClaudeCode.Options` (v0.32.2), key options for future workflow phases:
+
+| Option | Type | Purpose |
+|--------|------|---------|
+| `dangerously_skip_permissions` | boolean | Bypass all permission checks |
+| `mcp_servers` | map | MCP server configs (merged with Destila MCP) |
+| `strict_mcp_config` | boolean | Only use explicit MCP servers, ignore global |
+| `setting_sources` | list | Which settings to load (`["project"]` for project-only) |
+| `allowed_tools` | list | Tool restrictions (omit for unrestricted) |
+| `cwd` | string | Working directory (already wired) |
+| `resume` | string | Session ID to resume (already wired) |
+
+## Dependencies & Risks
+
+**Low risk.** This is additive wiring with no behavioral change for the existing workflow.
+
+- `ChoreTaskPhases` returns `:resume` for all phases — identical to current behavior
+- `Session.init/1` already supports override via `put_new` semantics — no changes needed there
+- `normalize_strategy/1` is trivial pattern matching
+- `merge_phase_opts/2` only applies when phase opts are non-empty
+
+**One subtle risk:** `AiQueryWorker` currently doesn't pass `timeout_ms`, so recreated sessions get the 5-min default instead of SetupWorker's 15-min. This is a pre-existing inconsistency, not introduced by this change, but worth noting for future work.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `lib/destila/workflows/chore_task_phases.ex` | Add `session_strategy/1` |
+| `lib/destila/workflows.ex` | Add `session_strategy/2`, `phases_module/1`, `normalize_strategy/1` |
+| `lib/destila/ai/session.ex` | Add `merge_phase_opts/2` |
+| `lib/destila/workers/setup_worker.ex` | Update `build_session_opts/1`, `start_ai_session_and_trigger/1` |
+| `lib/destila/workers/ai_query_worker.ex` | Update `build_session_opts` (add phase arg), `perform/1`, `handle_skip_phase/2` |
+| `lib/destila/setup.ex` | Replace hardcoded `ChoreTaskPhases` with `Workflows.phases_module/1` |
+
+## References
+
+### Internal
+
+- `lib/destila/ai/session.ex:10-18` — Current default allowed tools and MCP server
+- `lib/destila/ai/session.ex:131-152` — `init/1` with `put_new` semantics
+- `lib/destila/workers/setup_worker.ex:117-132` — Current `build_session_opts/1`
+- `lib/destila/workers/ai_query_worker.ex:80-91` — Current `build_session_opts/1`
+- `lib/destila/workers/ai_query_worker.ex:93-111` — `handle_skip_phase/2` hardcoded to `ChoreTaskPhases`
+- `lib/destila/setup.ex:69-88` — `trigger_phase1/1` hardcoded to `ChoreTaskPhases`
+- `lib/destila/workflows.ex:80-81` — Existing dispatch pattern for `phase_name/2`
+- `deps/claude_code/lib/claude_code/options.ex:600-611` — `dangerously_skip_permissions` option
+- `deps/claude_code/lib/claude_code/options.ex:557-566` — `mcp_servers` and `strict_mcp_config` options
+
+### Prior Plans
+
+- `docs/plans/2026-03-20-feat-chore-task-workflow-plan.md` — Original AI-driven phase system design
+- `docs/plans/2026-03-22-feat-phase-zero-setup-worktree-plan.md` — Phase 0 background job architecture

--- a/lib/destila/ai/session.ex
+++ b/lib/destila/ai/session.ex
@@ -126,6 +126,37 @@ defmodule Destila.AI.Session do
   end
 
   @doc """
+  Builds ClaudeCode session options for a workflow session and phase.
+
+  Resolves the session strategy from the workflow module, adds `:resume`
+  and `:cwd` from the workflow session, and merges any phase-provided options.
+
+  Additional base options (e.g. `timeout_ms`) can be passed and will be included.
+  """
+  def session_opts_for_workflow(workflow_session, phase, base_opts \\ []) do
+    {_action, phase_opts} =
+      Destila.Workflows.session_strategy(workflow_session.workflow_type, phase)
+
+    opts = base_opts
+
+    opts =
+      if workflow_session.ai_session_id do
+        Keyword.put(opts, :resume, workflow_session.ai_session_id)
+      else
+        opts
+      end
+
+    opts =
+      if workflow_session.worktree_path do
+        Keyword.put(opts, :cwd, workflow_session.worktree_path)
+      else
+        opts
+      end
+
+    merge_phase_opts(opts, phase_opts)
+  end
+
+  @doc """
   Merges phase-provided ClaudeCode options with base session options.
   MCP servers are map-merged; all other options use standard keyword merge.
   """

--- a/lib/destila/ai/session.ex
+++ b/lib/destila/ai/session.ex
@@ -125,6 +125,25 @@ defmodule Destila.AI.Session do
     end
   end
 
+  @doc """
+  Merges phase-provided ClaudeCode options with base session options.
+  MCP servers are map-merged; all other options use standard keyword merge.
+  """
+  def merge_phase_opts(base_opts, phase_opts) do
+    {phase_mcp, phase_rest} = Keyword.pop(phase_opts, :mcp_servers, %{})
+    {base_mcp, base_rest} = Keyword.pop(base_opts, :mcp_servers, %{})
+
+    merged = Keyword.merge(base_rest, phase_rest)
+
+    merged_mcp = Map.merge(base_mcp, phase_mcp)
+
+    if merged_mcp == %{} do
+      merged
+    else
+      Keyword.put(merged, :mcp_servers, merged_mcp)
+    end
+  end
+
   # Server callbacks
 
   @impl true

--- a/lib/destila/messages.ex
+++ b/lib/destila/messages.ex
@@ -100,6 +100,9 @@ defmodule Destila.Messages do
   # Returns {cleaned_content, message_type}.
   defp parse_markers(text, phase, workflow_session) do
     cond do
+      phase == workflow_session.steps_total ->
+        {String.trim(text), :generated_prompt}
+
       String.contains?(text, "<<SKIP_PHASE>>") ->
         content = String.replace(text, "<<SKIP_PHASE>>", "") |> String.trim()
         content = if content == "", do: "Skipping this phase.", else: content
@@ -109,9 +112,6 @@ defmodule Destila.Messages do
         content = String.replace(text, "<<READY_TO_ADVANCE>>", "") |> String.trim()
         content = if content == "", do: "Ready to move to the next phase.", else: content
         {content, :phase_advance}
-
-      phase == workflow_session.steps_total ->
-        {String.trim(text), :generated_prompt}
 
       true ->
         {String.trim(text), nil}

--- a/lib/destila/setup.ex
+++ b/lib/destila/setup.ex
@@ -11,7 +11,6 @@ defmodule Destila.Setup do
 
   alias Destila.{Messages, Repo}
   alias Destila.WorkflowSessions.WorkflowSession
-  alias Destila.Workflows.ChoreTaskPhases
 
   @doc """
   Checks if Phase 0 setup is fully complete (both title generation and setup steps)
@@ -74,8 +73,9 @@ defmodule Destila.Setup do
       Messages.list_messages(workflow_session.id)
       |> Enum.filter(&(&1.phase > 0))
 
-    system_prompt = ChoreTaskPhases.system_prompt(phase, workflow_session)
-    context = ChoreTaskPhases.build_conversation_context(messages)
+    phases_module = Destila.Workflows.phases_module(workflow_session.workflow_type)
+    system_prompt = phases_module.system_prompt(phase, workflow_session)
+    context = phases_module.build_conversation_context(messages)
     query = system_prompt <> "\n\n" <> context
 
     # Broadcast the update so LiveView picks up the :generating status

--- a/lib/destila/setup.ex
+++ b/lib/destila/setup.ex
@@ -73,9 +73,9 @@ defmodule Destila.Setup do
       Messages.list_messages(workflow_session.id)
       |> Enum.filter(&(&1.phase > 0))
 
-    phases_module = Destila.Workflows.phases_module(workflow_session.workflow_type)
-    system_prompt = phases_module.system_prompt(phase, workflow_session)
-    context = phases_module.build_conversation_context(messages)
+    workflow_module = Destila.Workflows.workflow_module(workflow_session.workflow_type)
+    system_prompt = workflow_module.system_prompt(phase, workflow_session)
+    context = workflow_module.build_conversation_context(messages)
     query = system_prompt <> "\n\n" <> context
 
     # Broadcast the update so LiveView picks up the :generating status

--- a/lib/destila/workers/ai_query_worker.ex
+++ b/lib/destila/workers/ai_query_worker.ex
@@ -13,13 +13,14 @@ defmodule Destila.Workers.AiQueryWorker do
       }) do
     ws = WorkflowSessions.get_workflow_session!(workflow_session_id)
 
-    {action, _} = Destila.Workflows.session_strategy(ws.workflow_type, phase)
+    {action, _phase_opts} =
+      strategy = Destila.Workflows.session_strategy(ws.workflow_type, phase)
 
     if action == :new do
       Destila.AI.Session.stop_for_workflow_session(workflow_session_id)
     end
 
-    session_opts = build_session_opts(ws, phase)
+    session_opts = build_session_opts(ws, strategy)
 
     case Destila.AI.Session.for_workflow_session(workflow_session_id, session_opts) do
       {:ok, session} ->
@@ -83,9 +84,7 @@ defmodule Destila.Workers.AiQueryWorker do
     end
   end
 
-  defp build_session_opts(ws, phase) do
-    {action, phase_opts} = Destila.Workflows.session_strategy(ws.workflow_type, phase)
-
+  defp build_session_opts(ws, {action, phase_opts}) do
     opts = []
 
     opts =

--- a/lib/destila/workers/ai_query_worker.ex
+++ b/lib/destila/workers/ai_query_worker.ex
@@ -120,8 +120,8 @@ defmodule Destila.Workers.AiQueryWorker do
     })
 
     workflow_session = WorkflowSessions.get_workflow_session!(workflow_session_id)
-    phases_module = Destila.Workflows.phases_module(workflow_session.workflow_type)
-    phase_prompt = phases_module.system_prompt(next_phase, workflow_session)
+    workflow_module = Destila.Workflows.workflow_module(workflow_session.workflow_type)
+    phase_prompt = workflow_module.system_prompt(next_phase, workflow_session)
 
     %{
       "workflow_session_id" => workflow_session_id,

--- a/lib/destila/workers/ai_query_worker.ex
+++ b/lib/destila/workers/ai_query_worker.ex
@@ -2,7 +2,6 @@ defmodule Destila.Workers.AiQueryWorker do
   use Oban.Worker, queue: :default, max_attempts: 1
 
   alias Destila.{Messages, WorkflowSessions}
-  alias Destila.Workflows.ChoreTaskPhases
 
   @impl Oban.Worker
   def perform(%Oban.Job{
@@ -13,7 +12,17 @@ defmodule Destila.Workers.AiQueryWorker do
         }
       }) do
     ws = WorkflowSessions.get_workflow_session!(workflow_session_id)
-    session_opts = build_session_opts(ws)
+
+    {action, _} =
+      Destila.Workflows.normalize_strategy(
+        Destila.Workflows.session_strategy(ws.workflow_type, phase)
+      )
+
+    if action == :new do
+      Destila.AI.Session.stop_for_workflow_session(workflow_session_id)
+    end
+
+    session_opts = build_session_opts(ws, phase)
 
     case Destila.AI.Session.for_workflow_session(workflow_session_id, session_opts) do
       {:ok, session} ->
@@ -77,17 +86,29 @@ defmodule Destila.Workers.AiQueryWorker do
     end
   end
 
-  defp build_session_opts(ws) do
+  defp build_session_opts(ws, phase) do
+    strategy = Destila.Workflows.session_strategy(ws.workflow_type, phase)
+    {action, phase_opts} = Destila.Workflows.normalize_strategy(strategy)
+
     opts = []
 
     opts =
-      if ws.ai_session_id,
-        do: Keyword.put(opts, :resume, ws.ai_session_id),
+      case action do
+        :resume ->
+          if ws.ai_session_id,
+            do: Keyword.put(opts, :resume, ws.ai_session_id),
+            else: opts
+
+        :new ->
+          opts
+      end
+
+    opts =
+      if ws.worktree_path,
+        do: Keyword.put(opts, :cwd, ws.worktree_path),
         else: opts
 
-    if ws.worktree_path,
-      do: Keyword.put(opts, :cwd, ws.worktree_path),
-      else: opts
+    Destila.AI.Session.merge_phase_opts(opts, phase_opts)
   end
 
   defp handle_skip_phase(workflow_session_id, current_phase) do
@@ -99,7 +120,8 @@ defmodule Destila.Workers.AiQueryWorker do
     })
 
     workflow_session = WorkflowSessions.get_workflow_session!(workflow_session_id)
-    phase_prompt = ChoreTaskPhases.system_prompt(next_phase, workflow_session)
+    phases_module = Destila.Workflows.phases_module(workflow_session.workflow_type)
+    phase_prompt = phases_module.system_prompt(next_phase, workflow_session)
 
     %{
       "workflow_session_id" => workflow_session_id,

--- a/lib/destila/workers/ai_query_worker.ex
+++ b/lib/destila/workers/ai_query_worker.ex
@@ -13,10 +13,7 @@ defmodule Destila.Workers.AiQueryWorker do
       }) do
     ws = WorkflowSessions.get_workflow_session!(workflow_session_id)
 
-    {action, _} =
-      Destila.Workflows.normalize_strategy(
-        Destila.Workflows.session_strategy(ws.workflow_type, phase)
-      )
+    {action, _} = Destila.Workflows.session_strategy(ws.workflow_type, phase)
 
     if action == :new do
       Destila.AI.Session.stop_for_workflow_session(workflow_session_id)
@@ -87,8 +84,7 @@ defmodule Destila.Workers.AiQueryWorker do
   end
 
   defp build_session_opts(ws, phase) do
-    strategy = Destila.Workflows.session_strategy(ws.workflow_type, phase)
-    {action, phase_opts} = Destila.Workflows.normalize_strategy(strategy)
+    {action, phase_opts} = Destila.Workflows.session_strategy(ws.workflow_type, phase)
 
     opts = []
 

--- a/lib/destila/workers/ai_query_worker.ex
+++ b/lib/destila/workers/ai_query_worker.ex
@@ -12,8 +12,7 @@ defmodule Destila.Workers.AiQueryWorker do
         }
       }) do
     ws = WorkflowSessions.get_workflow_session!(workflow_session_id)
-    {_action, phase_opts} = Destila.Workflows.session_strategy(ws.workflow_type, phase)
-    session_opts = build_session_opts(ws, phase_opts)
+    session_opts = Destila.AI.Session.session_opts_for_workflow(ws, phase)
 
     case Destila.AI.Session.for_workflow_session(workflow_session_id, session_opts) do
       {:ok, session} ->
@@ -75,13 +74,6 @@ defmodule Destila.Workers.AiQueryWorker do
 
         :ok
     end
-  end
-
-  defp build_session_opts(ws, phase_opts) do
-    opts = []
-    opts = if ws.ai_session_id, do: Keyword.put(opts, :resume, ws.ai_session_id), else: opts
-    opts = if ws.worktree_path, do: Keyword.put(opts, :cwd, ws.worktree_path), else: opts
-    Destila.AI.Session.merge_phase_opts(opts, phase_opts)
   end
 
   defp handle_skip_phase(workflow_session_id, current_phase) do

--- a/lib/destila/workers/ai_query_worker.ex
+++ b/lib/destila/workers/ai_query_worker.ex
@@ -87,31 +87,39 @@ defmodule Destila.Workers.AiQueryWorker do
   defp handle_skip_phase(workflow_session_id, current_phase) do
     next_phase = current_phase + 1
     workflow_session = WorkflowSessions.get_workflow_session!(workflow_session_id)
+    total = Destila.Workflows.total_steps(workflow_session.workflow_type)
 
-    {action, _} =
-      Destila.Workflows.session_strategy(workflow_session.workflow_type, next_phase)
+    if next_phase > total do
+      # Can't skip past the last phase — ignore the marker
+      WorkflowSessions.update_workflow_session(workflow_session_id, %{
+        phase_status: :conversing
+      })
+    else
+      {action, _} =
+        Destila.Workflows.session_strategy(workflow_session.workflow_type, next_phase)
 
-    update_attrs = %{steps_completed: next_phase, phase_status: :generating}
+      update_attrs = %{steps_completed: next_phase, phase_status: :generating}
 
-    update_attrs =
-      if action == :new do
-        Destila.AI.Session.stop_for_workflow_session(workflow_session_id)
-        Map.put(update_attrs, :ai_session_id, nil)
-      else
-        update_attrs
-      end
+      update_attrs =
+        if action == :new do
+          Destila.AI.Session.stop_for_workflow_session(workflow_session_id)
+          Map.put(update_attrs, :ai_session_id, nil)
+        else
+          update_attrs
+        end
 
-    WorkflowSessions.update_workflow_session(workflow_session_id, update_attrs)
-    workflow_session = WorkflowSessions.get_workflow_session!(workflow_session_id)
-    workflow_module = Destila.Workflows.workflow_module(workflow_session.workflow_type)
-    phase_prompt = workflow_module.system_prompt(next_phase, workflow_session)
+      WorkflowSessions.update_workflow_session(workflow_session_id, update_attrs)
+      workflow_session = WorkflowSessions.get_workflow_session!(workflow_session_id)
+      workflow_module = Destila.Workflows.workflow_module(workflow_session.workflow_type)
+      phase_prompt = workflow_module.system_prompt(next_phase, workflow_session)
 
-    %{
-      "workflow_session_id" => workflow_session_id,
-      "phase" => next_phase,
-      "query" => phase_prompt
-    }
-    |> __MODULE__.new()
-    |> Oban.insert()
+      %{
+        "workflow_session_id" => workflow_session_id,
+        "phase" => next_phase,
+        "query" => phase_prompt
+      }
+      |> __MODULE__.new()
+      |> Oban.insert()
+    end
   end
 end

--- a/lib/destila/workers/ai_query_worker.ex
+++ b/lib/destila/workers/ai_query_worker.ex
@@ -12,15 +12,8 @@ defmodule Destila.Workers.AiQueryWorker do
         }
       }) do
     ws = WorkflowSessions.get_workflow_session!(workflow_session_id)
-
-    {action, _phase_opts} =
-      strategy = Destila.Workflows.session_strategy(ws.workflow_type, phase)
-
-    if action == :new do
-      Destila.AI.Session.stop_for_workflow_session(workflow_session_id)
-    end
-
-    session_opts = build_session_opts(ws, strategy)
+    {_action, phase_opts} = Destila.Workflows.session_strategy(ws.workflow_type, phase)
+    session_opts = build_session_opts(ws, phase_opts)
 
     case Destila.AI.Session.for_workflow_session(workflow_session_id, session_opts) do
       {:ok, session} ->
@@ -84,36 +77,31 @@ defmodule Destila.Workers.AiQueryWorker do
     end
   end
 
-  defp build_session_opts(ws, {action, phase_opts}) do
+  defp build_session_opts(ws, phase_opts) do
     opts = []
-
-    opts =
-      case action do
-        :resume ->
-          if ws.ai_session_id,
-            do: Keyword.put(opts, :resume, ws.ai_session_id),
-            else: opts
-
-        :new ->
-          opts
-      end
-
-    opts =
-      if ws.worktree_path,
-        do: Keyword.put(opts, :cwd, ws.worktree_path),
-        else: opts
-
+    opts = if ws.ai_session_id, do: Keyword.put(opts, :resume, ws.ai_session_id), else: opts
+    opts = if ws.worktree_path, do: Keyword.put(opts, :cwd, ws.worktree_path), else: opts
     Destila.AI.Session.merge_phase_opts(opts, phase_opts)
   end
 
   defp handle_skip_phase(workflow_session_id, current_phase) do
     next_phase = current_phase + 1
+    workflow_session = WorkflowSessions.get_workflow_session!(workflow_session_id)
 
-    WorkflowSessions.update_workflow_session(workflow_session_id, %{
-      steps_completed: next_phase,
-      phase_status: :generating
-    })
+    {action, _} =
+      Destila.Workflows.session_strategy(workflow_session.workflow_type, next_phase)
 
+    update_attrs = %{steps_completed: next_phase, phase_status: :generating}
+
+    update_attrs =
+      if action == :new do
+        Destila.AI.Session.stop_for_workflow_session(workflow_session_id)
+        Map.put(update_attrs, :ai_session_id, nil)
+      else
+        update_attrs
+      end
+
+    WorkflowSessions.update_workflow_session(workflow_session_id, update_attrs)
     workflow_session = WorkflowSessions.get_workflow_session!(workflow_session_id)
     workflow_module = Destila.Workflows.workflow_module(workflow_session.workflow_type)
     phase_prompt = workflow_module.system_prompt(next_phase, workflow_session)

--- a/lib/destila/workers/setup_worker.ex
+++ b/lib/destila/workers/setup_worker.ex
@@ -100,6 +100,19 @@ defmodule Destila.Workers.SetupWorker do
     broadcast_step(workflow_session.id, "ai_session", "in_progress", "Starting AI session...")
 
     workflow_session = WorkflowSessions.get_workflow_session!(workflow_session.id)
+
+    {action, _} =
+      Destila.Workflows.normalize_strategy(
+        Destila.Workflows.session_strategy(
+          workflow_session.workflow_type,
+          workflow_session.steps_completed
+        )
+      )
+
+    if action == :new do
+      Destila.AI.Session.stop_for_workflow_session(workflow_session.id)
+    end
+
     session_opts = build_session_opts(workflow_session)
 
     case Destila.AI.Session.for_workflow_session(workflow_session.id, session_opts) do
@@ -116,20 +129,37 @@ defmodule Destila.Workers.SetupWorker do
   end
 
   defp build_session_opts(workflow_session) do
+    strategy =
+      Destila.Workflows.session_strategy(
+        workflow_session.workflow_type,
+        workflow_session.steps_completed
+      )
+
+    {action, phase_opts} = Destila.Workflows.normalize_strategy(strategy)
+
     opts = [timeout_ms: :timer.minutes(15)]
 
     opts =
-      if workflow_session.ai_session_id do
-        Keyword.put(opts, :resume, workflow_session.ai_session_id)
+      case action do
+        :resume ->
+          if workflow_session.ai_session_id do
+            Keyword.put(opts, :resume, workflow_session.ai_session_id)
+          else
+            opts
+          end
+
+        :new ->
+          opts
+      end
+
+    opts =
+      if workflow_session.worktree_path do
+        Keyword.put(opts, :cwd, workflow_session.worktree_path)
       else
         opts
       end
 
-    if workflow_session.worktree_path do
-      Keyword.put(opts, :cwd, workflow_session.worktree_path)
-    else
-      opts
-    end
+    Destila.AI.Session.merge_phase_opts(opts, phase_opts)
   end
 
   defp broadcast_step(workflow_session_id, step, status, content) do

--- a/lib/destila/workers/setup_worker.ex
+++ b/lib/destila/workers/setup_worker.ex
@@ -101,13 +101,12 @@ defmodule Destila.Workers.SetupWorker do
 
     workflow_session = WorkflowSessions.get_workflow_session!(workflow_session.id)
 
-    {_action, phase_opts} =
-      Destila.Workflows.session_strategy(
-        workflow_session.workflow_type,
-        workflow_session.steps_completed
+    session_opts =
+      Destila.AI.Session.session_opts_for_workflow(
+        workflow_session,
+        workflow_session.steps_completed,
+        timeout_ms: :timer.minutes(15)
       )
-
-    session_opts = build_session_opts(workflow_session, phase_opts)
 
     case Destila.AI.Session.for_workflow_session(workflow_session.id, session_opts) do
       {:ok, _session} ->
@@ -120,26 +119,6 @@ defmodule Destila.Workers.SetupWorker do
         broadcast_step(workflow_session.id, "ai_session", "failed", inspect(reason))
         {:error, reason}
     end
-  end
-
-  defp build_session_opts(workflow_session, phase_opts) do
-    opts = [timeout_ms: :timer.minutes(15)]
-
-    opts =
-      if workflow_session.ai_session_id do
-        Keyword.put(opts, :resume, workflow_session.ai_session_id)
-      else
-        opts
-      end
-
-    opts =
-      if workflow_session.worktree_path do
-        Keyword.put(opts, :cwd, workflow_session.worktree_path)
-      else
-        opts
-      end
-
-    Destila.AI.Session.merge_phase_opts(opts, phase_opts)
   end
 
   defp broadcast_step(workflow_session_id, step, status, content) do

--- a/lib/destila/workers/setup_worker.ex
+++ b/lib/destila/workers/setup_worker.ex
@@ -102,11 +102,9 @@ defmodule Destila.Workers.SetupWorker do
     workflow_session = WorkflowSessions.get_workflow_session!(workflow_session.id)
 
     {action, _} =
-      Destila.Workflows.normalize_strategy(
-        Destila.Workflows.session_strategy(
-          workflow_session.workflow_type,
-          workflow_session.steps_completed
-        )
+      Destila.Workflows.session_strategy(
+        workflow_session.workflow_type,
+        workflow_session.steps_completed
       )
 
     if action == :new do
@@ -129,13 +127,11 @@ defmodule Destila.Workers.SetupWorker do
   end
 
   defp build_session_opts(workflow_session) do
-    strategy =
+    {action, phase_opts} =
       Destila.Workflows.session_strategy(
         workflow_session.workflow_type,
         workflow_session.steps_completed
       )
-
-    {action, phase_opts} = Destila.Workflows.normalize_strategy(strategy)
 
     opts = [timeout_ms: :timer.minutes(15)]
 

--- a/lib/destila/workers/setup_worker.ex
+++ b/lib/destila/workers/setup_worker.ex
@@ -101,7 +101,8 @@ defmodule Destila.Workers.SetupWorker do
 
     workflow_session = WorkflowSessions.get_workflow_session!(workflow_session.id)
 
-    {action, _} =
+    {action, _phase_opts} =
+      strategy =
       Destila.Workflows.session_strategy(
         workflow_session.workflow_type,
         workflow_session.steps_completed
@@ -111,7 +112,7 @@ defmodule Destila.Workers.SetupWorker do
       Destila.AI.Session.stop_for_workflow_session(workflow_session.id)
     end
 
-    session_opts = build_session_opts(workflow_session)
+    session_opts = build_session_opts(workflow_session, strategy)
 
     case Destila.AI.Session.for_workflow_session(workflow_session.id, session_opts) do
       {:ok, _session} ->
@@ -126,13 +127,7 @@ defmodule Destila.Workers.SetupWorker do
     end
   end
 
-  defp build_session_opts(workflow_session) do
-    {action, phase_opts} =
-      Destila.Workflows.session_strategy(
-        workflow_session.workflow_type,
-        workflow_session.steps_completed
-      )
-
+  defp build_session_opts(workflow_session, {action, phase_opts}) do
     opts = [timeout_ms: :timer.minutes(15)]
 
     opts =

--- a/lib/destila/workers/setup_worker.ex
+++ b/lib/destila/workers/setup_worker.ex
@@ -101,18 +101,13 @@ defmodule Destila.Workers.SetupWorker do
 
     workflow_session = WorkflowSessions.get_workflow_session!(workflow_session.id)
 
-    {action, _phase_opts} =
-      strategy =
+    {_action, phase_opts} =
       Destila.Workflows.session_strategy(
         workflow_session.workflow_type,
         workflow_session.steps_completed
       )
 
-    if action == :new do
-      Destila.AI.Session.stop_for_workflow_session(workflow_session.id)
-    end
-
-    session_opts = build_session_opts(workflow_session, strategy)
+    session_opts = build_session_opts(workflow_session, phase_opts)
 
     case Destila.AI.Session.for_workflow_session(workflow_session.id, session_opts) do
       {:ok, _session} ->
@@ -127,20 +122,14 @@ defmodule Destila.Workers.SetupWorker do
     end
   end
 
-  defp build_session_opts(workflow_session, {action, phase_opts}) do
+  defp build_session_opts(workflow_session, phase_opts) do
     opts = [timeout_ms: :timer.minutes(15)]
 
     opts =
-      case action do
-        :resume ->
-          if workflow_session.ai_session_id do
-            Keyword.put(opts, :resume, workflow_session.ai_session_id)
-          else
-            opts
-          end
-
-        :new ->
-          opts
+      if workflow_session.ai_session_id do
+        Keyword.put(opts, :resume, workflow_session.ai_session_id)
+      else
+        opts
       end
 
     opts =

--- a/lib/destila/workers/title_generation_worker.ex
+++ b/lib/destila/workers/title_generation_worker.ex
@@ -7,11 +7,11 @@ defmodule Destila.Workers.TitleGenerationWorker do
   def perform(%Oban.Job{
         args: %{
           "workflow_session_id" => workflow_session_id,
-          "workflow_type" => workflow_type,
           "idea" => idea
         }
       }) do
-    workflow_type = String.to_existing_atom(workflow_type)
+    workflow_session = WorkflowSessions.get_workflow_session!(workflow_session_id)
+    workflow_type = workflow_session.workflow_type
 
     Messages.create_message(workflow_session_id, %{
       role: :system,

--- a/lib/destila/workers/title_generation_worker.ex
+++ b/lib/destila/workers/title_generation_worker.ex
@@ -23,7 +23,7 @@ defmodule Destila.Workers.TitleGenerationWorker do
     title =
       case Destila.AI.generate_title(workflow_type, idea) do
         {:ok, title} -> title
-        {:error, _reason} -> default_title(workflow_type)
+        {:error, _reason} -> Destila.Workflows.default_title(workflow_type)
       end
 
     WorkflowSessions.update_workflow_session(workflow_session_id, %{
@@ -46,8 +46,4 @@ defmodule Destila.Workers.TitleGenerationWorker do
 
     :ok
   end
-
-  defp default_title(:prompt_new_project), do: "New Project"
-  defp default_title(:prompt_chore_task), do: "New Chore/Task"
-  defp default_title(:implement_generic_prompt), do: "New Session"
 end

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -1,126 +1,41 @@
 defmodule Destila.Workflows do
   @moduledoc """
-  Defines workflow scripts for each workflow type.
-  Each step has an AI message with an input_type and optional options.
+  Thin dispatcher that routes workflow operations to the appropriate
+  workflow module based on `workflow_type`.
   """
 
-  def steps(:prompt_new_project) do
-    [
-      %{
-        step: 1,
-        content:
-          "Tell me about your project idea. What are you building and who is it for? The more context you provide, the better the resulting prompt will be.",
-        input_type: :text,
-        options: nil
-      },
-      %{
-        step: 2,
-        content: "What's the primary tech stack for this project?",
-        input_type: :single_select,
-        options: [
-          %{
-            label: "Web App",
-            description: "Full-stack web application with frontend and backend"
-          },
-          %{
-            label: "Mobile App",
-            description: "iOS, Android, or cross-platform mobile application"
-          },
-          %{label: "CLI Tool", description: "Command-line interface tool or utility"},
-          %{label: "Library", description: "Reusable package or library for other developers"}
-        ]
-      },
-      %{
-        step: 3,
-        content:
-          "Which features should be in scope for v1? Select all that apply to your initial release.",
-        input_type: :multi_select,
-        options: [
-          %{label: "Auth", description: "User authentication and authorization"},
-          %{label: "Dashboard", description: "Main overview or analytics view"},
-          %{label: "API", description: "REST or GraphQL API endpoints"},
-          %{label: "Admin Panel", description: "Administrative management interface"},
-          %{label: "Notifications", description: "Email, push, or in-app notifications"}
-        ]
-      }
-    ]
-  end
-
-  def steps(:prompt_chore_task) do
-    [
-      %{
-        step: 1,
-        content:
-          "Let's work on your task. Describe what you need done — the more context you provide, the better I can help clarify and refine the approach.",
-        input_type: :text,
-        options: nil
-      }
-    ]
-  end
-
-  def steps(:implement_generic_prompt) do
-    [
-      %{
-        step: 1,
-        content:
-          "Describe what you want to implement. Provide as much context as possible about the desired outcome.",
-        input_type: :text,
-        options: nil
-      }
-    ]
-  end
-
-  def total_steps(:prompt_new_project), do: 3
-  def total_steps(:prompt_chore_task), do: 4
-  def total_steps(:implement_generic_prompt), do: 1
+  @workflow_modules %{
+    prompt_chore_task: Destila.Workflows.PromptChoreTaskWorkflow,
+    prompt_new_project: Destila.Workflows.PromptNewProjectWorkflow,
+    implement_generic_prompt: Destila.Workflows.ImplementGenericPromptWorkflow
+  }
 
   @doc """
-  Returns the human-readable phase name for a workflow type and phase number.
+  Returns the workflow module for a given workflow type.
   """
-  def phase_name(:prompt_chore_task, phase),
-    do: Destila.Workflows.ChoreTaskPhases.phase_name(phase)
-
-  def phase_name(:prompt_new_project, 1), do: "Project Idea"
-  def phase_name(:prompt_new_project, 2), do: "Tech Stack"
-  def phase_name(:prompt_new_project, 3), do: "V1 Features"
-
-  def phase_name(:implement_generic_prompt, 1), do: "Implementation"
-
-  def phase_name(_type, _phase), do: nil
-
-  @doc """
-  Returns the list of {phase_number, phase_name} column definitions for a workflow type,
-  including a final {:done, "Done"} column.
-  """
-  def phase_columns(workflow_type) do
-    # prompt_chore_task starts at phase 0 (Setup — git/worktree init) while
-    # static workflows have no phase 0.
-    range =
-      case workflow_type do
-        :prompt_chore_task -> 0..total_steps(workflow_type)
-        _ -> 1..total_steps(workflow_type)
-      end
-
-    columns =
-      range
-      |> Enum.map(fn n -> {n, phase_name(workflow_type, n)} end)
-      |> Enum.reject(fn {_, name} -> is_nil(name) end)
-
-    columns ++ [{:done, "Done"}]
+  def workflow_module(workflow_type) do
+    Map.fetch!(@workflow_modules, workflow_type)
   end
 
-  @doc """
-  Returns the phases module for a given workflow type.
-  """
-  def phases_module(:prompt_chore_task), do: Destila.Workflows.ChoreTaskPhases
+  def steps(workflow_type), do: workflow_module(workflow_type).steps()
+  def total_steps(workflow_type), do: workflow_module(workflow_type).total_steps()
+  def phase_name(workflow_type, phase), do: workflow_module(workflow_type).phase_name(phase)
+  def phase_columns(workflow_type), do: workflow_module(workflow_type).phase_columns()
+  def completion_message(workflow_type), do: workflow_module(workflow_type).completion_message()
 
   @doc """
   Returns the session strategy for a given workflow type and phase.
+  Defaults to `:resume` for workflow types that don't define `session_strategy/1`.
   """
-  def session_strategy(:prompt_chore_task, phase),
-    do: Destila.Workflows.ChoreTaskPhases.session_strategy(phase)
+  def session_strategy(workflow_type, phase) do
+    module = workflow_module(workflow_type)
 
-  def session_strategy(_type, _phase), do: :resume
+    if function_exported?(module, :session_strategy, 1) do
+      module.session_strategy(phase)
+    else
+      :resume
+    end
+  end
 
   @doc """
   Normalizes a session strategy to `{action, opts}` tuple form.
@@ -128,16 +43,4 @@ defmodule Destila.Workflows do
   def normalize_strategy(:resume), do: {:resume, []}
   def normalize_strategy(:new), do: {:new, []}
   def normalize_strategy({action, opts}) when action in [:resume, :new], do: {action, opts}
-
-  def completion_message(:prompt_new_project) do
-    "Your project prompt is complete! I've captured your project vision, tech stack, and scope. This prompt is ready to guide a coding agent through the initial implementation."
-  end
-
-  def completion_message(:prompt_chore_task) do
-    "Your implementation prompt is ready! The task has been clarified, the technical approach defined, and Gherkin scenarios reviewed."
-  end
-
-  def completion_message(:implement_generic_prompt) do
-    "Your implementation session is complete."
-  end
 end

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -109,6 +109,26 @@ defmodule Destila.Workflows do
     columns ++ [{:done, "Done"}]
   end
 
+  @doc """
+  Returns the phases module for a given workflow type.
+  """
+  def phases_module(:prompt_chore_task), do: Destila.Workflows.ChoreTaskPhases
+
+  @doc """
+  Returns the session strategy for a given workflow type and phase.
+  """
+  def session_strategy(:prompt_chore_task, phase),
+    do: Destila.Workflows.ChoreTaskPhases.session_strategy(phase)
+
+  def session_strategy(_type, _phase), do: :resume
+
+  @doc """
+  Normalizes a session strategy to `{action, opts}` tuple form.
+  """
+  def normalize_strategy(:resume), do: {:resume, []}
+  def normalize_strategy(:new), do: {:new, []}
+  def normalize_strategy({action, opts}) when action in [:resume, :new], do: {action, opts}
+
   def completion_message(:prompt_new_project) do
     "Your project prompt is complete! I've captured your project vision, tech stack, and scope. This prompt is ready to guide a coding agent through the initial implementation."
   end

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -21,6 +21,7 @@ defmodule Destila.Workflows do
   def total_steps(workflow_type), do: workflow_module(workflow_type).total_steps()
   def phase_name(workflow_type, phase), do: workflow_module(workflow_type).phase_name(phase)
   def phase_columns(workflow_type), do: workflow_module(workflow_type).phase_columns()
+  def default_title(workflow_type), do: workflow_module(workflow_type).default_title()
   def completion_message(workflow_type), do: workflow_module(workflow_type).completion_message()
 
   @doc """

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -24,23 +24,25 @@ defmodule Destila.Workflows do
   def completion_message(workflow_type), do: workflow_module(workflow_type).completion_message()
 
   @doc """
-  Returns the session strategy for a given workflow type and phase.
-  Defaults to `:resume` for workflow types that don't define `session_strategy/1`.
+  Returns the session strategy for a given workflow type and phase
+  as a normalized `{action, opts}` tuple.
+
+  Defaults to `{:resume, []}` for workflow types that don't define `session_strategy/1`.
   """
   def session_strategy(workflow_type, phase) do
     module = workflow_module(workflow_type)
 
-    if function_exported?(module, :session_strategy, 1) do
-      module.session_strategy(phase)
-    else
-      :resume
-    end
+    strategy =
+      if function_exported?(module, :session_strategy, 1) do
+        module.session_strategy(phase)
+      else
+        :resume
+      end
+
+    normalize_strategy(strategy)
   end
 
-  @doc """
-  Normalizes a session strategy to `{action, opts}` tuple form.
-  """
-  def normalize_strategy(:resume), do: {:resume, []}
-  def normalize_strategy(:new), do: {:new, []}
-  def normalize_strategy({action, opts}) when action in [:resume, :new], do: {action, opts}
+  defp normalize_strategy(:resume), do: {:resume, []}
+  defp normalize_strategy(:new), do: {:new, []}
+  defp normalize_strategy({action, opts}) when action in [:resume, :new], do: {action, opts}
 end

--- a/lib/destila/workflows/chore_task_phases.ex
+++ b/lib/destila/workflows/chore_task_phases.ex
@@ -158,6 +158,17 @@ defmodule Destila.Workflows.ChoreTaskPhases do
   end
 
   @doc """
+  Returns the session strategy for a given phase.
+
+  Possible return values:
+    - `:resume` — continue the existing session (default behavior)
+    - `{:resume, claude_opts}` — continue with additional ClaudeCode options
+    - `:new` — start a fresh session with default options
+    - `{:new, claude_opts}` — start a fresh session with specific options
+  """
+  def session_strategy(_phase), do: :resume
+
+  @doc """
   Builds a conversation context string from existing messages for session resumption.
   Groups messages by phase and summarizes each.
   """

--- a/lib/destila/workflows/implement_generic_prompt_workflow.ex
+++ b/lib/destila/workflows/implement_generic_prompt_workflow.ex
@@ -1,0 +1,43 @@
+defmodule Destila.Workflows.ImplementGenericPromptWorkflow do
+  @moduledoc """
+  Defines the Implement Generic Prompt workflow — a single-step form
+  that captures an implementation description.
+  """
+
+  def steps do
+    [
+      %{
+        step: 1,
+        content:
+          "Describe what you want to implement. Provide as much context as possible about the desired outcome.",
+        input_type: :text,
+        options: nil
+      }
+    ]
+  end
+
+  def total_steps, do: 1
+
+  @phase_names %{
+    1 => "Implementation"
+  }
+
+  def phase_name(phase) when is_map_key(@phase_names, phase) do
+    @phase_names[phase]
+  end
+
+  def phase_name(_phase), do: nil
+
+  def phase_columns do
+    columns =
+      1..total_steps()
+      |> Enum.map(fn n -> {n, phase_name(n)} end)
+      |> Enum.reject(fn {_, name} -> is_nil(name) end)
+
+    columns ++ [{:done, "Done"}]
+  end
+
+  def completion_message do
+    "Your implementation session is complete."
+  end
+end

--- a/lib/destila/workflows/implement_generic_prompt_workflow.ex
+++ b/lib/destila/workflows/implement_generic_prompt_workflow.ex
@@ -37,6 +37,8 @@ defmodule Destila.Workflows.ImplementGenericPromptWorkflow do
     columns ++ [{:done, "Done"}]
   end
 
+  def default_title, do: "New Session"
+
   def completion_message do
     "Your implementation session is complete."
   end

--- a/lib/destila/workflows/prompt_chore_task_workflow.ex
+++ b/lib/destila/workflows/prompt_chore_task_workflow.ex
@@ -46,6 +46,8 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflow do
     columns ++ [{:done, "Done"}]
   end
 
+  def default_title, do: "New Chore/Task"
+
   def completion_message do
     "Your implementation prompt is ready! The task has been clarified, the technical approach defined, and Gherkin scenarios reviewed."
   end

--- a/lib/destila/workflows/prompt_chore_task_workflow.ex
+++ b/lib/destila/workflows/prompt_chore_task_workflow.ex
@@ -1,12 +1,27 @@
-defmodule Destila.Workflows.ChoreTaskPhases do
+defmodule Destila.Workflows.PromptChoreTaskWorkflow do
   @moduledoc """
-  Defines AI system prompts and phase metadata for the Chore/Task workflow.
+  Defines the Chore/Task workflow — an AI-driven multi-phase conversation
+  that clarifies a coding task and produces an implementation prompt.
 
   Each phase is a multi-turn AI conversation. The AI uses markers to signal
   phase transitions:
   - `<<READY_TO_ADVANCE>>` — AI suggests advancing to the next phase
   - `<<SKIP_PHASE>>` — AI determines phase can be skipped (Phase 2 only)
   """
+
+  def steps do
+    [
+      %{
+        step: 1,
+        content:
+          "Let's work on your task. Describe what you need done — the more context you provide, the better I can help clarify and refine the approach.",
+        input_type: :text,
+        options: nil
+      }
+    ]
+  end
+
+  def total_steps, do: 4
 
   @phase_names %{
     0 => "Setup",
@@ -16,14 +31,39 @@ defmodule Destila.Workflows.ChoreTaskPhases do
     4 => "Prompt Generation"
   }
 
-  @doc """
-  Returns the human-readable name for a phase number.
-  """
   def phase_name(phase) when is_map_key(@phase_names, phase) do
     @phase_names[phase]
   end
 
   def phase_name(_phase), do: nil
+
+  def phase_columns do
+    columns =
+      0..total_steps()
+      |> Enum.map(fn n -> {n, phase_name(n)} end)
+      |> Enum.reject(fn {_, name} -> is_nil(name) end)
+
+    columns ++ [{:done, "Done"}]
+  end
+
+  def completion_message do
+    "Your implementation prompt is ready! The task has been clarified, the technical approach defined, and Gherkin scenarios reviewed."
+  end
+
+  # Session strategy
+
+  @doc """
+  Returns the session strategy for a given phase.
+
+  Possible return values:
+    - `:resume` — continue the existing session (default behavior)
+    - `{:resume, claude_opts}` — continue with additional ClaudeCode options
+    - `:new` — start a fresh session with default options
+    - `{:new, claude_opts}` — start a fresh session with specific options
+  """
+  def session_strategy(_phase), do: :resume
+
+  # AI system prompts
 
   @tool_instructions """
 
@@ -157,16 +197,7 @@ defmodule Destila.Workflows.ChoreTaskPhases do
     """
   end
 
-  @doc """
-  Returns the session strategy for a given phase.
-
-  Possible return values:
-    - `:resume` — continue the existing session (default behavior)
-    - `{:resume, claude_opts}` — continue with additional ClaudeCode options
-    - `:new` — start a fresh session with default options
-    - `{:new, claude_opts}` — start a fresh session with specific options
-  """
-  def session_strategy(_phase), do: :resume
+  # Conversation context
 
   @doc """
   Builds a conversation context string from existing messages for session resumption.

--- a/lib/destila/workflows/prompt_new_project_workflow.ex
+++ b/lib/destila/workflows/prompt_new_project_workflow.ex
@@ -1,0 +1,75 @@
+defmodule Destila.Workflows.PromptNewProjectWorkflow do
+  @moduledoc """
+  Defines the New Project workflow — a scripted multi-step form
+  that captures project idea, tech stack, and v1 scope.
+  """
+
+  def steps do
+    [
+      %{
+        step: 1,
+        content:
+          "Tell me about your project idea. What are you building and who is it for? The more context you provide, the better the resulting prompt will be.",
+        input_type: :text,
+        options: nil
+      },
+      %{
+        step: 2,
+        content: "What's the primary tech stack for this project?",
+        input_type: :single_select,
+        options: [
+          %{
+            label: "Web App",
+            description: "Full-stack web application with frontend and backend"
+          },
+          %{
+            label: "Mobile App",
+            description: "iOS, Android, or cross-platform mobile application"
+          },
+          %{label: "CLI Tool", description: "Command-line interface tool or utility"},
+          %{label: "Library", description: "Reusable package or library for other developers"}
+        ]
+      },
+      %{
+        step: 3,
+        content:
+          "Which features should be in scope for v1? Select all that apply to your initial release.",
+        input_type: :multi_select,
+        options: [
+          %{label: "Auth", description: "User authentication and authorization"},
+          %{label: "Dashboard", description: "Main overview or analytics view"},
+          %{label: "API", description: "REST or GraphQL API endpoints"},
+          %{label: "Admin Panel", description: "Administrative management interface"},
+          %{label: "Notifications", description: "Email, push, or in-app notifications"}
+        ]
+      }
+    ]
+  end
+
+  def total_steps, do: 3
+
+  @phase_names %{
+    1 => "Project Idea",
+    2 => "Tech Stack",
+    3 => "V1 Features"
+  }
+
+  def phase_name(phase) when is_map_key(@phase_names, phase) do
+    @phase_names[phase]
+  end
+
+  def phase_name(_phase), do: nil
+
+  def phase_columns do
+    columns =
+      1..total_steps()
+      |> Enum.map(fn n -> {n, phase_name(n)} end)
+      |> Enum.reject(fn {_, name} -> is_nil(name) end)
+
+    columns ++ [{:done, "Done"}]
+  end
+
+  def completion_message do
+    "Your project prompt is complete! I've captured your project vision, tech stack, and scope. This prompt is ready to guide a coding agent through the initial implementation."
+  end
+end

--- a/lib/destila/workflows/prompt_new_project_workflow.ex
+++ b/lib/destila/workflows/prompt_new_project_workflow.ex
@@ -69,6 +69,8 @@ defmodule Destila.Workflows.PromptNewProjectWorkflow do
     columns ++ [{:done, "Done"}]
   end
 
+  def default_title, do: "New Project"
+
   def completion_message do
     "Your project prompt is complete! I've captured your project vision, tech stack, and scope. This prompt is ready to guide a coding agent through the initial implementation."
   end

--- a/lib/destila_web/components/chat_components.ex
+++ b/lib/destila_web/components/chat_components.ex
@@ -27,7 +27,11 @@ defmodule DestilaWeb.ChatComponents do
     assigns = assign(assigns, :next_phase, next_phase)
 
     assigns =
-      assign(assigns, :next_phase_name, Destila.Workflows.ChoreTaskPhases.phase_name(next_phase))
+      assign(
+        assigns,
+        :next_phase_name,
+        Destila.Workflows.PromptChoreTaskWorkflow.phase_name(next_phase)
+      )
 
     ~H"""
     <div class="flex gap-3 mb-4">

--- a/lib/destila_web/live/new_session_live.ex
+++ b/lib/destila_web/live/new_session_live.ex
@@ -213,11 +213,7 @@ defmodule DestilaWeb.NewSessionLive do
 
   defp enqueue_setup_jobs(workflow_session, workflow_type, idea) do
     # Always enqueue title generation
-    %{
-      "workflow_session_id" => workflow_session.id,
-      "workflow_type" => to_string(workflow_type),
-      "idea" => idea
-    }
+    %{"workflow_session_id" => workflow_session.id, "idea" => idea}
     |> Destila.Workers.TitleGenerationWorker.new()
     |> Oban.insert()
 

--- a/lib/destila_web/live/session_detail_live.ex
+++ b/lib/destila_web/live/session_detail_live.ex
@@ -209,11 +209,19 @@ defmodule DestilaWeb.SessionDetailLive do
     if next_phase > ws.steps_total do
       {:noreply, socket}
     else
-      {:ok, _} =
-        Destila.WorkflowSessions.update_workflow_session(ws, %{
-          steps_completed: next_phase,
-          phase_status: :generating
-        })
+      {action, _} = Workflows.session_strategy(ws.workflow_type, next_phase)
+
+      update_attrs = %{steps_completed: next_phase, phase_status: :generating}
+
+      update_attrs =
+        if action == :new do
+          Destila.AI.Session.stop_for_workflow_session(ws.id)
+          Map.put(update_attrs, :ai_session_id, nil)
+        else
+          update_attrs
+        end
+
+      {:ok, _} = Destila.WorkflowSessions.update_workflow_session(ws, update_attrs)
 
       updated_ws = Destila.WorkflowSessions.get_workflow_session!(ws.id)
       workflow_module = Workflows.workflow_module(updated_ws.workflow_type)

--- a/lib/destila_web/live/session_detail_live.ex
+++ b/lib/destila_web/live/session_detail_live.ex
@@ -144,9 +144,7 @@ defmodule DestilaWeb.SessionDetailLive do
     end
 
     if ws.title_generating do
-      workflow_type = to_string(ws.workflow_type)
-
-      %{"workflow_session_id" => ws.id, "workflow_type" => workflow_type, "idea" => ""}
+      %{"workflow_session_id" => ws.id, "idea" => ""}
       |> Destila.Workers.TitleGenerationWorker.new()
       |> Oban.insert()
     end

--- a/lib/destila_web/live/session_detail_live.ex
+++ b/lib/destila_web/live/session_detail_live.ex
@@ -4,7 +4,7 @@ defmodule DestilaWeb.SessionDetailLive do
   import DestilaWeb.ChatComponents
   import DestilaWeb.BoardComponents, only: [workflow_badge: 1, progress_indicator: 1]
 
-  alias Destila.Workflows.ChoreTaskPhases
+  alias Destila.Workflows
 
   def mount(%{"id" => id}, session, socket) do
     workflow_session = Destila.WorkflowSessions.get_workflow_session(id)
@@ -216,7 +216,8 @@ defmodule DestilaWeb.SessionDetailLive do
         })
 
       updated_ws = Destila.WorkflowSessions.get_workflow_session!(ws.id)
-      phase_prompt = ChoreTaskPhases.system_prompt(next_phase, updated_ws)
+      workflow_module = Workflows.workflow_module(updated_ws.workflow_type)
+      phase_prompt = workflow_module.system_prompt(next_phase, updated_ws)
 
       %{"workflow_session_id" => ws.id, "phase" => next_phase, "query" => phase_prompt}
       |> Destila.Workers.AiQueryWorker.new()
@@ -541,7 +542,8 @@ defmodule DestilaWeb.SessionDetailLive do
     """
   end
 
-  defp phase_name(phase), do: ChoreTaskPhases.phase_name(phase)
+  defp phase_name(phase),
+    do: Destila.Workflows.PromptChoreTaskWorkflow.phase_name(phase)
 
   defp phase_groups(messages, current_phase) do
     groups =


### PR DESCRIPTION
## Summary

- Add `session_strategy/1` callback to workflow phase modules for per-phase ClaudeCode session configuration
- Apply Locality of Behavior: move all workflow-specific logic into dedicated per-type modules (`PromptChoreTaskWorkflow`, `PromptNewProjectWorkflow`, `ImplementGenericPromptWorkflow`)
- `Workflows` module is now a thin dispatcher routing by `workflow_type`
- Extract `session_opts_for_workflow/3` to `Destila.AI.Session` — single place to build session opts
- Fix session resumption: `:new` strategy applied at phase transition time, not on every query
- Fix `handle_skip_phase` advancing past the last phase when AI quotes `<<SKIP_PHASE>>` in content
- Fix `parse_markers` tagging the final phase as `:skip_phase` instead of `:generated_prompt`
- `TitleGenerationWorker` derives `workflow_type` from session instead of job args

## Changes

| File | Change |
|------|--------|
| `workflows/prompt_chore_task_workflow.ex` | New — all chore task logic (phases, prompts, session strategy, default title) |
| `workflows/prompt_new_project_workflow.ex` | New — all new project logic |
| `workflows/implement_generic_prompt_workflow.ex` | New — all generic prompt logic |
| `workflows.ex` | Rewritten as thin dispatcher |
| `workflows/chore_task_phases.ex` | Deleted |
| `ai/session.ex` | Added `session_opts_for_workflow/3` and `merge_phase_opts/2` |
| `workers/setup_worker.ex` | Uses `session_opts_for_workflow/3` |
| `workers/ai_query_worker.ex` | Uses `session_opts_for_workflow/3`; bounds guard on `handle_skip_phase` |
| `workers/title_generation_worker.ex` | Derives `workflow_type` from session |
| `setup.ex` | Uses `Workflows.workflow_module/1` |
| `session_detail_live.ex` | Phase advance handles `:new` strategy |
| `chat_components.ex` | Updated module reference |
| `messages.ex` | Check final phase before marker detection |

## Testing

- `mix precommit`: 105 tests, 0 failures, 0 warnings
- Manually fixed affected session state via RPC

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: existing workflow behavior unchanged. Bug fixes prevent edge cases already occurring in production.