### PR TITLE
Reduce dark theme primary color brightness (55% → 50%)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -32,7 +32,7 @@
   --color-base-200: oklch(19% 0.008 260);
   --color-base-300: oklch(26% 0.012 260);
   --color-base-content: oklch(93% 0.005 260);
-  --color-primary: oklch(55% 0.2 265);
+  --color-primary: oklch(50% 0.2 265);
   --color-primary-content: oklch(98% 0.01 265);
   --color-secondary: oklch(60% 0.15 290);
   --color-secondary-content: oklch(98% 0.01 290);

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,27 @@
+# Plan: Reduce dark theme primary color brightness
+
+## Summary
+
+Reduce the `--color-primary` lightness in the dark theme from 55% to 50% to address user reports that the primary color is still too bright after a previous reduction (65% → 55%).
+
+## Change
+
+**File:** `assets/css/app.css`
+**Line:** 35 (dark theme definition inside the `@plugin "../vendor/daisyui-theme"` block with `name: "dark"`)
+
+| Property | Before | After |
+|---|---|---|
+| `--color-primary` | `oklch(55% 0.2 265)` | `oklch(50% 0.2 265)` |
+
+Only the lightness component (first value) changes. Chroma (0.2) and hue (265) remain the same.
+
+## Scope
+
+- The light theme (`name: "light"`, line 71) also uses `oklch(55% 0.2 265)` for `--color-primary` but is **not** changed — only the dark theme is affected.
+- `--color-primary-content` (line 36) stays at `oklch(98% 0.01 265)` — contrast with the darker primary will actually improve slightly.
+- No other files need modification; daisyUI theme tokens are defined entirely in `assets/css/app.css`.
+
+## Testing
+
+- No Gherkin scenarios needed — this is a purely cosmetic CSS adjustment with no behavioral changes.
+- Visual verification: open the app in dark mode and confirm the primary color (buttons, links, active states) appears slightly darker/less bright.


### PR DESCRIPTION
## Summary
- Reduced `--color-primary` lightness in the dark theme from `oklch(55% 0.2 265)` to `oklch(50% 0.2 265)` in `assets/css/app.css`
- Addresses user reports that the primary color is still too bright after a previous reduction (65% → 55%)
- Light theme primary color remains unchanged

## Test plan
- [ ] Open the app in dark mode and verify primary-colored elements (buttons, links, active states) appear slightly darker
- [ ] Confirm light theme is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)