### PR TITLE
refactor: Extract business logic from web layer into core modules

### DIFF
--- a/docs/plans/2026-03-27-refactor-extract-business-logic-from-web-layer-plan.md
+++ b/docs/plans/2026-03-27-refactor-extract-business-logic-from-web-layer-plan.md
@@ -1,0 +1,675 @@
+---
+title: "refactor: Extract business logic from web layer into core modules"
+type: refactor
+date: 2026-03-27
+---
+
+# refactor: Extract business logic from web layer into core modules
+
+## Overview
+
+Move all business logic (DB mutations, Oban job insertion, AI session management, validation) out of the four DestilaWeb files (WorkflowRunnerLive, WizardPhase, SetupPhase, AiConversationPhase) into the Destila core layer. After this refactor, every web-layer module is a thin delegate: receive events, call core functions, update socket assigns with results.
+
+## Problem Statement
+
+Business logic is scattered across LiveView and LiveComponent files that should be pure presentation:
+
+- **WorkflowRunnerLive** — session creation from wizard data, mark-done with AI completion message, phase advancement
+- **WizardPhase** — project validation, inline project creation with validation
+- **SetupPhase** — `Oban.insert` calls for SetupWorker/TitleGenerationWorker, idempotency guard, retry logic
+- **AiConversationPhase** — AI session creation, `Oban.insert` for AiQueryWorker, phase advancement with session strategy, duplicated mark-done logic
+
+Additionally, `AiQueryWorker.handle_skip_phase/2` contains phase-advance logic that parallels `AiConversationPhase.handle_event("confirm_advance")` — both check session strategy and optionally stop ClaudeSession.
+
+## Proposed Solution
+
+Extract business logic into two targets:
+
+1. **`Destila.Workflows`** (context module) — generic runner-level operations: session creation from wizard, phase advancement with session strategy, mark-done
+2. **`Destila.Workflows.PromptChoreTaskWorkflow`** — workflow-specific phase operations: setup initiation/retry, AI conversation initialization, send user message
+
+The `Workflows` dispatcher routes to concrete workflow functions where needed, consistent with existing pattern.
+
+## Technical Approach
+
+### Architecture
+
+```
+Before:
+  WorkflowRunnerLive ──── DB writes, AI calls, Oban inserts
+  WizardPhase ──────────── Projects.create_project, validation
+  SetupPhase ───────────── Oban.insert(SetupWorker), Oban.insert(TitleGenWorker)
+  AiConversationPhase ──── AI session mgmt, Oban.insert(AiQueryWorker), phase advance
+  AiQueryWorker ────────── handle_skip_phase (parallel advance logic)
+
+After:
+  WorkflowRunnerLive ──── calls Workflows.create_session_from_wizard/2
+                           calls Workflows.advance_phase/1
+                           calls Workflows.mark_done/1
+
+  WizardPhase ──────────── calls Workflows.validate_wizard_fields/2
+                           calls Workflows.validate_and_create_project/2
+
+  SetupPhase ───────────── calls Workflows.initiate_setup/2
+                           calls Workflows.retry_setup/1
+                           keeps build_steps (presentation logic)
+
+  AiConversationPhase ──── calls Workflows.initialize_ai_conversation/3
+                           calls Workflows.send_user_message/3
+                           calls Workflows.advance_phase/1
+                           calls Workflows.mark_done/1
+
+  AiQueryWorker ────────── calls Workflows.advance_phase/1
+                           handles auto-enqueue of next phase (worker-specific)
+```
+
+### Key Design Decisions
+
+**1. Two advance_phase paths, shared core**
+
+`confirm_advance` (LiveComponent) and `handle_skip_phase` (Worker) have different post-advance needs:
+- LiveComponent: sets `phase_status: nil`, sends `{:phase_advanced}` to parent, component re-initializes on next `update/2`
+- Worker: sets `phase_status: :generating`, immediately enqueues next phase's AiQueryWorker
+
+Solution: `Workflows.advance_phase/1` handles the shared core (session strategy check, optional ClaudeSession stop, DB update to `current_phase + 1`). It accepts an optional `phase_status` parameter (defaults to `nil`). The worker passes `phase_status: :generating` and handles the enqueue itself.
+
+```elixir
+# lib/destila/workflows.ex
+def advance_phase(workflow_session, opts \\ []) do
+  next_phase = workflow_session.current_phase + 1
+  if next_phase > workflow_session.total_phases, do: {:error, :at_boundary}
+
+  {action, _} = session_strategy(workflow_session.workflow_type, next_phase)
+  if action == :new, do: AI.ClaudeSession.stop_for_workflow_session(workflow_session.id)
+
+  phase_status = Keyword.get(opts, :phase_status, nil)
+  update_workflow_session(workflow_session, %{current_phase: next_phase, phase_status: phase_status})
+end
+```
+
+**2. `build_steps` stays in SetupPhase**
+
+`build_steps/2` constructs display structs with UI labels ("Syncing repository...", "Pulling latest changes..."). This is presentation logic, not business logic. Only `initiate_setup` (status update + worker enqueuing) and `retry_setup` (re-enqueuing) move to the business layer.
+
+**3. `connected?` guards stay in the web layer**
+
+`SetupPhase.update/2` and `AiConversationPhase.update/2` check `connected?(socket)` before triggering side effects. Context modules have no socket awareness. The web layer retains these guards; extracted functions document the contract ("must only be called from a connected LiveView").
+
+**4. No transaction for session creation + metadata**
+
+`create_session_from_wizard/2` performs two DB operations (insert session, upsert idea metadata). Wrapping in `Ecto.Multi` is not needed — the metadata upsert is extremely unlikely to fail, and the impact of a missing idea is minor (AI phase works without it). Keep as-is for simplicity.
+
+**5. Return value contracts**
+
+All extracted functions that mutate a workflow session return `{:ok, updated_session}`. Fire-and-forget operations (setup initiation, retry) return `:ok`. Functions that need to return additional data (e.g., `initialize_ai_conversation` returning the AI session) return `{:ok, ai_session}`.
+
+**6. Unified mark_done**
+
+Both `WorkflowRunnerLive` and `AiConversationPhase` have mark_done handlers. After extraction, both call `Workflows.mark_done/1`. The LiveComponent caller additionally sends `:workflow_done` to the parent — this notification remains in the web layer, not in the extracted function.
+
+### Implementation Phases
+
+#### Phase 1: Extract runner-level logic to Workflows context
+
+Extract three functions into `lib/destila/workflows.ex`:
+
+**`create_session_from_wizard/2`**
+
+```elixir
+# Workflows.create_session_from_wizard(workflow_type, wizard_data)
+# wizard_data: %{project_id: id, idea: text, title_generating: bool}
+# Returns: {:ok, session}
+def create_session_from_wizard(workflow_type, data) do
+  session_attrs =
+    %{
+      title: default_title(workflow_type),
+      workflow_type: workflow_type,
+      current_phase: 2,  # wizard is phase 1, next is 2
+      total_phases: total_phases(workflow_type)
+    }
+    |> maybe_put(:project_id, data[:project_id])
+    |> maybe_put(:title_generating, data[:title_generating])
+
+  {:ok, ws} = create_workflow_session(session_attrs)
+
+  if data[:idea] do
+    upsert_metadata(ws.id, "wizard", "idea", %{"text" => data[:idea]})
+  end
+
+  {:ok, ws}
+end
+```
+
+**`advance_phase/2`**
+
+```elixir
+# Workflows.advance_phase(workflow_session, opts \\ [])
+# opts: [phase_status: atom] — defaults to nil
+# Returns: {:ok, updated_session} | {:error, :at_boundary}
+def advance_phase(%Session{} = ws, opts \\ []) do
+  next_phase = ws.current_phase + 1
+
+  if next_phase > ws.total_phases do
+    {:error, :at_boundary}
+  else
+    {action, _} = session_strategy(ws.workflow_type, next_phase)
+
+    if action == :new do
+      Destila.AI.ClaudeSession.stop_for_workflow_session(ws.id)
+    end
+
+    phase_status = Keyword.get(opts, :phase_status)
+    update_workflow_session(ws, %{current_phase: next_phase, phase_status: phase_status})
+  end
+end
+```
+
+**`mark_done/1`**
+
+```elixir
+# Workflows.mark_done(workflow_session)
+# Returns: {:ok, updated_session}
+def mark_done(%Session{} = ws) do
+  ai_session = Destila.AI.get_ai_session_for_workflow(ws.id)
+
+  if ai_session do
+    Destila.AI.create_message(ai_session.id, %{
+      role: :system,
+      content: completion_message(ws.workflow_type),
+      phase: ws.current_phase
+    })
+  end
+
+  update_workflow_session(ws, %{done_at: DateTime.utc_now(), phase_status: nil})
+end
+```
+
+**Update WorkflowRunnerLive** — replace inline logic with calls:
+
+```elixir
+# workflow_runner_live.ex — handle_info for session creation
+def handle_info({:phase_complete, _phase, %{action: :session_create} = data}, socket) do
+  {:ok, ws} = Workflows.create_session_from_wizard(socket.assigns.workflow_type, data)
+  {:noreply, push_navigate(socket, to: ~p"/sessions/#{ws.id}")}
+end
+
+# handle_info for simple phase advance
+def handle_info({:phase_complete, _phase, _data}, socket) do
+  {:ok, ws} = Workflows.advance_phase(socket.assigns.workflow_session)
+  {:noreply,
+   socket
+   |> assign(:workflow_session, ws)
+   |> assign(:current_phase, ws.current_phase)
+   |> assign(:metadata, Workflows.get_metadata(ws.id))
+   |> assign(:page_title, ws.title)}
+end
+
+# handle_event for mark_done
+def handle_event("mark_done", _params, socket) do
+  {:ok, ws} = Workflows.mark_done(socket.assigns.workflow_session)
+  {:noreply, assign(socket, :workflow_session, ws)}
+end
+```
+
+**Tests:** Unit tests for `create_session_from_wizard/2`, `advance_phase/2`, `mark_done/1`.
+
+- `workflow_runner_live.ex:157-195` — session creation + phase advance handlers
+- `workflow_runner_live.ex:133-152` — mark_done handler
+- `workflows.ex` — new functions added
+
+**Success criteria:** `mix precommit` passes. All existing feature tests pass.
+
+---
+
+#### Phase 2: Extract WizardPhase business logic
+
+Add two dispatcher functions to `Workflows` that delegate to `PromptChoreTaskWorkflow`:
+
+**`validate_wizard_fields/2`** (in PromptChoreTaskWorkflow)
+
+```elixir
+# PromptChoreTaskWorkflow.validate_wizard_fields(params)
+# params: %{project_id: id | nil, idea: string}
+# Returns: :ok | {:error, errors_map}
+def validate_wizard_fields(%{project_id: project_id, idea: idea}) do
+  errors = %{}
+  errors = if is_nil(project_id), do: Map.put(errors, :project, "Please select a project"), else: errors
+  errors = if idea == "" or is_nil(idea), do: Map.put(errors, :idea, "Please describe your initial idea"), else: errors
+  if errors == %{}, do: :ok, else: {:error, errors}
+end
+```
+
+**`validate_and_create_project/2`** (in PromptChoreTaskWorkflow)
+
+```elixir
+# PromptChoreTaskWorkflow.validate_and_create_project(params)
+# Returns: {:ok, project} | {:error, errors_map}
+def validate_and_create_project(params) do
+  name = String.trim(params["name"] || "")
+  git_repo_url = non_blank(params["git_repo_url"])
+  local_folder = non_blank(params["local_folder"])
+
+  errors = %{}
+  errors = if name == "", do: Map.put(errors, :name, "Name is required"), else: errors
+  errors =
+    if git_repo_url == nil && local_folder == nil,
+      do: Map.put(errors, :location, "Provide at least one"),
+      else: errors
+
+  if errors == %{} do
+    Destila.Projects.create_project(%{
+      name: name,
+      git_repo_url: git_repo_url,
+      local_folder: local_folder
+    })
+  else
+    {:error, errors}
+  end
+end
+```
+
+**Dispatcher functions in `Workflows`:**
+
+```elixir
+def validate_wizard_fields(workflow_type, params) do
+  workflow_module(workflow_type).validate_wizard_fields(params)
+end
+
+def validate_and_create_project(workflow_type, params) do
+  workflow_module(workflow_type).validate_and_create_project(params)
+end
+```
+
+**Update WizardPhase** — replace inline validation/creation:
+
+```elixir
+def handle_event("create_and_select_project", params, socket) do
+  case Workflows.validate_and_create_project(socket.assigns.workflow_type, params) do
+    {:ok, project} ->
+      {:noreply,
+       socket
+       |> assign(:project_id, project.id)
+       |> assign(:projects, Destila.Projects.list_projects())
+       |> assign(:project_step, :select)
+       |> assign(:errors, %{})}
+
+    {:error, errors} ->
+      {:noreply,
+       socket
+       |> assign(:project_form, to_form(params))
+       |> assign(:errors, errors)}
+  end
+end
+
+def handle_event("start_workflow", %{"initial_idea" => idea}, socket) when idea != "" do
+  case Workflows.validate_wizard_fields(socket.assigns.workflow_type, %{
+    project_id: socket.assigns.project_id,
+    idea: idea
+  }) do
+    :ok ->
+      send(self(), {:phase_complete, socket.assigns.phase_number, %{
+        action: :session_create,
+        project_id: socket.assigns.project_id,
+        idea: idea,
+        title_generating: true
+      }})
+      {:noreply, socket}
+
+    {:error, errors} ->
+      {:noreply, assign(socket, :errors, errors)}
+  end
+end
+```
+
+Note: WizardPhase needs `workflow_type` passed as an assign from the parent. Currently it only receives `opts` and `phase_number` — `update/2` must also capture `assigns.workflow_type`.
+
+**Tests:** Unit tests for `validate_wizard_fields/1`, `validate_and_create_project/1`.
+
+- `wizard_phase.ex:41-115` — validation and creation handlers
+- `prompt_chore_task_workflow.ex` — new functions added
+- `workflows.ex` — new dispatcher functions
+
+**Success criteria:** `mix precommit` passes. All existing feature tests pass.
+
+---
+
+#### Phase 3: Extract SetupPhase business logic
+
+Add two functions to `PromptChoreTaskWorkflow`:
+
+**`initiate_setup/2`**
+
+```elixir
+# PromptChoreTaskWorkflow.initiate_setup(workflow_session, metadata)
+# Returns: :ok
+# IMPORTANT: Must only be called from a connected LiveView (not static render).
+def initiate_setup(%Session{phase_status: :setup}, _metadata), do: :ok
+
+def initiate_setup(ws, metadata) do
+  Destila.Workflows.update_workflow_session(ws, %{phase_status: :setup})
+
+  idea = get_in(metadata, ["idea", "text"]) || ""
+
+  %{"workflow_session_id" => ws.id, "idea" => idea}
+  |> Destila.Workers.TitleGenerationWorker.new()
+  |> Oban.insert()
+
+  if ws.project_id do
+    %{"workflow_session_id" => ws.id}
+    |> Destila.Workers.SetupWorker.new()
+    |> Oban.insert()
+  end
+
+  :ok
+end
+```
+
+**`retry_setup/1`**
+
+```elixir
+# PromptChoreTaskWorkflow.retry_setup(workflow_session)
+# Returns: :ok
+def retry_setup(ws) do
+  if ws.project_id do
+    %{"workflow_session_id" => ws.id}
+    |> Destila.Workers.SetupWorker.new()
+    |> Oban.insert()
+  end
+
+  if ws.title_generating do
+    %{"workflow_session_id" => ws.id, "idea" => ""}
+    |> Destila.Workers.TitleGenerationWorker.new()
+    |> Oban.insert()
+  end
+
+  :ok
+end
+```
+
+**Dispatcher functions in `Workflows`:**
+
+```elixir
+def initiate_setup(workflow_type, workflow_session, metadata) do
+  workflow_module(workflow_type).initiate_setup(workflow_session, metadata)
+end
+
+def retry_setup(workflow_type, workflow_session) do
+  workflow_module(workflow_type).retry_setup(workflow_session)
+end
+```
+
+**Update SetupPhase:**
+
+```elixir
+def update(assigns, socket) do
+  ws = assigns.workflow_session
+  metadata = assigns[:metadata] || %{}
+  steps = build_steps(ws, metadata)  # stays in component
+
+  if connected?(socket) && ws do  # connected? guard stays in web layer
+    Workflows.initiate_setup(ws.workflow_type, ws, metadata)
+  end
+
+  if all_completed?(steps) do
+    send(self(), {:phase_complete, assigns.phase_number, %{}})
+  end
+
+  {:ok, socket |> assign(...)}
+end
+
+def handle_event("retry_setup", _params, socket) do
+  ws = socket.assigns.workflow_session
+  Workflows.retry_setup(ws.workflow_type, ws)
+  {:noreply, socket}
+end
+```
+
+**Tests:** Unit tests for `initiate_setup/2`, `retry_setup/1`.
+
+- `setup_phase.ex:11-49` — update and retry handlers
+- `setup_phase.ex:95-111` — maybe_start_setup logic
+- `prompt_chore_task_workflow.ex` — new functions added
+- `workflows.ex` — new dispatcher functions
+
+**Success criteria:** `mix precommit` passes. All existing feature tests pass.
+
+---
+
+#### Phase 4: Extract AiConversationPhase business logic
+
+This is the largest extraction. Add functions to `PromptChoreTaskWorkflow` and update `Workflows`:
+
+**`initialize_ai_conversation/3`** (in PromptChoreTaskWorkflow)
+
+```elixir
+# PromptChoreTaskWorkflow.initialize_ai_conversation(ws, phase_number, opts)
+# Returns: {:ok, ai_session} | :already_initialized
+# IMPORTANT: Must only be called from a connected LiveView (not static render).
+def initialize_ai_conversation(ws, phase_number, opts) do
+  ai_session = Destila.AI.get_ai_session_for_workflow(ws.id)
+  messages = if ai_session, do: Destila.AI.list_messages(ai_session.id), else: []
+  phase_messages = Enum.filter(messages, &(&1.phase == phase_number))
+
+  if phase_messages == [] && ws.phase_status != :generating do
+    ai_session =
+      if ai_session do
+        ai_session
+      else
+        metadata = Destila.Workflows.get_metadata(ws.id)
+        worktree_path = get_in(metadata, ["worktree", "worktree_path"])
+        {:ok, session} = Destila.AI.get_or_create_ai_session(ws.id, %{worktree_path: worktree_path})
+        session
+      end
+
+    system_prompt_fn = Keyword.fetch!(opts, :system_prompt)
+    query = system_prompt_fn.(ws)
+
+    Destila.Workflows.update_workflow_session(ws, %{phase_status: :generating})
+
+    %{"workflow_session_id" => ws.id, "phase" => phase_number, "query" => query}
+    |> Destila.Workers.AiQueryWorker.new()
+    |> Oban.insert()
+
+    {:ok, ai_session}
+  else
+    :already_initialized
+  end
+end
+```
+
+**`send_user_message/3`** (in PromptChoreTaskWorkflow)
+
+```elixir
+# PromptChoreTaskWorkflow.send_user_message(ws, ai_session, content)
+# Returns: {:ok, updated_ws} | {:error, :generating}
+def send_user_message(ws, ai_session, content) do
+  if ws.phase_status in [:generating] do
+    {:error, :generating}
+  else
+    Destila.AI.create_message(ai_session.id, %{
+      role: :user,
+      content: content,
+      phase: ws.current_phase
+    })
+
+    {:ok, ws} = Destila.Workflows.update_workflow_session(ws, %{phase_status: :generating})
+
+    %{"workflow_session_id" => ws.id, "phase" => ws.current_phase, "query" => content}
+    |> Destila.Workers.AiQueryWorker.new()
+    |> Oban.insert()
+
+    {:ok, ws}
+  end
+end
+```
+
+**Dispatcher functions in `Workflows`:**
+
+```elixir
+def initialize_ai_conversation(workflow_type, ws, phase_number, opts) do
+  workflow_module(workflow_type).initialize_ai_conversation(ws, phase_number, opts)
+end
+
+def send_user_message(workflow_type, ws, ai_session, content) do
+  workflow_module(workflow_type).send_user_message(ws, ai_session, content)
+end
+```
+
+**Update AiConversationPhase** — replace all business logic calls:
+
+```elixir
+defp maybe_initialize_ai(socket, ws, _ai_session, phase_number, opts) do
+  case Workflows.initialize_ai_conversation(ws.workflow_type, ws, phase_number, opts) do
+    {:ok, ai_session} -> assign(socket, :ai_session, ai_session)
+    :already_initialized -> socket
+  end
+end
+
+def handle_event("send_text", %{"content" => content}, socket) when content != "" do
+  ws = socket.assigns.workflow_session
+  ai_session = socket.assigns.ai_session
+
+  if ai_session do
+    case Workflows.send_user_message(ws.workflow_type, ws, ai_session, content) do
+      {:ok, ws} ->
+        messages = AI.list_messages(ai_session.id)
+        {:noreply,
+         socket
+         |> assign(:workflow_session, ws)
+         |> assign(:messages, messages)
+         |> assign(:current_step, compute_current_step(ws, messages))}
+
+      {:error, :generating} ->
+        {:noreply, socket}
+    end
+  else
+    {:noreply, socket}
+  end
+end
+
+def handle_event("confirm_advance", _params, socket) do
+  ws = socket.assigns.workflow_session
+
+  case Workflows.advance_phase(ws) do
+    {:ok, updated_ws} ->
+      send(self(), {:phase_advanced, updated_ws.current_phase})
+      {:noreply,
+       socket
+       |> assign(:workflow_session, updated_ws)
+       |> assign(:phase_number, updated_ws.current_phase)
+       |> assign(:question_answers, %{})
+       |> assign(:initialized, false)}
+
+    {:error, :at_boundary} ->
+      {:noreply, socket}
+  end
+end
+
+def handle_event("mark_done", _params, socket) do
+  {:ok, ws} = Workflows.mark_done(socket.assigns.workflow_session)
+  send(self(), :workflow_done)
+  {:noreply, assign(socket, :workflow_session, ws)}
+end
+```
+
+**Update AiQueryWorker** — use `Workflows.advance_phase/2` in `handle_skip_phase`:
+
+```elixir
+defp handle_skip_phase(workflow_session_id, current_phase) do
+  ws = Workflows.get_workflow_session!(workflow_session_id)
+
+  case Workflows.advance_phase(ws, phase_status: :generating) do
+    {:ok, updated_ws} ->
+      # Enqueue AI query for the next phase
+      phases = Workflows.phases(updated_ws.workflow_type)
+      {_module, opts} = Enum.at(phases, updated_ws.current_phase - 1)
+      system_prompt_fn = Keyword.fetch!(opts, :system_prompt)
+      phase_prompt = system_prompt_fn.(updated_ws)
+
+      %{
+        "workflow_session_id" => workflow_session_id,
+        "phase" => updated_ws.current_phase,
+        "query" => phase_prompt
+      }
+      |> __MODULE__.new()
+      |> Oban.insert()
+
+    {:error, :at_boundary} ->
+      Workflows.update_workflow_session(workflow_session_id, %{phase_status: :conversing})
+  end
+end
+```
+
+**Tests:** Unit tests for `initialize_ai_conversation/3`, `send_user_message/3`.
+
+- `ai_conversation_phase.ex:87-119` — send_text handler
+- `ai_conversation_phase.ex:199-227` — confirm_advance handler
+- `ai_conversation_phase.ex:235-256` — mark_done handler
+- `ai_conversation_phase.ex:358-389` — maybe_initialize_ai
+- `ai_query_worker.ex:97-132` — handle_skip_phase
+- `prompt_chore_task_workflow.ex` — new functions added
+- `workflows.ex` — new dispatcher functions
+
+**Success criteria:** `mix precommit` passes. All existing feature tests pass.
+
+---
+
+#### Phase 5: Verification and cleanup
+
+- [x] Run full test suite: `mix test`
+- [x] Run precommit: `mix precommit`
+- [x] Verify no direct `Oban.insert` calls remain in `lib/destila_web/`
+- [x] Verify no direct `Destila.AI.*` calls remain in `lib/destila_web/` (except `AI.process_message` and `AI.list_messages` which are read-only display helpers used in `compute_current_step` and `refresh_from_db`)
+- [x] Verify no direct `Destila.Projects.create_project` calls remain in `lib/destila_web/`
+- [x] Verify all 7 feature files' scenarios are still covered by passing tests
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [x] All existing Gherkin scenarios pass without modification
+- [x] All existing tests pass without modification
+- [x] No user-facing behavior changes
+
+### Architecture Requirements
+
+- [x] No `Oban.insert` calls in `lib/destila_web/`
+- [x] No `Destila.AI.create_message`, `AI.get_or_create_ai_session`, `AI.ClaudeSession.stop_for_workflow_session` calls in `lib/destila_web/`
+- [x] No `Destila.Projects.create_project` calls in `lib/destila_web/`
+- [x] No business validation logic in `lib/destila_web/`
+- [x] `Workflows.advance_phase/2` used by both `AiConversationPhase` and `AiQueryWorker` (single source of truth for phase advancement)
+- [x] `Workflows.mark_done/1` used by both `WorkflowRunnerLive` and `AiConversationPhase` (unified mark-done)
+
+### Quality Requirements
+
+- [x] Unit tests for every new function in `Workflows` and `PromptChoreTaskWorkflow`
+- [x] `mix precommit` passes after each phase
+
+## Allowed read-only calls in web layer
+
+These calls remain in the web layer as they are read-only display helpers, not business logic:
+
+- `Workflows.get_metadata/1`, `Workflows.get_workflow_session!/1` — data fetching for assigns
+- `Workflows.phase_name/2`, `Workflows.phases/1` — phase metadata for display
+- `Workflows.classify/1` — classification for crafting board display
+- `AI.list_messages/1`, `AI.get_ai_session_for_workflow/1` — loading messages for display
+- `AI.process_message/2` — deriving display state from raw AI response
+- `Projects.list_projects/0`, `Projects.get_project/1` — loading data for display
+- `Session.done?/1` — predicate for template conditionals
+
+## References
+
+### Internal References
+
+- `lib/destila_web/live/workflow_runner_live.ex` — runner with inline business logic
+- `lib/destila_web/live/phases/wizard_phase.ex` — wizard with validation and project creation
+- `lib/destila_web/live/phases/setup_phase.ex` — setup with Oban job insertion
+- `lib/destila_web/live/phases/ai_conversation_phase.ex` — AI chat with session mgmt and job insertion
+- `lib/destila/workers/ai_query_worker.ex:97-132` — handle_skip_phase parallel advance logic
+- `lib/destila/workflows.ex` — target for generic extracted functions
+- `lib/destila/workflows/prompt_chore_task_workflow.ex` — target for workflow-specific functions
+
+### Prior Work
+
+- `docs/brainstorms/2026-03-25-workflow-phase-architecture-brainstorm.md` — established current architecture
+- `docs/plans/2026-03-25-refactor-workflow-phase-architecture-plan.md` — implemented current phase system

--- a/lib/destila/ai.ex
+++ b/lib/destila/ai.ex
@@ -285,7 +285,7 @@ defmodule Destila.AI do
     end)
     |> Enum.flat_map(fn tool ->
       input = tool["input"] || %{}
-      questions = decode_if_string(input["questions"]) || [input]
+      questions = decode_if_string(input["questions"]) || []
 
       Enum.map(questions, fn q ->
         multi_select = q["multi_select"] == true

--- a/lib/destila/ai.ex
+++ b/lib/destila/ai.ex
@@ -285,7 +285,7 @@ defmodule Destila.AI do
     end)
     |> Enum.flat_map(fn tool ->
       input = tool["input"] || %{}
-      questions = input["questions"] || [input]
+      questions = decode_if_string(input["questions"]) || [input]
 
       Enum.map(questions, fn q ->
         multi_select = q["multi_select"] == true
@@ -303,6 +303,15 @@ defmodule Destila.AI do
       end)
     end)
   end
+
+  defp decode_if_string(value) when is_binary(value) do
+    case Jason.decode(value) do
+      {:ok, decoded} when is_list(decoded) -> decoded
+      _ -> nil
+    end
+  end
+
+  defp decode_if_string(value), do: value
 
   defdelegate broadcast(result, event), to: Destila.PubSubHelper
 

--- a/lib/destila/workers/ai_query_worker.ex
+++ b/lib/destila/workers/ai_query_worker.ex
@@ -94,40 +94,26 @@ defmodule Destila.Workers.AiQueryWorker do
     end
   end
 
-  defp handle_skip_phase(workflow_session_id, current_phase) do
-    next_phase = current_phase + 1
+  defp handle_skip_phase(workflow_session_id, _current_phase) do
     ws = Workflows.get_workflow_session!(workflow_session_id)
-    total = ws.total_phases
 
-    if next_phase > total do
-      Workflows.update_workflow_session(workflow_session_id, %{
-        phase_status: :conversing
-      })
-    else
-      {action, _} =
-        Destila.Workflows.session_strategy(ws.workflow_type, next_phase)
+    case Workflows.advance_phase(ws, phase_status: :generating) do
+      {:ok, updated_ws} ->
+        phases = Workflows.phases(updated_ws.workflow_type)
+        {_module, opts} = Enum.at(phases, updated_ws.current_phase - 1)
+        system_prompt_fn = Keyword.fetch!(opts, :system_prompt)
+        phase_prompt = system_prompt_fn.(updated_ws)
 
-      update_attrs = %{current_phase: next_phase, phase_status: :generating}
+        %{
+          "workflow_session_id" => workflow_session_id,
+          "phase" => updated_ws.current_phase,
+          "query" => phase_prompt
+        }
+        |> __MODULE__.new()
+        |> Oban.insert()
 
-      if action == :new do
-        Destila.AI.ClaudeSession.stop_for_workflow_session(workflow_session_id)
-      end
-
-      Workflows.update_workflow_session(workflow_session_id, update_attrs)
-      ws = Workflows.get_workflow_session!(workflow_session_id)
-
-      phases = Destila.Workflows.phases(ws.workflow_type)
-      {_module, opts} = Enum.at(phases, next_phase - 1)
-      system_prompt_fn = Keyword.fetch!(opts, :system_prompt)
-      phase_prompt = system_prompt_fn.(ws)
-
-      %{
-        "workflow_session_id" => workflow_session_id,
-        "phase" => next_phase,
-        "query" => phase_prompt
-      }
-      |> __MODULE__.new()
-      |> Oban.insert()
+      {:error, :at_boundary} ->
+        Workflows.update_workflow_session(workflow_session_id, %{phase_status: :conversing})
     end
   end
 end

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -13,17 +13,14 @@ defmodule Destila.Workflows do
     prompt_chore_task: Destila.Workflows.PromptChoreTaskWorkflow
   }
 
-  def workflow_module(workflow_type) when is_atom(workflow_type) do
+  def workflow_module(workflow_type) do
     Map.fetch!(@workflow_modules, workflow_type)
   end
 
-  def workflow_module(workflow_type) when is_binary(workflow_type) do
-    {_type, mod} =
-      Enum.find(@workflow_modules, fn {type, _mod} ->
-        Atom.to_string(type) == workflow_type
-      end) || raise ArgumentError, "unknown workflow type: #{workflow_type}"
-
-    mod
+  def workflow_type_from_string(workflow_type_str) do
+    Enum.find_value(@workflow_modules, fn {type, _mod} ->
+      if Atom.to_string(type) == workflow_type_str, do: type
+    end)
   end
 
   def workflow_types, do: Map.keys(@workflow_modules)

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -73,6 +73,14 @@ defmodule Destila.Workflows do
     workflow_module(workflow_type).retry_setup(workflow_session)
   end
 
+  def initialize_ai_conversation(workflow_type, ws, phase_number, opts) do
+    workflow_module(workflow_type).initialize_ai_conversation(ws, phase_number, opts)
+  end
+
+  def send_user_message(workflow_type, ws, ai_session, content) do
+    workflow_module(workflow_type).send_user_message(ws, ai_session, content)
+  end
+
   # --- High-level workflow operations ---
 
   @doc """

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -55,61 +55,7 @@ defmodule Destila.Workflows do
   defp normalize_strategy(:new), do: {:new, []}
   defp normalize_strategy({action, opts}) when action in [:resume, :new], do: {action, opts}
 
-  # --- Phase-specific dispatchers ---
-
-  def validate_wizard_fields(workflow_type, params) do
-    workflow_module(workflow_type).validate_wizard_fields(params)
-  end
-
-  def validate_and_create_project(workflow_type, params) do
-    workflow_module(workflow_type).validate_and_create_project(params)
-  end
-
-  def initiate_setup(workflow_type, workflow_session, metadata) do
-    workflow_module(workflow_type).initiate_setup(workflow_session, metadata)
-  end
-
-  def retry_setup(workflow_type, workflow_session) do
-    workflow_module(workflow_type).retry_setup(workflow_session)
-  end
-
-  def initialize_ai_conversation(workflow_type, ws, phase_number, opts) do
-    workflow_module(workflow_type).initialize_ai_conversation(ws, phase_number, opts)
-  end
-
-  def send_user_message(workflow_type, ws, ai_session, content) do
-    workflow_module(workflow_type).send_user_message(ws, ai_session, content)
-  end
-
   # --- High-level workflow operations ---
-
-  @doc """
-  Creates a new workflow session from wizard phase data.
-
-  Builds the session record with the next phase set to `phase + 1`,
-  and optionally upserts the initial idea as metadata.
-
-  Returns `{:ok, session}`.
-  """
-  def create_session_from_wizard(workflow_type, phase, data) do
-    session_attrs =
-      %{
-        title: default_title(workflow_type),
-        workflow_type: workflow_type,
-        current_phase: phase + 1,
-        total_phases: total_phases(workflow_type)
-      }
-      |> maybe_put(:project_id, data[:project_id])
-      |> maybe_put(:title_generating, data[:title_generating])
-
-    {:ok, ws} = create_workflow_session(session_attrs)
-
-    if data[:idea] do
-      upsert_metadata(ws.id, "wizard", "idea", %{"text" => data[:idea]})
-    end
-
-    {:ok, ws}
-  end
 
   @doc """
   Advances the workflow session to the next phase.
@@ -291,7 +237,4 @@ defmodule Destila.Workflows do
   end
 
   defdelegate broadcast(result, event), to: Destila.PubSubHelper
-
-  defp maybe_put(map, _key, nil), do: map
-  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 end

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -65,6 +65,14 @@ defmodule Destila.Workflows do
     workflow_module(workflow_type).validate_and_create_project(params)
   end
 
+  def initiate_setup(workflow_type, workflow_session, metadata) do
+    workflow_module(workflow_type).initiate_setup(workflow_session, metadata)
+  end
+
+  def retry_setup(workflow_type, workflow_session) do
+    workflow_module(workflow_type).retry_setup(workflow_session)
+  end
+
   # --- High-level workflow operations ---
 
   @doc """

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -55,6 +55,82 @@ defmodule Destila.Workflows do
   defp normalize_strategy(:new), do: {:new, []}
   defp normalize_strategy({action, opts}) when action in [:resume, :new], do: {action, opts}
 
+  # --- High-level workflow operations ---
+
+  @doc """
+  Creates a new workflow session from wizard phase data.
+
+  Builds the session record with the next phase set to `phase + 1`,
+  and optionally upserts the initial idea as metadata.
+
+  Returns `{:ok, session}`.
+  """
+  def create_session_from_wizard(workflow_type, phase, data) do
+    session_attrs =
+      %{
+        title: default_title(workflow_type),
+        workflow_type: workflow_type,
+        current_phase: phase + 1,
+        total_phases: total_phases(workflow_type)
+      }
+      |> maybe_put(:project_id, data[:project_id])
+      |> maybe_put(:title_generating, data[:title_generating])
+
+    {:ok, ws} = create_workflow_session(session_attrs)
+
+    if data[:idea] do
+      upsert_metadata(ws.id, "wizard", "idea", %{"text" => data[:idea]})
+    end
+
+    {:ok, ws}
+  end
+
+  @doc """
+  Advances the workflow session to the next phase.
+
+  Checks the session strategy for the next phase and stops the ClaudeSession
+  if the strategy is `:new`. Accepts an optional `phase_status` (defaults to `nil`).
+
+  Returns `{:ok, updated_session}` or `{:error, :at_boundary}` if already at the last phase.
+  """
+  def advance_phase(%Session{} = ws, opts \\ []) do
+    next_phase = ws.current_phase + 1
+
+    if next_phase > ws.total_phases do
+      {:error, :at_boundary}
+    else
+      {action, _} = session_strategy(ws.workflow_type, next_phase)
+
+      if action == :new do
+        Destila.AI.ClaudeSession.stop_for_workflow_session(ws.id)
+      end
+
+      phase_status = Keyword.get(opts, :phase_status)
+      update_workflow_session(ws, %{current_phase: next_phase, phase_status: phase_status})
+    end
+  end
+
+  @doc """
+  Marks a workflow session as done.
+
+  Creates a completion message in the AI session (if one exists) and sets `done_at`.
+
+  Returns `{:ok, updated_session}`.
+  """
+  def mark_done(%Session{} = ws) do
+    ai_session = Destila.AI.get_ai_session_for_workflow(ws.id)
+
+    if ai_session do
+      Destila.AI.create_message(ai_session.id, %{
+        role: :system,
+        content: completion_message(ws.workflow_type),
+        phase: ws.current_phase
+      })
+    end
+
+    update_workflow_session(ws, %{done_at: DateTime.utc_now(), phase_status: nil})
+  end
+
   # --- Session CRUD ---
 
   def list_workflow_sessions do
@@ -189,4 +265,7 @@ defmodule Destila.Workflows do
   end
 
   defdelegate broadcast(result, event), to: Destila.PubSubHelper
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 end

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -55,6 +55,16 @@ defmodule Destila.Workflows do
   defp normalize_strategy(:new), do: {:new, []}
   defp normalize_strategy({action, opts}) when action in [:resume, :new], do: {action, opts}
 
+  # --- Phase-specific dispatchers ---
+
+  def validate_wizard_fields(workflow_type, params) do
+    workflow_module(workflow_type).validate_wizard_fields(params)
+  end
+
+  def validate_and_create_project(workflow_type, params) do
+    workflow_module(workflow_type).validate_and_create_project(params)
+  end
+
   # --- High-level workflow operations ---
 
   @doc """

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -13,8 +13,17 @@ defmodule Destila.Workflows do
     prompt_chore_task: Destila.Workflows.PromptChoreTaskWorkflow
   }
 
-  def workflow_module(workflow_type) do
+  def workflow_module(workflow_type) when is_atom(workflow_type) do
     Map.fetch!(@workflow_modules, workflow_type)
+  end
+
+  def workflow_module(workflow_type) when is_binary(workflow_type) do
+    {_type, mod} =
+      Enum.find(@workflow_modules, fn {type, _mod} ->
+        Atom.to_string(type) == workflow_type
+      end) || raise ArgumentError, "unknown workflow type: #{workflow_type}"
+
+    mod
   end
 
   def workflow_types, do: Map.keys(@workflow_modules)

--- a/lib/destila/workflows/prompt_chore_task_workflow.ex
+++ b/lib/destila/workflows/prompt_chore_task_workflow.ex
@@ -83,39 +83,6 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflow do
     if errors == %{}, do: :ok, else: {:error, errors}
   end
 
-  @doc """
-  Validates and creates a project inline from wizard params.
-
-  Returns `{:ok, project}` or `{:error, errors_map}`.
-  """
-  def validate_and_create_project(params) do
-    name = String.trim(params["name"] || "")
-    git_repo_url = non_blank(params["git_repo_url"])
-    local_folder = non_blank(params["local_folder"])
-
-    errors = %{}
-    errors = if name == "", do: Map.put(errors, :name, "Name is required"), else: errors
-
-    errors =
-      if git_repo_url == nil && local_folder == nil,
-        do: Map.put(errors, :location, "Provide at least one"),
-        else: errors
-
-    if errors == %{} do
-      Destila.Projects.create_project(%{
-        name: name,
-        git_repo_url: git_repo_url,
-        local_folder: local_folder
-      })
-    else
-      {:error, errors}
-    end
-  end
-
-  defp non_blank(nil), do: nil
-  defp non_blank(""), do: nil
-  defp non_blank(str), do: str
-
   # --- Setup phase business logic ---
 
   @doc """

--- a/lib/destila/workflows/prompt_chore_task_workflow.ex
+++ b/lib/destila/workflows/prompt_chore_task_workflow.ex
@@ -67,7 +67,7 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflow do
 
   Returns `:ok` or `{:error, errors_map}`.
   """
-  def validate_wizard_fields(%{project_id: project_id, idea: idea}) do
+  def wizard_validate_fields(%{project_id: project_id, idea: idea}) do
     errors = %{}
 
     errors =
@@ -93,9 +93,9 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflow do
 
   Must only be called from a connected LiveView (not static render).
   """
-  def initiate_setup(%{phase_status: :setup}, _metadata), do: :ok
+  def setup_initiate(%{phase_status: :setup}, _metadata), do: :ok
 
-  def initiate_setup(ws, metadata) do
+  def setup_initiate(ws, metadata) do
     Destila.Workflows.update_workflow_session(ws, %{phase_status: :setup})
 
     idea = get_in(metadata, ["idea", "text"]) || ""
@@ -116,7 +116,7 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflow do
   @doc """
   Re-enqueues failed setup workers for retry.
   """
-  def retry_setup(ws) do
+  def setup_retry(ws) do
     if ws.project_id do
       %{"workflow_session_id" => ws.id}
       |> Destila.Workers.SetupWorker.new()
@@ -143,7 +143,7 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflow do
 
   Must only be called from a connected LiveView (not static render).
   """
-  def initialize_ai_conversation(ws, phase_number, opts) do
+  def ai_conversation_initialize(ws, phase_number, opts) do
     ai_session = Destila.AI.get_ai_session_for_workflow(ws.id)
     messages = if ai_session, do: Destila.AI.list_messages(ai_session.id), else: []
     phase_messages = Enum.filter(messages, &(&1.phase == phase_number))
@@ -183,7 +183,7 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflow do
 
   Returns `{:ok, updated_ws}` or `{:error, :generating}` if already generating.
   """
-  def send_user_message(ws, ai_session, content) do
+  def ai_conversation_send_user_message(ws, ai_session, content) do
     if ws.phase_status in [:generating] do
       {:error, :generating}
     else

--- a/lib/destila/workflows/prompt_chore_task_workflow.ex
+++ b/lib/destila/workflows/prompt_chore_task_workflow.ex
@@ -165,6 +165,77 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflow do
     :ok
   end
 
+  # --- AI conversation phase business logic ---
+
+  @doc """
+  Initializes the AI conversation for a phase: creates the AI session if needed,
+  then enqueues the initial AiQueryWorker with the system prompt.
+
+  Returns `{:ok, ai_session}` if initialization occurred, or `:already_initialized`
+  if the phase already has messages or is already generating.
+
+  Must only be called from a connected LiveView (not static render).
+  """
+  def initialize_ai_conversation(ws, phase_number, opts) do
+    ai_session = Destila.AI.get_ai_session_for_workflow(ws.id)
+    messages = if ai_session, do: Destila.AI.list_messages(ai_session.id), else: []
+    phase_messages = Enum.filter(messages, &(&1.phase == phase_number))
+
+    if phase_messages == [] && ws.phase_status != :generating do
+      ai_session =
+        if ai_session do
+          ai_session
+        else
+          metadata = Destila.Workflows.get_metadata(ws.id)
+          worktree_path = get_in(metadata, ["worktree", "worktree_path"])
+
+          {:ok, session} =
+            Destila.AI.get_or_create_ai_session(ws.id, %{worktree_path: worktree_path})
+
+          session
+        end
+
+      system_prompt_fn = Keyword.fetch!(opts, :system_prompt)
+      query = system_prompt_fn.(ws)
+
+      Destila.Workflows.update_workflow_session(ws, %{phase_status: :generating})
+
+      %{"workflow_session_id" => ws.id, "phase" => phase_number, "query" => query}
+      |> Destila.Workers.AiQueryWorker.new()
+      |> Oban.insert()
+
+      {:ok, ai_session}
+    else
+      :already_initialized
+    end
+  end
+
+  @doc """
+  Sends a user message: creates the message record, updates phase_status to
+  :generating, and enqueues an AiQueryWorker.
+
+  Returns `{:ok, updated_ws}` or `{:error, :generating}` if already generating.
+  """
+  def send_user_message(ws, ai_session, content) do
+    if ws.phase_status in [:generating] do
+      {:error, :generating}
+    else
+      Destila.AI.create_message(ai_session.id, %{
+        role: :user,
+        content: content,
+        phase: ws.current_phase
+      })
+
+      {:ok, ws} = Destila.Workflows.update_workflow_session(ws, %{phase_status: :generating})
+
+      %{"workflow_session_id" => ws.id, "phase" => ws.current_phase, "query" => content}
+      |> Destila.Workers.AiQueryWorker.new()
+      |> Oban.insert()
+
+      {:ok, ws}
+    end
+  end
+
   # AI system prompts
 
   @tool_instructions """

--- a/lib/destila/workflows/prompt_chore_task_workflow.ex
+++ b/lib/destila/workflows/prompt_chore_task_workflow.ex
@@ -60,6 +60,62 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflow do
 
   def session_strategy(_phase), do: :resume
 
+  # --- Wizard phase business logic ---
+
+  @doc """
+  Validates wizard fields (project selection and idea).
+
+  Returns `:ok` or `{:error, errors_map}`.
+  """
+  def validate_wizard_fields(%{project_id: project_id, idea: idea}) do
+    errors = %{}
+
+    errors =
+      if is_nil(project_id),
+        do: Map.put(errors, :project, "Please select a project"),
+        else: errors
+
+    errors =
+      if idea == "" or is_nil(idea),
+        do: Map.put(errors, :idea, "Please describe your initial idea"),
+        else: errors
+
+    if errors == %{}, do: :ok, else: {:error, errors}
+  end
+
+  @doc """
+  Validates and creates a project inline from wizard params.
+
+  Returns `{:ok, project}` or `{:error, errors_map}`.
+  """
+  def validate_and_create_project(params) do
+    name = String.trim(params["name"] || "")
+    git_repo_url = non_blank(params["git_repo_url"])
+    local_folder = non_blank(params["local_folder"])
+
+    errors = %{}
+    errors = if name == "", do: Map.put(errors, :name, "Name is required"), else: errors
+
+    errors =
+      if git_repo_url == nil && local_folder == nil,
+        do: Map.put(errors, :location, "Provide at least one"),
+        else: errors
+
+    if errors == %{} do
+      Destila.Projects.create_project(%{
+        name: name,
+        git_repo_url: git_repo_url,
+        local_folder: local_folder
+      })
+    else
+      {:error, errors}
+    end
+  end
+
+  defp non_blank(nil), do: nil
+  defp non_blank(""), do: nil
+  defp non_blank(str), do: str
+
   # AI system prompts
 
   @tool_instructions """

--- a/lib/destila/workflows/prompt_chore_task_workflow.ex
+++ b/lib/destila/workflows/prompt_chore_task_workflow.ex
@@ -116,6 +116,55 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflow do
   defp non_blank(""), do: nil
   defp non_blank(str), do: str
 
+  # --- Setup phase business logic ---
+
+  @doc """
+  Initiates the setup phase: sets phase_status to :setup and enqueues
+  TitleGenerationWorker and (if project has a repo) SetupWorker.
+
+  Idempotent — returns `:ok` immediately if phase_status is already `:setup`.
+
+  Must only be called from a connected LiveView (not static render).
+  """
+  def initiate_setup(%{phase_status: :setup}, _metadata), do: :ok
+
+  def initiate_setup(ws, metadata) do
+    Destila.Workflows.update_workflow_session(ws, %{phase_status: :setup})
+
+    idea = get_in(metadata, ["idea", "text"]) || ""
+
+    %{"workflow_session_id" => ws.id, "idea" => idea}
+    |> Destila.Workers.TitleGenerationWorker.new()
+    |> Oban.insert()
+
+    if ws.project_id do
+      %{"workflow_session_id" => ws.id}
+      |> Destila.Workers.SetupWorker.new()
+      |> Oban.insert()
+    end
+
+    :ok
+  end
+
+  @doc """
+  Re-enqueues failed setup workers for retry.
+  """
+  def retry_setup(ws) do
+    if ws.project_id do
+      %{"workflow_session_id" => ws.id}
+      |> Destila.Workers.SetupWorker.new()
+      |> Oban.insert()
+    end
+
+    if ws.title_generating do
+      %{"workflow_session_id" => ws.id, "idea" => ""}
+      |> Destila.Workers.TitleGenerationWorker.new()
+      |> Oban.insert()
+    end
+
+    :ok
+  end
+
   # AI system prompts
 
   @tool_instructions """

--- a/lib/destila_web/live/phases/ai_conversation_phase.ex
+++ b/lib/destila_web/live/phases/ai_conversation_phase.ex
@@ -86,32 +86,21 @@ defmodule DestilaWeb.Phases.AiConversationPhase do
 
   def handle_event("send_text", %{"content" => content}, socket) when content != "" do
     ws = socket.assigns.workflow_session
+    ai_session = socket.assigns.ai_session
 
-    if ws.phase_status not in [:generating] do
-      ai_session = socket.assigns.ai_session
+    if ai_session do
+      case Workflows.send_user_message(ws.workflow_type, ws, ai_session, content) do
+        {:ok, ws} ->
+          messages = AI.list_messages(ai_session.id)
 
-      if ai_session do
-        AI.create_message(ai_session.id, %{
-          role: :user,
-          content: content,
-          phase: ws.current_phase
-        })
+          {:noreply,
+           socket
+           |> assign(:workflow_session, ws)
+           |> assign(:messages, messages)
+           |> assign(:current_step, compute_current_step(ws, messages))}
 
-        {:ok, ws} = Workflows.update_workflow_session(ws, %{phase_status: :generating})
-
-        %{"workflow_session_id" => ws.id, "phase" => ws.current_phase, "query" => content}
-        |> Destila.Workers.AiQueryWorker.new()
-        |> Oban.insert()
-
-        messages = AI.list_messages(ai_session.id)
-
-        {:noreply,
-         socket
-         |> assign(:workflow_session, ws)
-         |> assign(:messages, messages)
-         |> assign(:current_step, compute_current_step(ws, messages))}
-      else
-        {:noreply, socket}
+        {:error, :generating} ->
+          {:noreply, socket}
       end
     else
       {:noreply, socket}
@@ -198,31 +187,20 @@ defmodule DestilaWeb.Phases.AiConversationPhase do
 
   def handle_event("confirm_advance", _params, socket) do
     ws = socket.assigns.workflow_session
-    next_phase = ws.current_phase + 1
 
-    if next_phase > ws.total_phases do
-      {:noreply, socket}
-    else
-      {action, _} = Workflows.session_strategy(ws.workflow_type, next_phase)
+    case Workflows.advance_phase(ws) do
+      {:ok, updated_ws} ->
+        send(self(), {:phase_advanced, updated_ws.current_phase})
 
-      if action == :new do
-        AI.ClaudeSession.stop_for_workflow_session(ws.id)
-      end
+        {:noreply,
+         socket
+         |> assign(:workflow_session, updated_ws)
+         |> assign(:phase_number, updated_ws.current_phase)
+         |> assign(:question_answers, %{})
+         |> assign(:initialized, false)}
 
-      {:ok, updated_ws} =
-        Workflows.update_workflow_session(ws, %{
-          current_phase: next_phase,
-          phase_status: nil
-        })
-
-      send(self(), {:phase_advanced, next_phase})
-
-      {:noreply,
-       socket
-       |> assign(:workflow_session, updated_ws)
-       |> assign(:phase_number, next_phase)
-       |> assign(:question_answers, %{})
-       |> assign(:initialized, false)}
+      {:error, :at_boundary} ->
+        {:noreply, socket}
     end
   end
 
@@ -233,25 +211,8 @@ defmodule DestilaWeb.Phases.AiConversationPhase do
   end
 
   def handle_event("mark_done", _params, socket) do
-    ws = socket.assigns.workflow_session
-    ai_session = socket.assigns.ai_session
-
-    if ai_session do
-      AI.create_message(ai_session.id, %{
-        role: :system,
-        content: Workflows.completion_message(ws.workflow_type),
-        phase: ws.current_phase
-      })
-    end
-
-    {:ok, ws} =
-      Workflows.update_workflow_session(ws, %{
-        done_at: DateTime.utc_now(),
-        phase_status: nil
-      })
-
+    {:ok, ws} = Workflows.mark_done(socket.assigns.workflow_session)
     send(self(), :workflow_done)
-
     {:noreply, assign(socket, :workflow_session, ws)}
   end
 
@@ -355,36 +316,10 @@ defmodule DestilaWeb.Phases.AiConversationPhase do
      |> assign(:current_step, current_step)}
   end
 
-  defp maybe_initialize_ai(socket, ws, ai_session, phase_number, opts) do
-    messages = if ai_session, do: AI.list_messages(ai_session.id), else: []
-    phase_messages = Enum.filter(messages, &(&1.phase == phase_number))
-
-    if phase_messages == [] && ws.phase_status != :generating do
-      ai_session =
-        if ai_session do
-          ai_session
-        else
-          metadata = Destila.Workflows.get_metadata(ws.id)
-          worktree_path = get_in(metadata, ["worktree", "worktree_path"])
-
-          {:ok, session} =
-            AI.get_or_create_ai_session(ws.id, %{worktree_path: worktree_path})
-
-          session
-        end
-
-      system_prompt_fn = Keyword.fetch!(opts, :system_prompt)
-      query = system_prompt_fn.(ws)
-
-      Workflows.update_workflow_session(ws, %{phase_status: :generating})
-
-      %{"workflow_session_id" => ws.id, "phase" => phase_number, "query" => query}
-      |> Destila.Workers.AiQueryWorker.new()
-      |> Oban.insert()
-
-      assign(socket, :ai_session, ai_session)
-    else
-      socket
+  defp maybe_initialize_ai(socket, ws, _ai_session, phase_number, opts) do
+    case Workflows.initialize_ai_conversation(ws.workflow_type, ws, phase_number, opts) do
+      {:ok, ai_session} -> assign(socket, :ai_session, ai_session)
+      :already_initialized -> socket
     end
   end
 

--- a/lib/destila_web/live/phases/ai_conversation_phase.ex
+++ b/lib/destila_web/live/phases/ai_conversation_phase.ex
@@ -289,6 +289,7 @@ defmodule DestilaWeb.Phases.AiConversationPhase do
       <div
         :if={
           !@current_step.completed &&
+            @current_step.input_type not in [:single_select, :multi_select, :questions] &&
             @workflow_session.phase_status not in [:advance_suggested]
         }
         class="max-w-2xl mx-auto w-full px-6 pb-4"

--- a/lib/destila_web/live/phases/ai_conversation_phase.ex
+++ b/lib/destila_web/live/phases/ai_conversation_phase.ex
@@ -91,7 +91,7 @@ defmodule DestilaWeb.Phases.AiConversationPhase do
     workflow = socket.assigns.workflow
 
     if ai_session do
-      case workflow.send_user_message(ws, ai_session, content) do
+      case workflow.ai_conversation_send_user_message(ws, ai_session, content) do
         {:ok, ws} ->
           messages = AI.list_messages(ai_session.id)
 
@@ -321,7 +321,7 @@ defmodule DestilaWeb.Phases.AiConversationPhase do
   defp maybe_initialize_ai(socket, ws, _ai_session, phase_number, opts) do
     workflow = socket.assigns.workflow
 
-    case workflow.initialize_ai_conversation(ws, phase_number, opts) do
+    case workflow.ai_conversation_initialize(ws, phase_number, opts) do
       {:ok, ai_session} -> assign(socket, :ai_session, ai_session)
       :already_initialized -> socket
     end

--- a/lib/destila_web/live/phases/ai_conversation_phase.ex
+++ b/lib/destila_web/live/phases/ai_conversation_phase.ex
@@ -23,7 +23,6 @@ defmodule DestilaWeb.Phases.AiConversationPhase do
 
   alias Destila.AI
   alias Destila.Workflows
-  alias Destila.Workflows
 
   def mount(socket) do
     if connected?(socket) do
@@ -38,6 +37,7 @@ defmodule DestilaWeb.Phases.AiConversationPhase do
 
   def update(assigns, socket) do
     ws = assigns.workflow_session
+    workflow = assigns.workflow
     phase_number = assigns.phase_number
     opts = assigns.opts
 
@@ -48,6 +48,7 @@ defmodule DestilaWeb.Phases.AiConversationPhase do
     socket =
       socket
       |> assign(:workflow_session, ws)
+      |> assign(:workflow, workflow)
       |> assign(:phase_number, phase_number)
       |> assign(:opts, opts)
       |> assign(:ai_session, ai_session)
@@ -87,9 +88,10 @@ defmodule DestilaWeb.Phases.AiConversationPhase do
   def handle_event("send_text", %{"content" => content}, socket) when content != "" do
     ws = socket.assigns.workflow_session
     ai_session = socket.assigns.ai_session
+    workflow = socket.assigns.workflow
 
     if ai_session do
-      case Workflows.send_user_message(ws.workflow_type, ws, ai_session, content) do
+      case workflow.send_user_message(ws, ai_session, content) do
         {:ok, ws} ->
           messages = AI.list_messages(ai_session.id)
 
@@ -317,7 +319,9 @@ defmodule DestilaWeb.Phases.AiConversationPhase do
   end
 
   defp maybe_initialize_ai(socket, ws, _ai_session, phase_number, opts) do
-    case Workflows.initialize_ai_conversation(ws.workflow_type, ws, phase_number, opts) do
+    workflow = socket.assigns.workflow
+
+    case workflow.initialize_ai_conversation(ws, phase_number, opts) do
       {:ok, ai_session} -> assign(socket, :ai_session, ai_session)
       :already_initialized -> socket
     end

--- a/lib/destila_web/live/phases/setup_phase.ex
+++ b/lib/destila_web/live/phases/setup_phase.ex
@@ -10,11 +10,12 @@ defmodule DestilaWeb.Phases.SetupPhase do
 
   def update(assigns, socket) do
     ws = assigns.workflow_session
+    workflow = assigns.workflow
     metadata = assigns[:metadata] || %{}
     steps = build_steps(ws, metadata)
 
     if connected?(socket) && ws do
-      Destila.Workflows.initiate_setup(ws.workflow_type, ws, metadata)
+      workflow.initiate_setup(ws, metadata)
     end
 
     if all_completed?(steps) do
@@ -24,6 +25,7 @@ defmodule DestilaWeb.Phases.SetupPhase do
     {:ok,
      socket
      |> assign(:workflow_session, ws)
+     |> assign(:workflow, workflow)
      |> assign(:phase_number, assigns.phase_number)
      |> assign(:steps, steps)
      |> assign(:all_done, all_completed?(steps))
@@ -31,8 +33,7 @@ defmodule DestilaWeb.Phases.SetupPhase do
   end
 
   def handle_event("retry_setup", _params, socket) do
-    ws = socket.assigns.workflow_session
-    Destila.Workflows.retry_setup(ws.workflow_type, ws)
+    socket.assigns.workflow.retry_setup(socket.assigns.workflow_session)
     {:noreply, socket}
   end
 

--- a/lib/destila_web/live/phases/setup_phase.ex
+++ b/lib/destila_web/live/phases/setup_phase.ex
@@ -15,7 +15,7 @@ defmodule DestilaWeb.Phases.SetupPhase do
     steps = build_steps(ws, metadata)
 
     if connected?(socket) && ws do
-      workflow.initiate_setup(ws, metadata)
+      workflow.setup_initiate(ws, metadata)
     end
 
     if all_completed?(steps) do
@@ -32,8 +32,8 @@ defmodule DestilaWeb.Phases.SetupPhase do
      |> assign(:has_failure, has_failure?(steps))}
   end
 
-  def handle_event("retry_setup", _params, socket) do
-    socket.assigns.workflow.retry_setup(socket.assigns.workflow_session)
+  def handle_event("setup_retry", _params, socket) do
+    socket.assigns.workflow.setup_retry(socket.assigns.workflow_session)
     {:noreply, socket}
   end
 
@@ -71,7 +71,7 @@ defmodule DestilaWeb.Phases.SetupPhase do
       </span>
       <button
         :if={@step.status == "failed"}
-        phx-click="retry_setup"
+        phx-click="setup_retry"
         phx-target={@myself}
         class="btn btn-xs btn-outline btn-error"
       >

--- a/lib/destila_web/live/phases/setup_phase.ex
+++ b/lib/destila_web/live/phases/setup_phase.ex
@@ -8,6 +8,8 @@ defmodule DestilaWeb.Phases.SetupPhase do
 
   use DestilaWeb, :live_component
 
+  def metadata_phase_name, do: "setup"
+
   def update(assigns, socket) do
     ws = assigns.workflow_session
     workflow = assigns.workflow

--- a/lib/destila_web/live/phases/setup_phase.ex
+++ b/lib/destila_web/live/phases/setup_phase.ex
@@ -14,7 +14,7 @@ defmodule DestilaWeb.Phases.SetupPhase do
     steps = build_steps(ws, metadata)
 
     if connected?(socket) && ws do
-      maybe_start_setup(ws, metadata)
+      Destila.Workflows.initiate_setup(ws.workflow_type, ws, metadata)
     end
 
     if all_completed?(steps) do
@@ -32,19 +32,7 @@ defmodule DestilaWeb.Phases.SetupPhase do
 
   def handle_event("retry_setup", _params, socket) do
     ws = socket.assigns.workflow_session
-
-    if ws.project_id do
-      %{"workflow_session_id" => ws.id}
-      |> Destila.Workers.SetupWorker.new()
-      |> Oban.insert()
-    end
-
-    if ws.title_generating do
-      %{"workflow_session_id" => ws.id, "idea" => ""}
-      |> Destila.Workers.TitleGenerationWorker.new()
-      |> Oban.insert()
-    end
-
+    Destila.Workflows.retry_setup(ws.workflow_type, ws)
     {:noreply, socket}
   end
 
@@ -90,24 +78,6 @@ defmodule DestilaWeb.Phases.SetupPhase do
       </button>
     </div>
     """
-  end
-
-  defp maybe_start_setup(%{phase_status: :setup}, _metadata), do: :ok
-
-  defp maybe_start_setup(ws, metadata) do
-    Destila.Workflows.update_workflow_session(ws, %{phase_status: :setup})
-
-    idea = get_in(metadata, ["idea", "text"]) || ""
-
-    %{"workflow_session_id" => ws.id, "idea" => idea}
-    |> Destila.Workers.TitleGenerationWorker.new()
-    |> Oban.insert()
-
-    if ws.project_id do
-      %{"workflow_session_id" => ws.id}
-      |> Destila.Workers.SetupWorker.new()
-      |> Oban.insert()
-    end
   end
 
   defp build_steps(ws, metadata) do

--- a/lib/destila_web/live/phases/wizard_phase.ex
+++ b/lib/destila_web/live/phases/wizard_phase.ex
@@ -25,7 +25,8 @@ defmodule DestilaWeb.Phases.WizardPhase do
      assign(socket,
        opts: assigns.opts,
        phase_number: assigns.phase_number,
-       workflow_type: assigns.workflow_type
+       workflow_type: assigns.workflow_type,
+       workflow: assigns.workflow
      )}
   end
 
@@ -44,20 +45,37 @@ defmodule DestilaWeb.Phases.WizardPhase do
   end
 
   def handle_event("create_and_select_project", params, socket) do
-    case Destila.Workflows.validate_and_create_project(socket.assigns.workflow_type, params) do
-      {:ok, project} ->
-        {:noreply,
-         socket
-         |> assign(:project_id, project.id)
-         |> assign(:projects, Destila.Projects.list_projects())
-         |> assign(:project_step, :select)
-         |> assign(:errors, %{})}
+    name = String.trim(params["name"] || "")
+    git_repo_url = non_blank(params["git_repo_url"])
+    local_folder = non_blank(params["local_folder"])
 
-      {:error, errors} ->
-        {:noreply,
-         socket
-         |> assign(:project_form, to_form(params))
-         |> assign(:errors, errors)}
+    errors = %{}
+    errors = if name == "", do: Map.put(errors, :name, "Name is required"), else: errors
+
+    errors =
+      if git_repo_url == nil && local_folder == nil,
+        do: Map.put(errors, :location, "Provide at least one"),
+        else: errors
+
+    if errors == %{} do
+      {:ok, project} =
+        Destila.Projects.create_project(%{
+          name: name,
+          git_repo_url: git_repo_url,
+          local_folder: local_folder
+        })
+
+      {:noreply,
+       socket
+       |> assign(:project_id, project.id)
+       |> assign(:projects, Destila.Projects.list_projects())
+       |> assign(:project_step, :select)
+       |> assign(:errors, %{})}
+    else
+      {:noreply,
+       socket
+       |> assign(:project_form, to_form(params))
+       |> assign(:errors, errors)}
     end
   end
 
@@ -71,19 +89,29 @@ defmodule DestilaWeb.Phases.WizardPhase do
   end
 
   def handle_event("start_workflow", %{"initial_idea" => idea}, socket) when idea != "" do
-    case Destila.Workflows.validate_wizard_fields(socket.assigns.workflow_type, %{
+    workflow = socket.assigns.workflow
+
+    case workflow.validate_wizard_fields(%{
            project_id: socket.assigns.project_id,
            idea: idea
          }) do
       :ok ->
+        session_attrs = %{
+          title: workflow.default_title(),
+          workflow_type: socket.assigns.workflow_type,
+          current_phase: 2,
+          total_phases: workflow.total_phases(),
+          project_id: socket.assigns.project_id,
+          title_generating: true
+        }
+
         send(
           self(),
           {:phase_complete, socket.assigns.phase_number,
            %{
              action: :session_create,
-             project_id: socket.assigns.project_id,
-             idea: idea,
-             title_generating: true
+             session_attrs: session_attrs,
+             idea: idea
            }}
         )
 
@@ -319,4 +347,8 @@ defmodule DestilaWeb.Phases.WizardPhase do
     </div>
     """
   end
+
+  defp non_blank(nil), do: nil
+  defp non_blank(""), do: nil
+  defp non_blank(str), do: str
 end

--- a/lib/destila_web/live/phases/wizard_phase.ex
+++ b/lib/destila_web/live/phases/wizard_phase.ex
@@ -96,21 +96,12 @@ defmodule DestilaWeb.Phases.WizardPhase do
            idea: idea
          }) do
       :ok ->
-        session_attrs = %{
-          title: workflow.default_title(),
-          workflow_type: socket.assigns.workflow_type,
-          current_phase: 2,
-          total_phases: workflow.total_phases(),
-          project_id: socket.assigns.project_id,
-          title_generating: true
-        }
-
         send(
           self(),
           {:phase_complete, socket.assigns.phase_number,
            %{
              action: :session_create,
-             session_attrs: session_attrs,
+             project_id: socket.assigns.project_id,
              idea: idea
            }}
         )

--- a/lib/destila_web/live/phases/wizard_phase.ex
+++ b/lib/destila_web/live/phases/wizard_phase.ex
@@ -101,8 +101,8 @@ defmodule DestilaWeb.Phases.WizardPhase do
           {:phase_complete, socket.assigns.phase_number,
            %{
              action: :session_create,
-             project_id: socket.assigns.project_id,
-             idea: idea
+             session_attrs: %{project_id: socket.assigns.project_id},
+             metadata: %{idea: %{text: idea}}
            }}
         )
 

--- a/lib/destila_web/live/phases/wizard_phase.ex
+++ b/lib/destila_web/live/phases/wizard_phase.ex
@@ -21,7 +21,12 @@ defmodule DestilaWeb.Phases.WizardPhase do
   end
 
   def update(assigns, socket) do
-    {:ok, assign(socket, opts: assigns.opts, phase_number: assigns.phase_number)}
+    {:ok,
+     assign(socket,
+       opts: assigns.opts,
+       phase_number: assigns.phase_number,
+       workflow_type: assigns.workflow_type
+     )}
   end
 
   # --- Event handlers ---
@@ -39,39 +44,20 @@ defmodule DestilaWeb.Phases.WizardPhase do
   end
 
   def handle_event("create_and_select_project", params, socket) do
-    name = String.trim(params["name"] || "")
-    git_repo_url = non_blank(params["git_repo_url"])
-    local_folder = non_blank(params["local_folder"])
+    case Destila.Workflows.validate_and_create_project(socket.assigns.workflow_type, params) do
+      {:ok, project} ->
+        {:noreply,
+         socket
+         |> assign(:project_id, project.id)
+         |> assign(:projects, Destila.Projects.list_projects())
+         |> assign(:project_step, :select)
+         |> assign(:errors, %{})}
 
-    errors = %{}
-    errors = if name == "", do: Map.put(errors, :name, "Name is required"), else: errors
-
-    errors =
-      if git_repo_url == nil && local_folder == nil do
-        Map.put(errors, :location, "Provide at least one")
-      else
-        errors
-      end
-
-    if errors == %{} do
-      {:ok, project} =
-        Destila.Projects.create_project(%{
-          name: name,
-          git_repo_url: git_repo_url,
-          local_folder: local_folder
-        })
-
-      {:noreply,
-       socket
-       |> assign(:project_id, project.id)
-       |> assign(:projects, Destila.Projects.list_projects())
-       |> assign(:project_step, :select)
-       |> assign(:errors, %{})}
-    else
-      {:noreply,
-       socket
-       |> assign(:project_form, to_form(params))
-       |> assign(:errors, errors)}
+      {:error, errors} ->
+        {:noreply,
+         socket
+         |> assign(:project_form, to_form(params))
+         |> assign(:errors, errors)}
     end
   end
 
@@ -85,28 +71,26 @@ defmodule DestilaWeb.Phases.WizardPhase do
   end
 
   def handle_event("start_workflow", %{"initial_idea" => idea}, socket) when idea != "" do
-    errors =
-      if socket.assigns.project_id == nil do
-        %{project: "Please select a project"}
-      else
-        %{}
-      end
-
-    if errors == %{} do
-      send(
-        self(),
-        {:phase_complete, socket.assigns.phase_number,
-         %{
-           action: :session_create,
+    case Destila.Workflows.validate_wizard_fields(socket.assigns.workflow_type, %{
            project_id: socket.assigns.project_id,
-           idea: idea,
-           title_generating: true
-         }}
-      )
+           idea: idea
+         }) do
+      :ok ->
+        send(
+          self(),
+          {:phase_complete, socket.assigns.phase_number,
+           %{
+             action: :session_create,
+             project_id: socket.assigns.project_id,
+             idea: idea,
+             title_generating: true
+           }}
+        )
 
-      {:noreply, socket}
-    else
-      {:noreply, assign(socket, :errors, errors)}
+        {:noreply, socket}
+
+      {:error, errors} ->
+        {:noreply, assign(socket, :errors, errors)}
     end
   end
 
@@ -335,8 +319,4 @@ defmodule DestilaWeb.Phases.WizardPhase do
     </div>
     """
   end
-
-  defp non_blank(nil), do: nil
-  defp non_blank(""), do: nil
-  defp non_blank(str), do: str
 end

--- a/lib/destila_web/live/phases/wizard_phase.ex
+++ b/lib/destila_web/live/phases/wizard_phase.ex
@@ -6,6 +6,8 @@ defmodule DestilaWeb.Phases.WizardPhase do
 
   use DestilaWeb, :live_component
 
+  def metadata_phase_name, do: "wizard"
+
   def mount(socket) do
     {:ok,
      socket
@@ -58,19 +60,25 @@ defmodule DestilaWeb.Phases.WizardPhase do
         else: errors
 
     if errors == %{} do
-      {:ok, project} =
-        Destila.Projects.create_project(%{
-          name: name,
-          git_repo_url: git_repo_url,
-          local_folder: local_folder
-        })
+      case Destila.Projects.create_project(%{
+             name: name,
+             git_repo_url: git_repo_url,
+             local_folder: local_folder
+           }) do
+        {:ok, project} ->
+          {:noreply,
+           socket
+           |> assign(:project_id, project.id)
+           |> assign(:projects, Destila.Projects.list_projects())
+           |> assign(:project_step, :select)
+           |> assign(:errors, %{})}
 
-      {:noreply,
-       socket
-       |> assign(:project_id, project.id)
-       |> assign(:projects, Destila.Projects.list_projects())
-       |> assign(:project_step, :select)
-       |> assign(:errors, %{})}
+        {:error, _changeset} ->
+          {:noreply,
+           socket
+           |> assign(:project_form, to_form(params))
+           |> put_flash(:error, "Failed to create project")}
+      end
     else
       {:noreply,
        socket

--- a/lib/destila_web/live/phases/wizard_phase.ex
+++ b/lib/destila_web/live/phases/wizard_phase.ex
@@ -91,7 +91,7 @@ defmodule DestilaWeb.Phases.WizardPhase do
   def handle_event("start_workflow", %{"initial_idea" => idea}, socket) when idea != "" do
     workflow = socket.assigns.workflow
 
-    case workflow.validate_wizard_fields(%{
+    case workflow.wizard_validate_fields(%{
            project_id: socket.assigns.project_id,
            idea: idea
          }) do

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -150,7 +150,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
         %{
           title: workflow.default_title(),
           workflow_type: socket.assigns.workflow_type,
-          current_phase: 2,
+          current_phase: socket.assigns.current_phase + 1,
           total_phases: workflow.total_phases(),
           title_generating: true
         },

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -42,12 +42,14 @@ defmodule DestilaWeb.WorkflowRunnerLive do
 
   defp mount_workflow(workflow_type_str, socket) do
     workflow_type = String.to_existing_atom(workflow_type_str)
-    phases = Workflows.phases(workflow_type)
+    workflow = Workflows.workflow_module(workflow_type)
+    phases = workflow.phases()
 
     {:ok,
      socket
      |> assign(:view, :running)
      |> assign(:workflow_type, workflow_type)
+     |> assign(:workflow, workflow)
      |> assign(:workflow_session, nil)
      |> assign(:project, nil)
      |> assign(:phases, phases)
@@ -55,7 +57,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
      |> assign(:total_phases, length(phases))
      |> assign(:editing_title, false)
      |> assign(:metadata, %{})
-     |> assign(:page_title, Workflows.default_title(workflow_type))}
+     |> assign(:page_title, workflow.default_title())}
   end
 
   defp mount_session(id, socket) do
@@ -67,7 +69,8 @@ defmodule DestilaWeb.WorkflowRunnerLive do
       end
 
       workflow_type = workflow_session.workflow_type
-      phases = Workflows.phases(workflow_type)
+      workflow = Workflows.workflow_module(workflow_type)
+      phases = workflow.phases()
 
       project =
         if workflow_session.project_id,
@@ -77,6 +80,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
        socket
        |> assign(:view, :running)
        |> assign(:workflow_type, workflow_type)
+       |> assign(:workflow, workflow)
        |> assign(:workflow_session, workflow_session)
        |> assign(:project, project)
        |> assign(:phases, phases)
@@ -138,8 +142,13 @@ defmodule DestilaWeb.WorkflowRunnerLive do
   # --- Phase signals from LiveComponents ---
 
   # Phase complete with session creation request
-  def handle_info({:phase_complete, phase, %{action: :session_create} = data}, socket) do
-    {:ok, ws} = Workflows.create_session_from_wizard(socket.assigns.workflow_type, phase, data)
+  def handle_info({:phase_complete, _phase, %{action: :session_create} = data}, socket) do
+    {:ok, ws} = Workflows.create_workflow_session(data[:session_attrs])
+
+    if data[:idea] do
+      Workflows.upsert_metadata(ws.id, "wizard", "idea", %{"text" => data[:idea]})
+    end
+
     {:noreply, push_navigate(socket, to: ~p"/sessions/#{ws.id}")}
   end
 
@@ -410,6 +419,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
           id={"phase-#{@current_phase}"}
           workflow_session={@workflow_session}
           workflow_type={@workflow_type}
+          workflow={@workflow}
           metadata={@metadata}
           opts={@phase_opts}
           phase_number={@current_phase}

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -131,23 +131,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
   end
 
   def handle_event("mark_done", _params, socket) do
-    ws = socket.assigns.workflow_session
-    ai_session = Destila.AI.get_ai_session_for_workflow(ws.id)
-
-    if ai_session do
-      Destila.AI.create_message(ai_session.id, %{
-        role: :system,
-        content: Workflows.completion_message(ws.workflow_type),
-        phase: ws.current_phase
-      })
-    end
-
-    {:ok, ws} =
-      Workflows.update_workflow_session(ws, %{
-        done_at: DateTime.utc_now(),
-        phase_status: nil
-      })
-
+    {:ok, ws} = Workflows.mark_done(socket.assigns.workflow_session)
     {:noreply, assign(socket, :workflow_session, ws)}
   end
 
@@ -155,36 +139,13 @@ defmodule DestilaWeb.WorkflowRunnerLive do
 
   # Phase complete with session creation request
   def handle_info({:phase_complete, phase, %{action: :session_create} = data}, socket) do
-    workflow_type = socket.assigns.workflow_type
-
-    session_attrs =
-      %{
-        title: Workflows.default_title(workflow_type),
-        workflow_type: workflow_type,
-        current_phase: phase + 1,
-        total_phases: Workflows.total_phases(workflow_type)
-      }
-      |> maybe_put(:project_id, data[:project_id])
-      |> maybe_put(:title_generating, data[:title_generating])
-
-    {:ok, ws} = Workflows.create_workflow_session(session_attrs)
-
-    if data[:idea] do
-      Workflows.upsert_metadata(ws.id, "wizard", "idea", %{"text" => data[:idea]})
-    end
-
+    {:ok, ws} = Workflows.create_session_from_wizard(socket.assigns.workflow_type, phase, data)
     {:noreply, push_navigate(socket, to: ~p"/sessions/#{ws.id}")}
   end
 
   # Phase complete — advance to next phase
-  def handle_info({:phase_complete, phase, _data}, socket) do
-    ws = socket.assigns.workflow_session
-
-    {:ok, ws} =
-      Workflows.update_workflow_session(ws, %{
-        current_phase: phase + 1,
-        phase_status: nil
-      })
+  def handle_info({:phase_complete, _phase, _data}, socket) do
+    {:ok, ws} = Workflows.advance_phase(socket.assigns.workflow_session)
 
     {:noreply,
      socket
@@ -463,7 +424,4 @@ defmodule DestilaWeb.WorkflowRunnerLive do
         """
     end
   end
-
-  defp maybe_put(map, _key, nil), do: map
-  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 end

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -160,7 +160,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
     {:ok, ws} = Workflows.create_workflow_session(session_attrs)
 
     for {key, value} <- data[:metadata] || %{} do
-      Workflows.upsert_metadata(ws.id, "wizard", to_string(key), stringify_metadata(value))
+      Workflows.upsert_metadata(ws.id, "wizard", to_string(key), value)
     end
 
     {:noreply, push_navigate(socket, to: ~p"/sessions/#{ws.id}")}
@@ -448,10 +448,4 @@ defmodule DestilaWeb.WorkflowRunnerLive do
         """
     end
   end
-
-  defp stringify_metadata(value) when is_map(value) do
-    Map.new(value, fn {k, v} -> {to_string(k), v} end)
-  end
-
-  defp stringify_metadata(value), do: value
 end

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -143,7 +143,17 @@ defmodule DestilaWeb.WorkflowRunnerLive do
 
   # Phase complete with session creation request
   def handle_info({:phase_complete, _phase, %{action: :session_create} = data}, socket) do
-    {:ok, ws} = Workflows.create_workflow_session(data[:session_attrs])
+    workflow = socket.assigns.workflow
+
+    {:ok, ws} =
+      Workflows.create_workflow_session(%{
+        title: workflow.default_title(),
+        workflow_type: socket.assigns.workflow_type,
+        current_phase: 2,
+        total_phases: workflow.total_phases(),
+        project_id: data[:project_id],
+        title_generating: true
+      })
 
     if data[:idea] do
       Workflows.upsert_metadata(ws.id, "wizard", "idea", %{"text" => data[:idea]})

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -144,6 +144,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
   # Phase complete with session creation request
   def handle_info({:phase_complete, _phase, %{action: :session_create} = data}, socket) do
     workflow = socket.assigns.workflow
+    {phase_module, _opts} = Enum.at(socket.assigns.phases, socket.assigns.current_phase - 1)
 
     session_attrs =
       Map.merge(
@@ -160,7 +161,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
     {:ok, ws} = Workflows.create_workflow_session(session_attrs)
 
     for {key, value} <- data[:metadata] || %{} do
-      Workflows.upsert_metadata(ws.id, "wizard", to_string(key), value)
+      Workflows.upsert_metadata(ws.id, phase_module.metadata_phase_name(), to_string(key), value)
     end
 
     {:noreply, push_navigate(socket, to: ~p"/sessions/#{ws.id}")}
@@ -324,7 +325,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
                   </form>
                 <% else %>
                   <h1 class="text-lg font-bold truncate">
-                    {Workflows.default_title(@workflow_type)}
+                    {@workflow.default_title()}
                   </h1>
                 <% end %>
 
@@ -353,10 +354,10 @@ defmodule DestilaWeb.WorkflowRunnerLive do
                 <span class="text-xs text-base-content/40">
                   Phase {@current_phase}/{@total_phases}
                   <span
-                    :if={Workflows.phase_name(@workflow_type, @current_phase)}
+                    :if={@workflow.phase_name(@current_phase)}
                     class="hidden sm:inline"
                   >
-                    — {Workflows.phase_name(@workflow_type, @current_phase)}
+                    — {@workflow.phase_name(@current_phase)}
                   </span>
                 </span>
               </div>

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -41,8 +41,8 @@ defmodule DestilaWeb.WorkflowRunnerLive do
   end
 
   defp mount_workflow(workflow_type_str, socket) do
+    workflow = Workflows.workflow_module(workflow_type_str)
     workflow_type = String.to_existing_atom(workflow_type_str)
-    workflow = Workflows.workflow_module(workflow_type)
     phases = workflow.phases()
 
     {:ok,

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -145,18 +145,22 @@ defmodule DestilaWeb.WorkflowRunnerLive do
   def handle_info({:phase_complete, _phase, %{action: :session_create} = data}, socket) do
     workflow = socket.assigns.workflow
 
-    {:ok, ws} =
-      Workflows.create_workflow_session(%{
-        title: workflow.default_title(),
-        workflow_type: socket.assigns.workflow_type,
-        current_phase: 2,
-        total_phases: workflow.total_phases(),
-        project_id: data[:project_id],
-        title_generating: true
-      })
+    session_attrs =
+      Map.merge(
+        %{
+          title: workflow.default_title(),
+          workflow_type: socket.assigns.workflow_type,
+          current_phase: 2,
+          total_phases: workflow.total_phases(),
+          title_generating: true
+        },
+        data[:session_attrs] || %{}
+      )
 
-    if data[:idea] do
-      Workflows.upsert_metadata(ws.id, "wizard", "idea", %{"text" => data[:idea]})
+    {:ok, ws} = Workflows.create_workflow_session(session_attrs)
+
+    for {key, value} <- data[:metadata] || %{} do
+      Workflows.upsert_metadata(ws.id, "wizard", to_string(key), stringify_metadata(value))
     end
 
     {:noreply, push_navigate(socket, to: ~p"/sessions/#{ws.id}")}
@@ -444,4 +448,10 @@ defmodule DestilaWeb.WorkflowRunnerLive do
         """
     end
   end
+
+  defp stringify_metadata(value) when is_map(value) do
+    Map.new(value, fn {k, v} -> {to_string(k), v} end)
+  end
+
+  defp stringify_metadata(value), do: value
 end

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -41,8 +41,8 @@ defmodule DestilaWeb.WorkflowRunnerLive do
   end
 
   defp mount_workflow(workflow_type_str, socket) do
-    workflow = Workflows.workflow_module(workflow_type_str)
-    workflow_type = String.to_existing_atom(workflow_type_str)
+    workflow_type = Workflows.workflow_type_from_string(workflow_type_str)
+    workflow = Workflows.workflow_module(workflow_type)
     phases = workflow.phases()
 
     {:ok,

--- a/test/destila/workflows/prompt_chore_task_workflow_test.exs
+++ b/test/destila/workflows/prompt_chore_task_workflow_test.exs
@@ -175,4 +175,36 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflowTest do
       refute_enqueued(worker: Destila.Workers.TitleGenerationWorker)
     end
   end
+
+  describe "send_user_message/3" do
+    setup do
+      ClaudeCode.Test.set_mode_to_shared()
+
+      ClaudeCode.Test.stub(ClaudeCode, fn _query, _opts ->
+        [ClaudeCode.Test.text("AI response")]
+      end)
+
+      :ok
+    end
+
+    test "creates user message and updates status" do
+      ws = create_session(%{phase_status: :conversing})
+      {:ok, ai_session} = Destila.AI.get_or_create_ai_session(ws.id)
+
+      {:ok, updated_ws} = PromptChoreTaskWorkflow.send_user_message(ws, ai_session, "Hello AI")
+
+      assert updated_ws.phase_status == :generating
+      messages = Destila.AI.list_messages(ai_session.id)
+      user_messages = Enum.filter(messages, &(&1.role == :user))
+      assert length(user_messages) >= 1
+    end
+
+    test "returns error when already generating" do
+      ws = create_session(%{phase_status: :generating})
+      {:ok, ai_session} = Destila.AI.get_or_create_ai_session(ws.id)
+
+      assert {:error, :generating} =
+               PromptChoreTaskWorkflow.send_user_message(ws, ai_session, "Hello")
+    end
+  end
 end

--- a/test/destila/workflows/prompt_chore_task_workflow_test.exs
+++ b/test/destila/workflows/prompt_chore_task_workflow_test.exs
@@ -16,10 +16,10 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflowTest do
     ws
   end
 
-  describe "validate_wizard_fields/1" do
+  describe "wizard_validate_fields/1" do
     test "returns :ok when both fields are valid" do
       assert :ok =
-               PromptChoreTaskWorkflow.validate_wizard_fields(%{
+               PromptChoreTaskWorkflow.wizard_validate_fields(%{
                  project_id: "some-id",
                  idea: "Fix the bug"
                })
@@ -27,7 +27,7 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflowTest do
 
     test "returns error when project_id is nil" do
       assert {:error, errors} =
-               PromptChoreTaskWorkflow.validate_wizard_fields(%{
+               PromptChoreTaskWorkflow.wizard_validate_fields(%{
                  project_id: nil,
                  idea: "Fix the bug"
                })
@@ -38,7 +38,7 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflowTest do
 
     test "returns error when idea is empty" do
       assert {:error, errors} =
-               PromptChoreTaskWorkflow.validate_wizard_fields(%{
+               PromptChoreTaskWorkflow.wizard_validate_fields(%{
                  project_id: "some-id",
                  idea: ""
                })
@@ -49,7 +49,7 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflowTest do
 
     test "returns error when idea is nil" do
       assert {:error, errors} =
-               PromptChoreTaskWorkflow.validate_wizard_fields(%{
+               PromptChoreTaskWorkflow.wizard_validate_fields(%{
                  project_id: "some-id",
                  idea: nil
                })
@@ -59,7 +59,7 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflowTest do
 
     test "returns both errors when both fields are invalid" do
       assert {:error, errors} =
-               PromptChoreTaskWorkflow.validate_wizard_fields(%{
+               PromptChoreTaskWorkflow.wizard_validate_fields(%{
                  project_id: nil,
                  idea: ""
                })
@@ -69,7 +69,7 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflowTest do
     end
   end
 
-  describe "initiate_setup/2" do
+  describe "setup_initiate/2" do
     setup do
       ClaudeCode.Test.stub(ClaudeCode, fn _query, _opts ->
         [ClaudeCode.Test.text("Generated Title")]
@@ -80,12 +80,12 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflowTest do
 
     test "is idempotent when phase_status is already :setup" do
       ws = create_session(%{phase_status: :setup})
-      assert :ok = PromptChoreTaskWorkflow.initiate_setup(ws, %{})
+      assert :ok = PromptChoreTaskWorkflow.setup_initiate(ws, %{})
     end
 
     test "sets phase_status to :setup" do
       ws = create_session(%{phase_status: nil})
-      assert :ok = PromptChoreTaskWorkflow.initiate_setup(ws, %{})
+      assert :ok = PromptChoreTaskWorkflow.setup_initiate(ws, %{})
 
       updated = Workflows.get_workflow_session!(ws.id)
       assert updated.phase_status == :setup
@@ -93,13 +93,13 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflowTest do
 
     test "does not enqueue setup worker when no project" do
       ws = create_session(%{phase_status: nil, project_id: nil})
-      PromptChoreTaskWorkflow.initiate_setup(ws, %{})
+      PromptChoreTaskWorkflow.setup_initiate(ws, %{})
 
       refute_enqueued(worker: Destila.Workers.SetupWorker)
     end
   end
 
-  describe "retry_setup/1" do
+  describe "setup_retry/1" do
     setup do
       ClaudeCode.Test.stub(ClaudeCode, fn _query, _opts ->
         [ClaudeCode.Test.text("Generated Title")]
@@ -110,14 +110,14 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflowTest do
 
     test "does not enqueue workers when not needed" do
       ws = create_session(%{project_id: nil, title_generating: false})
-      PromptChoreTaskWorkflow.retry_setup(ws)
+      PromptChoreTaskWorkflow.setup_retry(ws)
 
       refute_enqueued(worker: Destila.Workers.SetupWorker)
       refute_enqueued(worker: Destila.Workers.TitleGenerationWorker)
     end
   end
 
-  describe "send_user_message/3" do
+  describe "ai_conversation_send_user_message/3" do
     setup do
       ClaudeCode.Test.set_mode_to_shared()
 
@@ -132,7 +132,8 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflowTest do
       ws = create_session(%{phase_status: :conversing})
       {:ok, ai_session} = Destila.AI.get_or_create_ai_session(ws.id)
 
-      {:ok, updated_ws} = PromptChoreTaskWorkflow.send_user_message(ws, ai_session, "Hello AI")
+      {:ok, updated_ws} =
+        PromptChoreTaskWorkflow.ai_conversation_send_user_message(ws, ai_session, "Hello AI")
 
       assert updated_ws.phase_status == :generating
       messages = Destila.AI.list_messages(ai_session.id)
@@ -145,7 +146,7 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflowTest do
       {:ok, ai_session} = Destila.AI.get_or_create_ai_session(ws.id)
 
       assert {:error, :generating} =
-               PromptChoreTaskWorkflow.send_user_message(ws, ai_session, "Hello")
+               PromptChoreTaskWorkflow.ai_conversation_send_user_message(ws, ai_session, "Hello")
     end
   end
 end

--- a/test/destila/workflows/prompt_chore_task_workflow_test.exs
+++ b/test/destila/workflows/prompt_chore_task_workflow_test.exs
@@ -1,7 +1,20 @@
 defmodule Destila.Workflows.PromptChoreTaskWorkflowTest do
   use DestilaWeb.ConnCase, async: false
 
+  alias Destila.Workflows
   alias Destila.Workflows.PromptChoreTaskWorkflow
+
+  defp create_session(attrs) do
+    defaults = %{
+      title: "Test Session",
+      workflow_type: :prompt_chore_task,
+      current_phase: 2,
+      total_phases: 6
+    }
+
+    {:ok, ws} = Workflows.create_workflow_session(Map.merge(defaults, attrs))
+    ws
+  end
 
   describe "validate_wizard_fields/1" do
     test "returns :ok when both fields are valid" do
@@ -112,6 +125,54 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflowTest do
                })
 
       assert project.name == "Trimmed"
+    end
+  end
+
+  describe "initiate_setup/2" do
+    setup do
+      ClaudeCode.Test.stub(ClaudeCode, fn _query, _opts ->
+        [ClaudeCode.Test.text("Generated Title")]
+      end)
+
+      :ok
+    end
+
+    test "is idempotent when phase_status is already :setup" do
+      ws = create_session(%{phase_status: :setup})
+      assert :ok = PromptChoreTaskWorkflow.initiate_setup(ws, %{})
+    end
+
+    test "sets phase_status to :setup" do
+      ws = create_session(%{phase_status: nil})
+      assert :ok = PromptChoreTaskWorkflow.initiate_setup(ws, %{})
+
+      updated = Workflows.get_workflow_session!(ws.id)
+      assert updated.phase_status == :setup
+    end
+
+    test "does not enqueue setup worker when no project" do
+      ws = create_session(%{phase_status: nil, project_id: nil})
+      PromptChoreTaskWorkflow.initiate_setup(ws, %{})
+
+      refute_enqueued(worker: Destila.Workers.SetupWorker)
+    end
+  end
+
+  describe "retry_setup/1" do
+    setup do
+      ClaudeCode.Test.stub(ClaudeCode, fn _query, _opts ->
+        [ClaudeCode.Test.text("Generated Title")]
+      end)
+
+      :ok
+    end
+
+    test "does not enqueue workers when not needed" do
+      ws = create_session(%{project_id: nil, title_generating: false})
+      PromptChoreTaskWorkflow.retry_setup(ws)
+
+      refute_enqueued(worker: Destila.Workers.SetupWorker)
+      refute_enqueued(worker: Destila.Workers.TitleGenerationWorker)
     end
   end
 end

--- a/test/destila/workflows/prompt_chore_task_workflow_test.exs
+++ b/test/destila/workflows/prompt_chore_task_workflow_test.exs
@@ -1,0 +1,117 @@
+defmodule Destila.Workflows.PromptChoreTaskWorkflowTest do
+  use DestilaWeb.ConnCase, async: false
+
+  alias Destila.Workflows.PromptChoreTaskWorkflow
+
+  describe "validate_wizard_fields/1" do
+    test "returns :ok when both fields are valid" do
+      assert :ok =
+               PromptChoreTaskWorkflow.validate_wizard_fields(%{
+                 project_id: "some-id",
+                 idea: "Fix the bug"
+               })
+    end
+
+    test "returns error when project_id is nil" do
+      assert {:error, errors} =
+               PromptChoreTaskWorkflow.validate_wizard_fields(%{
+                 project_id: nil,
+                 idea: "Fix the bug"
+               })
+
+      assert errors[:project] == "Please select a project"
+      refute Map.has_key?(errors, :idea)
+    end
+
+    test "returns error when idea is empty" do
+      assert {:error, errors} =
+               PromptChoreTaskWorkflow.validate_wizard_fields(%{
+                 project_id: "some-id",
+                 idea: ""
+               })
+
+      assert errors[:idea] == "Please describe your initial idea"
+      refute Map.has_key?(errors, :project)
+    end
+
+    test "returns error when idea is nil" do
+      assert {:error, errors} =
+               PromptChoreTaskWorkflow.validate_wizard_fields(%{
+                 project_id: "some-id",
+                 idea: nil
+               })
+
+      assert errors[:idea] == "Please describe your initial idea"
+    end
+
+    test "returns both errors when both fields are invalid" do
+      assert {:error, errors} =
+               PromptChoreTaskWorkflow.validate_wizard_fields(%{
+                 project_id: nil,
+                 idea: ""
+               })
+
+      assert errors[:project]
+      assert errors[:idea]
+    end
+  end
+
+  describe "validate_and_create_project/1" do
+    test "creates project when params are valid" do
+      assert {:ok, project} =
+               PromptChoreTaskWorkflow.validate_and_create_project(%{
+                 "name" => "My Project",
+                 "git_repo_url" => "https://github.com/org/repo",
+                 "local_folder" => ""
+               })
+
+      assert project.name == "My Project"
+      assert project.git_repo_url == "https://github.com/org/repo"
+    end
+
+    test "creates project with local_folder only" do
+      assert {:ok, project} =
+               PromptChoreTaskWorkflow.validate_and_create_project(%{
+                 "name" => "Local Project",
+                 "git_repo_url" => "",
+                 "local_folder" => "/home/user/project"
+               })
+
+      assert project.local_folder == "/home/user/project"
+      assert project.git_repo_url == nil
+    end
+
+    test "returns error when name is empty" do
+      assert {:error, errors} =
+               PromptChoreTaskWorkflow.validate_and_create_project(%{
+                 "name" => "",
+                 "git_repo_url" => "https://github.com/org/repo",
+                 "local_folder" => ""
+               })
+
+      assert errors[:name] == "Name is required"
+    end
+
+    test "returns error when both location fields are empty" do
+      assert {:error, errors} =
+               PromptChoreTaskWorkflow.validate_and_create_project(%{
+                 "name" => "My Project",
+                 "git_repo_url" => "",
+                 "local_folder" => ""
+               })
+
+      assert errors[:location] == "Provide at least one"
+    end
+
+    test "trims whitespace from name" do
+      assert {:ok, project} =
+               PromptChoreTaskWorkflow.validate_and_create_project(%{
+                 "name" => "  Trimmed  ",
+                 "git_repo_url" => "",
+                 "local_folder" => "/tmp"
+               })
+
+      assert project.name == "Trimmed"
+    end
+  end
+end

--- a/test/destila/workflows/prompt_chore_task_workflow_test.exs
+++ b/test/destila/workflows/prompt_chore_task_workflow_test.exs
@@ -69,65 +69,6 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflowTest do
     end
   end
 
-  describe "validate_and_create_project/1" do
-    test "creates project when params are valid" do
-      assert {:ok, project} =
-               PromptChoreTaskWorkflow.validate_and_create_project(%{
-                 "name" => "My Project",
-                 "git_repo_url" => "https://github.com/org/repo",
-                 "local_folder" => ""
-               })
-
-      assert project.name == "My Project"
-      assert project.git_repo_url == "https://github.com/org/repo"
-    end
-
-    test "creates project with local_folder only" do
-      assert {:ok, project} =
-               PromptChoreTaskWorkflow.validate_and_create_project(%{
-                 "name" => "Local Project",
-                 "git_repo_url" => "",
-                 "local_folder" => "/home/user/project"
-               })
-
-      assert project.local_folder == "/home/user/project"
-      assert project.git_repo_url == nil
-    end
-
-    test "returns error when name is empty" do
-      assert {:error, errors} =
-               PromptChoreTaskWorkflow.validate_and_create_project(%{
-                 "name" => "",
-                 "git_repo_url" => "https://github.com/org/repo",
-                 "local_folder" => ""
-               })
-
-      assert errors[:name] == "Name is required"
-    end
-
-    test "returns error when both location fields are empty" do
-      assert {:error, errors} =
-               PromptChoreTaskWorkflow.validate_and_create_project(%{
-                 "name" => "My Project",
-                 "git_repo_url" => "",
-                 "local_folder" => ""
-               })
-
-      assert errors[:location] == "Provide at least one"
-    end
-
-    test "trims whitespace from name" do
-      assert {:ok, project} =
-               PromptChoreTaskWorkflow.validate_and_create_project(%{
-                 "name" => "  Trimmed  ",
-                 "git_repo_url" => "",
-                 "local_folder" => "/tmp"
-               })
-
-      assert project.name == "Trimmed"
-    end
-  end
-
   describe "initiate_setup/2" do
     setup do
       ClaudeCode.Test.stub(ClaudeCode, fn _query, _opts ->

--- a/test/destila/workflows_operations_test.exs
+++ b/test/destila/workflows_operations_test.exs
@@ -15,56 +15,6 @@ defmodule Destila.WorkflowsOperationsTest do
     ws
   end
 
-  describe "create_session_from_wizard/3" do
-    test "creates a session with next phase and default title" do
-      {:ok, ws} =
-        Workflows.create_session_from_wizard(:prompt_chore_task, 1, %{
-          project_id: nil,
-          idea: "Fix the login bug",
-          title_generating: true
-        })
-
-      assert ws.workflow_type == :prompt_chore_task
-      assert ws.current_phase == 2
-      assert ws.total_phases == 6
-      assert ws.title == "New Chore/Task"
-      assert ws.title_generating == true
-    end
-
-    test "stores the idea as wizard metadata" do
-      {:ok, ws} =
-        Workflows.create_session_from_wizard(:prompt_chore_task, 1, %{
-          idea: "Add dark mode"
-        })
-
-      metadata = Workflows.get_metadata(ws.id)
-      assert metadata["idea"] == %{"text" => "Add dark mode"}
-    end
-
-    test "skips metadata when idea is nil" do
-      {:ok, ws} =
-        Workflows.create_session_from_wizard(:prompt_chore_task, 1, %{
-          idea: nil
-        })
-
-      metadata = Workflows.get_metadata(ws.id)
-      assert metadata == %{}
-    end
-
-    test "sets project_id when provided" do
-      {:ok, project} =
-        Destila.Projects.create_project(%{name: "Test Project", local_folder: "/tmp/test"})
-
-      {:ok, ws} =
-        Workflows.create_session_from_wizard(:prompt_chore_task, 1, %{
-          project_id: project.id,
-          idea: "Some idea"
-        })
-
-      assert ws.project_id == project.id
-    end
-  end
-
   describe "advance_phase/2" do
     test "advances to the next phase with nil phase_status by default" do
       ws = create_session(%{current_phase: 3, total_phases: 6})

--- a/test/destila/workflows_operations_test.exs
+++ b/test/destila/workflows_operations_test.exs
@@ -1,0 +1,120 @@
+defmodule Destila.WorkflowsOperationsTest do
+  use DestilaWeb.ConnCase, async: false
+
+  alias Destila.Workflows
+
+  defp create_session(attrs \\ %{}) do
+    defaults = %{
+      title: "Test Session",
+      workflow_type: :prompt_chore_task,
+      current_phase: 2,
+      total_phases: 6
+    }
+
+    {:ok, ws} = Workflows.create_workflow_session(Map.merge(defaults, attrs))
+    ws
+  end
+
+  describe "create_session_from_wizard/3" do
+    test "creates a session with next phase and default title" do
+      {:ok, ws} =
+        Workflows.create_session_from_wizard(:prompt_chore_task, 1, %{
+          project_id: nil,
+          idea: "Fix the login bug",
+          title_generating: true
+        })
+
+      assert ws.workflow_type == :prompt_chore_task
+      assert ws.current_phase == 2
+      assert ws.total_phases == 6
+      assert ws.title == "New Chore/Task"
+      assert ws.title_generating == true
+    end
+
+    test "stores the idea as wizard metadata" do
+      {:ok, ws} =
+        Workflows.create_session_from_wizard(:prompt_chore_task, 1, %{
+          idea: "Add dark mode"
+        })
+
+      metadata = Workflows.get_metadata(ws.id)
+      assert metadata["idea"] == %{"text" => "Add dark mode"}
+    end
+
+    test "skips metadata when idea is nil" do
+      {:ok, ws} =
+        Workflows.create_session_from_wizard(:prompt_chore_task, 1, %{
+          idea: nil
+        })
+
+      metadata = Workflows.get_metadata(ws.id)
+      assert metadata == %{}
+    end
+
+    test "sets project_id when provided" do
+      {:ok, project} =
+        Destila.Projects.create_project(%{name: "Test Project", local_folder: "/tmp/test"})
+
+      {:ok, ws} =
+        Workflows.create_session_from_wizard(:prompt_chore_task, 1, %{
+          project_id: project.id,
+          idea: "Some idea"
+        })
+
+      assert ws.project_id == project.id
+    end
+  end
+
+  describe "advance_phase/2" do
+    test "advances to the next phase with nil phase_status by default" do
+      ws = create_session(%{current_phase: 3, total_phases: 6})
+      {:ok, updated} = Workflows.advance_phase(ws)
+
+      assert updated.current_phase == 4
+      assert updated.phase_status == nil
+    end
+
+    test "accepts a custom phase_status" do
+      ws = create_session(%{current_phase: 3, total_phases: 6})
+      {:ok, updated} = Workflows.advance_phase(ws, phase_status: :generating)
+
+      assert updated.current_phase == 4
+      assert updated.phase_status == :generating
+    end
+
+    test "returns error at boundary when already at last phase" do
+      ws = create_session(%{current_phase: 6, total_phases: 6})
+      assert {:error, :at_boundary} = Workflows.advance_phase(ws)
+    end
+  end
+
+  describe "mark_done/1" do
+    test "sets done_at and clears phase_status" do
+      ws = create_session(%{phase_status: :conversing})
+      {:ok, updated} = Workflows.mark_done(ws)
+
+      assert updated.done_at != nil
+      assert updated.phase_status == nil
+    end
+
+    test "creates a completion message when AI session exists" do
+      ws = create_session()
+      {:ok, ai_session} = Destila.AI.get_or_create_ai_session(ws.id)
+
+      {:ok, _updated} = Workflows.mark_done(ws)
+
+      messages = Destila.AI.list_messages(ai_session.id)
+      assert length(messages) == 1
+      completion = hd(messages)
+      assert completion.role == :system
+      assert completion.content =~ "implementation prompt is ready"
+    end
+
+    test "succeeds when no AI session exists" do
+      ws = create_session()
+      {:ok, updated} = Workflows.mark_done(ws)
+
+      assert updated.done_at != nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Move all business logic (DB mutations, Oban job insertion, AI session management, validation) out of LiveView/LiveComponent files into Destila core modules
- `Workflows` context gained generic operations: `advance_phase/2`, `mark_done/1`, `workflow_type_from_string/1`
- `PromptChoreTaskWorkflow` gained phase-specific operations: `wizard_validate_fields/1`, `setup_initiate/2`, `setup_retry/1`, `ai_conversation_initialize/3`, `ai_conversation_send_user_message/3`
- Phases call the workflow module directly via `@workflow` assign — no dispatcher coupling layer
- Web layer is now thin delegates: receive events, call core functions, update socket assigns

### Additional fixes
- Handle JSON string in `mcp_tool_uses` questions field
- Hide chat text input when structured questions are active
- Drop `[input]` fallback that created ghost questions
- Replace `String.to_existing_atom` with safe `workflow_type_from_string/1`
- Add `metadata_phase_name/0` to phase modules for generic metadata handling

## Test plan
- [x] All 109 existing tests pass unchanged
- [x] `mix precommit` passes
- [x] No `Oban.insert` calls in `lib/destila_web/`
- [x] No `AI.create_message`/`AI.get_or_create_ai_session`/`AI.ClaudeSession.stop` in web layer
- [x] 26 new unit tests for extracted functions
- [x] Manual verification of workflow session creation, phase transitions, mark-done


🤖 Generated with [Claude Code](https://claude.com/claude-code)