### PR TITLE
feat: Redirect to crafting board after archiving a session

### DIFF
--- a/docs/plans/2026-03-27-feat-archive-redirect-to-crafting-board-plan.md
+++ b/docs/plans/2026-03-27-feat-archive-redirect-to-crafting-board-plan.md
@@ -1,0 +1,78 @@
+---
+title: "feat: Redirect to crafting board after archiving session"
+type: feat
+date: 2026-03-27
+---
+
+# Redirect to Crafting Board After Archiving Session
+
+When a user archives a session from the session detail page, redirect them to `/crafting` instead of staying on the page. The "Session archived" flash message displays on the crafting board.
+
+## Acceptance Criteria
+
+- [x] Archiving a session redirects the user to the crafting board (`/crafting`)
+- [x] The flash message "Session archived" appears on the crafting board after redirect
+- [x] Unarchive flow is unchanged — user stays on session detail page
+- [x] The `data-confirm` dialog text remains unchanged
+- [x] Gherkin scenario updated to reflect redirect behavior
+- [x] Test updated to assert redirect and flash on crafting board
+
+## Implementation
+
+### 1. Update `handle_event("archive_session", ...)` in `workflow_runner_live.ex`
+
+**File:** `lib/destila_web/live/workflow_runner_live.ex` (lines 116-123)
+
+**Current:**
+
+```elixir
+def handle_event("archive_session", _params, socket) do
+  {:ok, ws} = WorkflowSessions.archive_workflow_session(socket.assigns.workflow_session)
+
+  {:noreply,
+   socket
+   |> assign(:workflow_session, ws)
+   |> put_flash(:info, "Session archived")}
+end
+```
+
+**New:**
+
+```elixir
+def handle_event("archive_session", _params, socket) do
+  {:ok, _ws} = WorkflowSessions.archive_workflow_session(socket.assigns.workflow_session)
+
+  {:noreply,
+   socket
+   |> put_flash(:info, "Session archived")
+   |> push_navigate(to: ~p"/crafting")}
+end
+```
+
+This follows the existing pattern at lines 91-93 of the same file (`put_flash` + `push_navigate` for "Session not found").
+
+### 2. Update Gherkin scenario in `features/session_archiving.feature`
+
+Replace the "Archive a session from the session detail page" scenario (lines 11-15):
+
+```gherkin
+Scenario: Archive a session from the session detail page
+  Given I am viewing a session titled "Fix login bug"
+  When I click the "Archive" button
+  Then I should be redirected to the crafting board
+  And I should see a flash message confirming the session was archived
+```
+
+### 3. Update test in `test/destila_web/live/session_archiving_live_test.exs`
+
+Rewrite the archive test (lines ~41-68) to assert:
+- User is redirected to `/crafting` after archive
+- Flash message "Session archived" is visible on the crafting board
+- The archived session is not listed on the crafting board
+
+## References
+
+- Existing `put_flash` + `push_navigate` pattern: `workflow_runner_live.ex:91-93`
+- Archive handler: `workflow_runner_live.ex:116-123`
+- Gherkin feature: `features/session_archiving.feature:11-15`
+- Test file: `test/destila_web/live/session_archiving_live_test.exs`

--- a/features/session_archiving.feature
+++ b/features/session_archiving.feature
@@ -11,8 +11,8 @@ Feature: Session Archiving
   Scenario: Archive a session from the session detail page
     Given I am viewing a session titled "Fix login bug"
     When I click the "Archive" button
-    Then I should see a flash message confirming the session was archived
-    And the button label should change to "Unarchive"
+    Then I should be redirected to the crafting board
+    And I should see a flash message confirming the session was archived
 
   Scenario: Archived session is hidden from the crafting board
     Given I have archived a session titled "Fix login bug"

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -114,12 +114,12 @@ defmodule DestilaWeb.WorkflowRunnerLive do
   end
 
   def handle_event("archive_session", _params, socket) do
-    {:ok, ws} = WorkflowSessions.archive_workflow_session(socket.assigns.workflow_session)
+    {:ok, _ws} = WorkflowSessions.archive_workflow_session(socket.assigns.workflow_session)
 
     {:noreply,
      socket
-     |> assign(:workflow_session, ws)
-     |> put_flash(:info, "Session archived")}
+     |> put_flash(:info, "Session archived")
+     |> push_navigate(to: ~p"/crafting")}
   end
 
   def handle_event("unarchive_session", _params, socket) do

--- a/test/destila_web/live/session_archiving_live_test.exs
+++ b/test/destila_web/live/session_archiving_live_test.exs
@@ -40,7 +40,7 @@ defmodule DestilaWeb.SessionArchivingLiveTest do
 
   describe "archive from session detail" do
     @tag feature: @feature, scenario: "Archive a session from the session detail page"
-    test "shows Archive button and archives on click", %{conn: conn, project: project} do
+    test "redirects to crafting board with flash on archive", %{conn: conn, project: project} do
       ws = create_session(%{title: "Fix login bug", project_id: project.id})
 
       # Add a message so mount doesn't try to start workflow
@@ -56,15 +56,14 @@ defmodule DestilaWeb.SessionArchivingLiveTest do
 
       # Archive button should be visible
       assert has_element?(view, "#archive-btn")
-      refute has_element?(view, "#unarchive-btn")
 
       # Click archive
       view |> element("#archive-btn") |> render_click()
 
-      # Flash and button swap
-      assert has_element?(view, "#unarchive-btn")
-      refute has_element?(view, "#archive-btn")
-      assert render(view) =~ "Session archived"
+      # Should redirect to crafting board with flash
+      {path, flash} = assert_redirect(view)
+      assert path == "/crafting"
+      assert flash["info"] == "Session archived"
     end
   end
 


### PR DESCRIPTION
## Summary
- Archiving a session from the detail page now redirects the user to `/crafting` instead of staying on the page
- The "Session archived" flash message is preserved and displayed on the crafting board
- Unarchive flow is unchanged — user stays on the session detail page

## Test plan
- [x] Archive test updated to assert redirect to `/crafting` and flash message
- [x] All 92 tests pass (`mix precommit`)

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: UI navigation change only, no new data paths or external calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)