### PR TITLE
Reduce dark theme primary color brightness

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -32,7 +32,7 @@
   --color-base-200: oklch(19% 0.008 260);
   --color-base-300: oklch(26% 0.012 260);
   --color-base-content: oklch(93% 0.005 260);
-  --color-primary: oklch(65% 0.2 265);
+  --color-primary: oklch(55% 0.2 265);
   --color-primary-content: oklch(98% 0.01 265);
   --color-secondary: oklch(60% 0.15 290);
   --color-secondary-content: oklch(98% 0.01 290);

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,27 @@
+# Plan: Reduce dark theme primary color brightness
+
+## Problem
+
+The dark theme's primary color is too bright (`oklch(65% 0.2 265)`) and causes visual strain. It should be reduced to `oklch(55% 0.2 265)` to match the light theme's primary lightness for consistency.
+
+## Changes
+
+### File: `assets/css/app.css`
+
+**Line 35** — In the dark theme plugin block, change the primary color lightness from 65% to 55%:
+
+```css
+/* Before */
+--color-primary: oklch(65% 0.2 265);
+
+/* After */
+--color-primary: oklch(55% 0.2 265);
+```
+
+No other color variables (secondary, accent, info, success, etc.) should be modified. No other files need changes.
+
+## Verification
+
+- Confirm only `--color-primary` in the dark theme block is changed.
+- The chroma (0.2) and hue (265) channels remain unchanged.
+- The light theme block (line 71) already uses `oklch(55% 0.2 265)` — after this change both themes share the same primary color definition.


### PR DESCRIPTION
## Summary
- Reduced dark theme `--color-primary` lightness from 65% to 55% in `assets/css/app.css`
- Both dark and light themes now share the same primary color definition (`oklch(55% 0.2 265)`)
- Addresses visual strain caused by overly bright primary color in dark mode

## Test plan
- [x] Project compiles successfully
- [x] Only `--color-primary` in the dark theme block was modified
- [x] Chroma (0.2) and hue (265) remain unchanged
- [ ] Visually verify dark theme primary color in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)