### PR TITLE
Rename 'Prompt for a Chore / Task' to 'Brainstorm Idea'

### DIFF
--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -5,7 +5,7 @@ Destila is a web application built with the Phoenix framework (Elixir). It appea
 - **Projects management** — organizing work into projects
 - **Prompt crafting** — a "Crafting Board" for building and refining prompts
 - **AI integration** — AI query workers, sessions, and tool support (via `Destila.AI` module)
-- **Workflow automation** — chore task workflows with phases
+- **Workflow automation** — brainstorm idea workflows with phases
 - **Message/chat system** — messages context with PubSub for real-time updates
 
 ## Tech Stack
@@ -27,7 +27,7 @@ lib/destila/          — Business logic (contexts)
   projects/           — Project schema
   prompts/            — Prompt schema
   workers/            — Oban workers (AI query, setup, title generation)
-  workflows/          — Chore task phases
+  workflows/          — Brainstorm Idea phases
 lib/destila_web/      — Web layer
   components/         — Core, chat, board, layout components
   controllers/        — Session controller, error handlers

--- a/.serena/memories/workflow-architecture-learnings.md
+++ b/.serena/memories/workflow-architecture-learnings.md
@@ -1,7 +1,7 @@
 # Institutional Knowledge: Workflow Architecture & Phase Transitions
 
 **Date:** 2026-03-28  
-**Sources:** Plan docs from workflow refactoring (2026-03-25, 2026-03-27), brainstorms, and chore task workflow implementation (2026-03-20)
+**Sources:** Plan docs from workflow refactoring (2026-03-25, 2026-03-27), brainstorms, and brainstorm idea workflow implementation (2026-03-20)
 
 ## Critical Architecture Pattern: Self-Contained LiveComponent Phases
 
@@ -58,7 +58,7 @@ The refactored schema separates concerns across multiple tables:
 - `phase_status :enum` (`:setup`, `:generating`, `:conversing`, `:advance_suggested`)
 - `setup_steps :map` (tracks setup task progress as JSON, e.g., `%{"clone" => "completed", "worktree" => "in_progress"}`)
 - `title :string` (editable after session creation)
-- `workflow_type :enum` (`:prompt_chore_task`, others added later)
+- `workflow_type :enum` (`:brainstorm_idea`, others added later)
 - `column :enum` (`:distill`, `:done` — no `:request` anymore)
 - `archived_at :utc_datetime` (for soft deletes)
 - `project_id :binary_id` (FK to projects)
@@ -72,7 +72,7 @@ The refactored schema separates concerns across multiple tables:
 - `worktree_path :string` (where repo is cloned)
 - `timestamps`
 
-**Why?** The AI session is phase-specific (created in Phase 3 of chore_task). Multiple AI sessions can exist for a single workflow session if a workflow has multiple AI phases. This allows independent session management and resume capability.
+**Why?** The AI session is phase-specific (created in Phase 3 of brainstorm_idea). Multiple AI sessions can exist for a single workflow session if a workflow has multiple AI phases. This allows independent session management and resume capability.
 
 ### messages table
 - `ai_session_id :binary_id` (FK, was `workflow_session_id`)
@@ -92,7 +92,7 @@ The refactored schema separates concerns across multiple tables:
 - **State:** In-memory (LiveView assigns)
 - **Signal completion:** Synchronously send `{:phase_complete, 1, %{project_id: "...", idea: "..."}}`
 - **Parent action on completion:** Create workflow_session DB record, `push_navigate` to post-session URL
-- **Example:** `prompt_chore_task` Phase 1 collects project + idea
+- **Example:** `brainstorm_idea` Phase 1 collects project + idea
 
 ### SetupPhase
 - **Purpose:** Execute setup tasks (clone, worktree, title generation) via background workers
@@ -100,7 +100,7 @@ The refactored schema separates concerns across multiple tables:
 - **Signal completion:** Workers call `SetupCoordinator.maybe_advance_setup/1` which atomically advances `current_phase` when all steps done
 - **Component behavior:** Renders task list, subscribes to `:workflow_session_updated`, detects phase advance, signals parent
 - **Parent action on completion:** Mount next phase component
-- **Example:** `prompt_chore_task` Phase 2 runs clone, worktree, title_gen workers
+- **Example:** `brainstorm_idea` Phase 2 runs clone, worktree, title_gen workers
 
 ### AiConversationPhase
 - **Purpose:** Have a multi-turn conversation with AI for context gathering or generation
@@ -113,14 +113,14 @@ The refactored schema separates concerns across multiple tables:
 - **First AI phase (Phase 3):** Creates AI session via `AI.Session.for_workflow_session/2`
 - **Subsequent phases:** Resumes existing AI session, sends system prompt as new query
 - **Signal completion:** User clicks "Continue to Phase N" (after AI suggests) or "Mark as Done" (if final)
-- **Example:** `prompt_chore_task` Phases 3-6 are all AiConversationPhase instances with different system prompts
+- **Example:** `brainstorm_idea` Phases 3-6 are all AiConversationPhase instances with different system prompts
 
 ## Critical Workflow Definition Pattern
 
 Workflows are defined as a simple list of `{PhaseModule, opts}` tuples in a function:
 
 ```elixir
-defmodule Destila.Workflows.PromptChoreTaskWorkflow do
+defmodule Destila.Workflows.BrainstormIdeaWorkflow do
   def phases do
     [
       {DestilaWeb.Phases.WizardPhase, name: "Project & Idea", fields: [:project, :idea]},
@@ -138,7 +138,7 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflow do
   
   def total_phases, do: length(phases())
   def phase_name(phase_num), do: Enum.at(phases(), phase_num - 1) |> elem(1) |> Map.get(:name)
-  def default_title, do: "New Chore/Task"
+  def default_title, do: "New Idea"
   
   # System prompts
   defp task_prompt(workflow_session), do: "..."
@@ -220,7 +220,7 @@ send(self(), {:phase_complete, phase_num, %{}})
 ### 1. Session Creation Timing Matters
 **Gotcha:** If you create the session in the wrong phase, field references break.
 
-**Pattern:** For `prompt_chore_task`, the session is created AFTER WizardPhase completes, not before. This allows Phase 1 to be fully in-memory and avoids DB writes until the user confirms their idea. If a new workflow needs the session created at a different point, it changes where the phase data flows.
+**Pattern:** For `brainstorm_idea`, the session is created AFTER WizardPhase completes, not before. This allows Phase 1 to be fully in-memory and avoids DB writes until the user confirms their idea. If a new workflow needs the session created at a different point, it changes where the phase data flows.
 
 **Mitigation:** Document when the session is created in your workflow definition. Make it explicit in the phase list comments.
 
@@ -280,7 +280,7 @@ Old → New:
 - `test/destila_web/live/phases/wizard_phase_test.exs` — phase 1 input
 - `test/destila_web/live/phases/setup_phase_test.exs` — phase 2 workers + coordination
 - `test/destila_web/live/phases/ai_conversation_phase_test.exs` — phase 3+ AI conversation
-- Feature files: `features/chore_task_workflow.feature`, `features/setup_phase.feature`, etc.
+- Feature files: `features/brainstorm_idea_workflow.feature`, `features/setup_phase.feature`, etc.
 
 ### Key Testing Patterns
 1. **Phase completion signals** — assert `send/2` calls are made correctly

--- a/docs/plans/2026-04-01-refactor-rename-chore-task-to-brainstorm-idea-plan.md
+++ b/docs/plans/2026-04-01-refactor-rename-chore-task-to-brainstorm-idea-plan.md
@@ -1,0 +1,181 @@
+# Rename "Prompt for a Chore / Task" → "Brainstorm Idea"
+
+**Date:** 2026-04-01
+**Type:** Refactor
+**Scope:** Full rename across all layers — UI labels, code identifiers, database, tests, features, memory files
+
+## Context
+
+The "Prompt for a Chore / Task" workflow is being renamed to "Brainstorm Idea" to better reflect its purpose. This is strictly a rename — no behavioral changes.
+
+## What stays the same
+
+- All 6 phases, their order, system prompts, and logic
+- The `hero-wrench-screwdriver` icon and `text-warning` / `badge-warning` classes
+- Files under `docs/brainstorms/` and `docs/plans/` (historical artifacts)
+- The workflow description: `"Straightforward coding tasks, bug fixes, or refactors"`
+- The completion message text
+
+## Implementation steps
+
+### Step 1: Database migration
+
+Create migration `priv/repo/migrations/YYYYMMDDHHMMSS_rename_prompt_chore_task_to_brainstorm_idea.exs`:
+
+```elixir
+defmodule Destila.Repo.Migrations.RenamePromptChoreTaskToBrainstormIdea do
+  use Ecto.Migration
+
+  def up do
+    execute "UPDATE workflow_sessions SET workflow_type = 'brainstorm_idea' WHERE workflow_type = 'prompt_chore_task'"
+  end
+
+  def down do
+    execute "UPDATE workflow_sessions SET workflow_type = 'prompt_chore_task' WHERE workflow_type = 'brainstorm_idea'"
+  end
+end
+```
+
+Run with `mix ecto.migrate`.
+
+### Step 2: Rename workflow module file
+
+| Old path | New path |
+|----------|----------|
+| `lib/destila/workflows/prompt_chore_task_workflow.ex` | `lib/destila/workflows/brainstorm_idea_workflow.ex` |
+
+Inside the file:
+- Module name: `Destila.Workflows.PromptChoreTaskWorkflow` → `Destila.Workflows.BrainstormIdeaWorkflow`
+- `@moduledoc` — update "Chore/Task workflow" → "Brainstorm Idea workflow"
+- `default_title/0` — `"New Chore/Task"` → `"New Idea"`
+- `label/0` — `"Prompt for a Chore / Task"` → `"Brainstorm Idea"`
+
+### Step 3: Update workflow registry
+
+**File:** `lib/destila/workflows.ex` (line 13)
+
+```elixir
+# Old
+prompt_chore_task: Destila.Workflows.PromptChoreTaskWorkflow,
+# New
+brainstorm_idea: Destila.Workflows.BrainstormIdeaWorkflow,
+```
+
+### Step 4: Update Ecto schema enum
+
+**File:** `lib/destila/workflows/session.ex` (line 9)
+
+```elixir
+# Old
+field(:workflow_type, Ecto.Enum, values: [:prompt_chore_task, :implement_general_prompt])
+# New
+field(:workflow_type, Ecto.Enum, values: [:brainstorm_idea, :implement_general_prompt])
+```
+
+### Step 5: Update board components
+
+**File:** `lib/destila_web/components/board_components.ex`
+
+| Line | Old | New |
+|------|-----|-----|
+| 139 | `def workflow_label(:prompt_chore_task), do: "Chore/Task"` | `def workflow_label(:brainstorm_idea), do: "Brainstorm Idea"` |
+| 143 | `defp workflow_badge_class(:prompt_chore_task), do: "badge-warning"` | `defp workflow_badge_class(:brainstorm_idea), do: "badge-warning"` |
+
+### Step 6: Update AI module
+
+**File:** `lib/destila/ai.ex` (line 248)
+
+```elixir
+# Old
+defp workflow_type_label(:prompt_chore_task), do: "chore/task"
+# New
+defp workflow_type_label(:brainstorm_idea), do: "brainstorm idea"
+```
+
+### Step 7: Update prompt wizard phase
+
+**File:** `lib/destila_web/live/phases/prompt_wizard_phase.ex` (line 200)
+
+```
+# Old
+Complete a Chore/Task workflow first, or write a prompt manually
+# New
+Complete a Brainstorm Idea workflow first, or write a prompt manually
+```
+
+### Step 8: Rename test file and update contents
+
+| Old path | New path |
+|----------|----------|
+| `test/destila_web/live/chore_task_workflow_live_test.exs` | `test/destila_web/live/brainstorm_idea_workflow_live_test.exs` |
+
+Inside the file:
+- Module name: `DestilaWeb.ChoreTaskWorkflowLiveTest` → `DestilaWeb.BrainstormIdeaWorkflowLiveTest`
+- `@feature "chore_task_workflow"` → `@feature "brainstorm_idea_workflow"`
+- All `:prompt_chore_task` atoms → `:brainstorm_idea`
+- Route: `~p"/workflows/prompt_chore_task"` → `~p"/workflows/brainstorm_idea"`
+
+### Step 9: Update all other test files
+
+Every file below needs `:prompt_chore_task` → `:brainstorm_idea` and any string references updated:
+
+| File | What to change |
+|------|----------------|
+| `test/destila_web/live/workflow_type_selection_live_test.exs` | `:prompt_chore_task` atom, `#type-prompt_chore_task` selector → `#type-brainstorm_idea` |
+| `test/destila_web/live/crafting_board_live_test.exs` | `:prompt_chore_task` atom, `#workflow-board-prompt_chore_task` → `#workflow-board-brainstorm_idea`, any "Chore/Task" strings → "Brainstorm Idea" |
+| `test/destila_web/live/archived_sessions_live_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
+| `test/destila_web/live/generated_prompt_viewing_live_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
+| `test/destila_web/live/implement_general_prompt_workflow_live_test.exs` | `:prompt_chore_task` → `:brainstorm_idea`, "Prompt for a Chore / Task" → "Brainstorm Idea" |
+| `test/destila_web/live/project_inline_creation_live_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
+| `test/destila_web/live/session_archiving_live_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
+| `test/destila_web/live/projects_live_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
+| `test/destila/ai_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
+| `test/destila/workflow_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
+| `test/destila/workflows_classify_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
+| `test/destila/workflows_metadata_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
+| `test/destila/executions_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
+| `test/destila/executions/engine_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
+
+### Step 10: Rename and update feature files
+
+**Rename:** `features/chore_task_workflow.feature` → `features/brainstorm_idea_workflow.feature`
+
+Inside the file:
+- `Feature: Prompt for a Chore / Task Workflow` → `Feature: Brainstorm Idea Workflow`
+- All `"Prompt for a Chore / Task"` strings → `"Brainstorm Idea"`
+
+**Update:** `features/crafting_board.feature`
+- `"Prompt for a Chore / Task"` → `"Brainstorm Idea"` (line 66)
+- `"Chore/Task"` → `"Brainstorm Idea"` (line 68)
+
+**Update:** `features/implement_general_prompt_workflow.feature`
+- `"Prompt for a Chore / Task"` → `"Brainstorm Idea"` (line 34)
+
+### Step 11: Update `.serena/memories/` files
+
+**File:** `.serena/memories/workflow-architecture-learnings.md`
+- All `prompt_chore_task` → `brainstorm_idea`
+- All `PromptChoreTaskWorkflow` → `BrainstormIdeaWorkflow`
+- `"New Chore/Task"` → `"New Idea"`
+- `chore task workflow` → `brainstorm idea workflow`
+- `chore_task` references (where referring to the workflow type) → `brainstorm_idea`
+
+**File:** `.serena/memories/project_overview.md`
+- `chore task workflows with phases` → `brainstorm idea workflows with phases`
+- `Chore task phases` → `Brainstorm Idea phases`
+
+## Verification
+
+After all changes:
+
+1. `mix compile --warnings-as-errors` — ensure no compilation errors or dangling references
+2. `mix ecto.migrate` — run the data migration
+3. `mix test` — full test suite must pass
+4. `mix precommit` — run the precommit alias
+5. Grep for any remaining `prompt_chore_task`, `PromptChoreTask`, `Chore/Task`, or `chore_task` references outside `docs/brainstorms/` and `docs/plans/` to catch stragglers
+
+## Risks
+
+- **Partial rename causes runtime crashes.** Every pattern match on `:prompt_chore_task` must be found. Use grep to verify no references remain.
+- **Ecto.Enum mismatch.** If the schema enum is updated before the migration runs, existing records with `:prompt_chore_task` will fail to load. Run migration first, or ensure tests use the new atom.
+- **URL breakage.** The route `/workflows/:workflow_type` uses the atom as the URL segment. Old bookmarks to `/workflows/prompt_chore_task` will 404. This is acceptable for a rename.

--- a/docs/plans/2026-04-01-refactor-rename-chore-task-to-brainstorm-idea-plan.md
+++ b/docs/plans/2026-04-01-refactor-rename-chore-task-to-brainstorm-idea-plan.md
@@ -109,32 +109,61 @@ Complete a Brainstorm Idea workflow first, or write a prompt manually
 |----------|----------|
 | `test/destila_web/live/chore_task_workflow_live_test.exs` | `test/destila_web/live/brainstorm_idea_workflow_live_test.exs` |
 
-Inside the file:
+Inside the file — apply **all** of these (not just atom swaps):
 - Module name: `DestilaWeb.ChoreTaskWorkflowLiveTest` → `DestilaWeb.BrainstormIdeaWorkflowLiveTest`
-- `@feature "chore_task_workflow"` → `@feature "brainstorm_idea_workflow"`
-- All `:prompt_chore_task` atoms → `:brainstorm_idea`
-- Route: `~p"/workflows/prompt_chore_task"` → `~p"/workflows/brainstorm_idea"`
+- Moduledoc: `"Chore/Task AI-Driven Workflow"` → `"Brainstorm Idea AI-Driven Workflow"` (line 3)
+- Moduledoc: `"features/chore_task_workflow.feature"` → `"features/brainstorm_idea_workflow.feature"` (line 4)
+- `@feature "chore_task_workflow"` → `@feature "brainstorm_idea_workflow"` (line 10)
+- Comment: `# Creates a chore_task session` → `# Creates a brainstorm_idea session` (line 38)
+- Fixture title: `"Test Chore Task"` → `"Test Brainstorm Idea"` (line 75)
+- All `:prompt_chore_task` atoms → `:brainstorm_idea` (lines 76, 127, 154, 166, 184, 427, 565, 617)
+- Routes: `~p"/workflows/prompt_chore_task"` → `~p"/workflows/brainstorm_idea"` (lines 127, 154, 166)
+- Assertion: `render(view) =~ "Test Chore Task"` → `render(view) =~ "Test Brainstorm Idea"` (line 398)
 
 ### Step 9: Update all other test files
 
-Every file below needs `:prompt_chore_task` → `:brainstorm_idea` and any string references updated:
+Each file below needs specific changes beyond simple atom swaps. The **catch-all rule** is: within every file, replace all occurrences of `:prompt_chore_task` with `:brainstorm_idea`, but also update these additional items per file:
 
-| File | What to change |
-|------|----------------|
-| `test/destila_web/live/workflow_type_selection_live_test.exs` | `:prompt_chore_task` atom, `#type-prompt_chore_task` selector → `#type-brainstorm_idea` |
-| `test/destila_web/live/crafting_board_live_test.exs` | `:prompt_chore_task` atom, `#workflow-board-prompt_chore_task` → `#workflow-board-brainstorm_idea`, any "Chore/Task" strings → "Brainstorm Idea" |
-| `test/destila_web/live/archived_sessions_live_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
-| `test/destila_web/live/generated_prompt_viewing_live_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
-| `test/destila_web/live/implement_general_prompt_workflow_live_test.exs` | `:prompt_chore_task` → `:brainstorm_idea`, "Prompt for a Chore / Task" → "Brainstorm Idea" |
-| `test/destila_web/live/project_inline_creation_live_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
-| `test/destila_web/live/session_archiving_live_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
-| `test/destila_web/live/projects_live_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
-| `test/destila/ai_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
-| `test/destila/workflow_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
-| `test/destila/workflows_classify_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
-| `test/destila/workflows_metadata_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
-| `test/destila/executions_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
-| `test/destila/executions/engine_test.exs` | `:prompt_chore_task` → `:brainstorm_idea` |
+**`test/destila/workflow_test.exs`** (11 occurrences):
+- Alias: `alias Destila.Workflows.PromptChoreTaskWorkflow` → `alias Destila.Workflows.BrainstormIdeaWorkflow` (line 4)
+- Describe block: `"Destila.Workflow behaviour via PromptChoreTaskWorkflow"` → `"Destila.Workflow behaviour via BrainstormIdeaWorkflow"` (line 7)
+- All `PromptChoreTaskWorkflow.` calls → `BrainstormIdeaWorkflow.` (lines 9, 13–15, 19–20, 24, 31–32)
+
+**`test/destila/ai_test.exs`** (12 occurrences):
+- All `:prompt_chore_task` atoms → `:brainstorm_idea` (lines 14, 26, 37, 49, 61, 71, 86, 99, 112)
+- Test name: `"returns title for a chore/task"` → `"returns title for a brainstorm idea"` (line 5)
+- Test name: `"returns title for a chore task with different idea"` → `"returns title for a brainstorm idea with different idea"` (line 17)
+- String assertion: `assert query =~ "chore/task"` → `assert query =~ "brainstorm idea"` (line 91)
+
+**`test/destila_web/live/implement_general_prompt_workflow_live_test.exs`**:
+- Helper function: `create_completed_chore_task_session` → `create_completed_brainstorm_idea_session` (definition on line 38, calls on lines 127, 136)
+- Fixture title: `"Completed Chore Task"` → `"Completed Brainstorm Idea"` (line 43)
+- All `:prompt_chore_task` atoms → `:brainstorm_idea` (line 44)
+- Test name: `"shows completed chore/task sessions for selection"` → `"shows completed brainstorm idea sessions for selection"` (line 126)
+
+**`test/destila_web/live/workflow_type_selection_live_test.exs`**:
+- Atom reference: `_ = :prompt_chore_task` → `_ = :brainstorm_idea` (line 13)
+- Selector: `"#type-prompt_chore_task"` → `"#type-brainstorm_idea"` (lines 28, 35)
+- Path assertion: `assert path == "/workflows/prompt_chore_task"` → `assert path == "/workflows/brainstorm_idea"` (line 38)
+
+**`test/destila_web/live/crafting_board_live_test.exs`**:
+- All `:prompt_chore_task` atoms → `:brainstorm_idea` (lines 33, 82, 133, 238, 264, 271, 294, 300, 307, 340, 347)
+- Selectors: `"#workflow-board-prompt_chore_task"` → `"#workflow-board-brainstorm_idea"` (lines 282, 300)
+- Comment: `# Chore/Task board should have phase columns` → `# Brainstorm Idea board should have phase columns` (line 284)
+
+**`test/destila_web/live/project_inline_creation_live_test.exs`**:
+- Atom reference: `_ = :prompt_chore_task` → `_ = :brainstorm_idea` (line 13)
+- Routes: `~p"/workflows/prompt_chore_task"` → `~p"/workflows/brainstorm_idea"` (lines 30, 52, 70, 89, 104)
+
+**Simple atom-only files** (just replace `:prompt_chore_task` → `:brainstorm_idea`):
+- `test/destila_web/live/archived_sessions_live_test.exs` (line 28)
+- `test/destila_web/live/generated_prompt_viewing_live_test.exs` (line 48)
+- `test/destila_web/live/session_archiving_live_test.exs` (line 28)
+- `test/destila_web/live/projects_live_test.exs` (line 200)
+- `test/destila/workflows_classify_test.exs` (line 9)
+- `test/destila/workflows_metadata_test.exs` (line 10)
+- `test/destila/executions_test.exs` (line 10)
+- `test/destila/executions/engine_test.exs` (line 21)
 
 ### Step 10: Rename and update feature files
 
@@ -153,16 +182,28 @@ Inside the file:
 
 ### Step 11: Update `.serena/memories/` files
 
-**File:** `.serena/memories/workflow-architecture-learnings.md`
-- All `prompt_chore_task` → `brainstorm_idea`
-- All `PromptChoreTaskWorkflow` → `BrainstormIdeaWorkflow`
-- `"New Chore/Task"` → `"New Idea"`
-- `chore task workflow` → `brainstorm idea workflow`
-- `chore_task` references (where referring to the workflow type) → `brainstorm_idea`
+**File:** `.serena/memories/workflow-architecture-learnings.md` (12 occurrences):
+- Line 4: `"chore task workflow implementation"` → `"brainstorm idea workflow implementation"`
+- Line 61: `":prompt_chore_task"` → `":brainstorm_idea"`
+- Line 75: `"Phase 3 of chore_task"` → `"Phase 3 of brainstorm_idea"`
+- Line 95: `"prompt_chore_task Phase 1"` → `"brainstorm_idea Phase 1"`
+- Line 103: `"prompt_chore_task Phase 2"` → `"brainstorm_idea Phase 2"`
+- Line 116: `"prompt_chore_task Phases 3-6"` → `"brainstorm_idea Phases 3-6"`
+- Line 123: `PromptChoreTaskWorkflow` → `BrainstormIdeaWorkflow` (code example)
+- Line 141: `"New Chore/Task"` → `"New Idea"` (code example)
+- Line 223: `"prompt_chore_task, the session"` → `"brainstorm_idea, the session"`
+- Line 283: `"features/chore_task_workflow.feature"` → `"features/brainstorm_idea_workflow.feature"`
 
-**File:** `.serena/memories/project_overview.md`
-- `chore task workflows with phases` → `brainstorm idea workflows with phases`
-- `Chore task phases` → `Brainstorm Idea phases`
+**File:** `.serena/memories/project_overview.md` (2 occurrences):
+- Line 8: `"chore task workflows with phases"` → `"brainstorm idea workflows with phases"`
+- Line 30: `"Chore task phases"` → `"Brainstorm Idea phases"`
+
+## Implementation order note
+
+All code changes (Steps 2–11) should be made together in a single commit, with the migration (Step 1) included. The order in which you edit files does not matter — what matters is that everything is consistent by the time you compile and run tests.
+
+- **Tests** use `MIX_ENV=test` which rebuilds the DB from `structure.sql` / migrations each run, so the migration and schema enum change are applied together.
+- **Production** (dev database): run `mix ecto.migrate` after deploying. Since the migration converts existing data and the schema accepts the new enum, they are safe to deploy in one step. There is no window where old data conflicts with the new schema because Ecto.Enum stores values as strings in SQLite.
 
 ## Verification
 
@@ -172,7 +213,14 @@ After all changes:
 2. `mix ecto.migrate` — run the data migration
 3. `mix test` — full test suite must pass
 4. `mix precommit` — run the precommit alias
-5. Grep for any remaining `prompt_chore_task`, `PromptChoreTask`, `Chore/Task`, or `chore_task` references outside `docs/brainstorms/` and `docs/plans/` to catch stragglers
+5. Run these greps to catch stragglers (exclude `docs/brainstorms/` and `docs/plans/`):
+   ```bash
+   grep -r "prompt_chore_task" lib/ test/ features/ .serena/
+   grep -r "PromptChoreTask" lib/ test/ features/ .serena/
+   grep -ri "chore.task" lib/ test/ features/ .serena/
+   grep -ri "chore_task" lib/ test/ features/ .serena/
+   ```
+   All of these should return zero results.
 
 ## Risks
 

--- a/features/brainstorm_idea_workflow.feature
+++ b/features/brainstorm_idea_workflow.feature
@@ -1,5 +1,5 @@
-Feature: Prompt for a Chore / Task Workflow
-  The "Prompt for a Chore / Task" workflow uses AI-driven conversational phases
+Feature: Brainstorm Idea Workflow
+  The "Brainstorm Idea" workflow uses AI-driven conversational phases
   to refine a coding task into an implementation prompt. It progresses through
   six phases:
   1. Project & Idea - Wizard collecting project selection and initial task description
@@ -13,7 +13,7 @@ Feature: Prompt for a Chore / Task Workflow
     Given I am logged in
 
   Scenario: Phase 1 - Wizard collects project and idea
-    When I navigate to start a new "Prompt for a Chore / Task" workflow
+    When I navigate to start a new "Brainstorm Idea" workflow
     Then I should see a form to select a project and describe my idea
     When I select a project and enter my initial idea
     And I click "Start"
@@ -21,13 +21,13 @@ Feature: Prompt for a Chore / Task Workflow
     And I should be redirected to the session detail page
 
   Scenario: Phase 1 - Wizard requires a project
-    When I navigate to start a new "Prompt for a Chore / Task" workflow
+    When I navigate to start a new "Brainstorm Idea" workflow
     And I enter an idea but do not select a project
     And I click "Start"
     Then I should see an error indicating a project is required
 
   Scenario: Phase 1 - Wizard requires an idea
-    When I navigate to start a new "Prompt for a Chore / Task" workflow
+    When I navigate to start a new "Brainstorm Idea" workflow
     And I select a project but leave the idea empty
     And I click "Start"
     Then I should see an error indicating an idea is required

--- a/features/crafting_board.feature
+++ b/features/crafting_board.feature
@@ -63,9 +63,9 @@ Feature: Crafting Board
     Then I should not see any drag-and-drop handles on the boards
 
   Scenario: Empty workflow boards are hidden
-    Given there are only "Prompt for a Chore / Task" sessions on the crafting board
+    Given there are only "Brainstorm Idea" sessions on the crafting board
     When I toggle "Group by Workflow"
-    Then I should see only the "Chore/Task" workflow board
+    Then I should see only the "Brainstorm Idea" workflow board
     And I should not see "New Project" or "Generic Prompt" boards
 
   Scenario: Filter by project with group by workflow active

--- a/features/implement_general_prompt_workflow.feature
+++ b/features/implement_general_prompt_workflow.feature
@@ -31,7 +31,7 @@ Feature: Implement General Prompt Workflow
     And I should be redirected to the session detail page
 
   Scenario: Phase 1 - Wizard with existing session prompt selection
-    Given a completed "Prompt for a Chore / Task" session exists
+    Given a completed "Brainstorm Idea" session exists
     When I navigate to start a new "Implement a Prompt" workflow
     Then I should see the completed session in the prompt list
     When I select an existing session prompt

--- a/lib/destila/ai.ex
+++ b/lib/destila/ai.ex
@@ -245,7 +245,7 @@ defmodule Destila.AI do
     end
   end
 
-  defp workflow_type_label(:prompt_chore_task), do: "chore/task"
+  defp workflow_type_label(:brainstorm_idea), do: "brainstorm idea"
   defp workflow_type_label(:implement_general_prompt), do: "prompt implementation"
   defp workflow_type_label(other), do: to_string(other)
 

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -10,7 +10,7 @@ defmodule Destila.Workflows do
   alias Destila.Workflows.{Session, SessionMetadata}
 
   @workflow_modules %{
-    prompt_chore_task: Destila.Workflows.PromptChoreTaskWorkflow,
+    brainstorm_idea: Destila.Workflows.BrainstormIdeaWorkflow,
     implement_general_prompt: Destila.Workflows.ImplementGeneralPromptWorkflow
   }
 

--- a/lib/destila/workflows/brainstorm_idea_workflow.ex
+++ b/lib/destila/workflows/brainstorm_idea_workflow.ex
@@ -1,6 +1,6 @@
-defmodule Destila.Workflows.PromptChoreTaskWorkflow do
+defmodule Destila.Workflows.BrainstormIdeaWorkflow do
   @moduledoc """
-  Defines the Chore/Task workflow — an AI-driven multi-phase conversation
+  Defines the Brainstorm Idea workflow — an AI-driven multi-phase conversation
   that clarifies a coding task and produces an implementation prompt.
 
   Phases:
@@ -32,9 +32,9 @@ defmodule Destila.Workflows.PromptChoreTaskWorkflow do
     ]
   end
 
-  def default_title, do: "New Chore/Task"
+  def default_title, do: "New Idea"
 
-  def label, do: "Prompt for a Chore / Task"
+  def label, do: "Brainstorm Idea"
   def description, do: "Straightforward coding tasks, bug fixes, or refactors"
   def icon, do: "hero-wrench-screwdriver"
   def icon_class, do: "text-warning"

--- a/lib/destila/workflows/session.ex
+++ b/lib/destila/workflows/session.ex
@@ -6,7 +6,7 @@ defmodule Destila.Workflows.Session do
   @foreign_key_type :binary_id
   schema "workflow_sessions" do
     field(:title, :string, default: "Untitled Session")
-    field(:workflow_type, Ecto.Enum, values: [:prompt_chore_task, :implement_general_prompt])
+    field(:workflow_type, Ecto.Enum, values: [:brainstorm_idea, :implement_general_prompt])
 
     field(:current_phase, :integer, default: 1)
     field(:total_phases, :integer)

--- a/lib/destila_web/components/board_components.ex
+++ b/lib/destila_web/components/board_components.ex
@@ -136,11 +136,11 @@ defmodule DestilaWeb.BoardComponents do
 
   # Helpers
 
-  def workflow_label(:prompt_chore_task), do: "Chore/Task"
+  def workflow_label(:brainstorm_idea), do: "Brainstorm Idea"
   def workflow_label(:implement_general_prompt), do: "Implementation"
   def workflow_label(_), do: "Workflow"
 
-  defp workflow_badge_class(:prompt_chore_task), do: "badge-warning"
+  defp workflow_badge_class(:brainstorm_idea), do: "badge-warning"
   defp workflow_badge_class(:implement_general_prompt), do: "badge-primary"
   defp workflow_badge_class(_), do: "badge-neutral"
 end

--- a/lib/destila_web/live/phases/prompt_wizard_phase.ex
+++ b/lib/destila_web/live/phases/prompt_wizard_phase.ex
@@ -197,7 +197,7 @@ defmodule DestilaWeb.Phases.PromptWizardPhase do
                 <.icon name="hero-document-text" class="size-10 text-base-content/20 mx-auto mb-3" />
                 <p class="text-sm text-base-content/30 mb-2">No completed prompts yet</p>
                 <p class="text-xs text-base-content/20">
-                  Complete a Chore/Task workflow first, or write a prompt manually
+                  Complete a Brainstorm Idea workflow first, or write a prompt manually
                 </p>
               </div>
             <% else %>

--- a/priv/repo/migrations/20260401000000_rename_prompt_chore_task_to_brainstorm_idea.exs
+++ b/priv/repo/migrations/20260401000000_rename_prompt_chore_task_to_brainstorm_idea.exs
@@ -1,0 +1,11 @@
+defmodule Destila.Repo.Migrations.RenamePromptChoreTaskToBrainstormIdea do
+  use Ecto.Migration
+
+  def up do
+    execute "UPDATE workflow_sessions SET workflow_type = 'brainstorm_idea' WHERE workflow_type = 'prompt_chore_task'"
+  end
+
+  def down do
+    execute "UPDATE workflow_sessions SET workflow_type = 'prompt_chore_task' WHERE workflow_type = 'brainstorm_idea'"
+  end
+end

--- a/test/destila/ai_test.exs
+++ b/test/destila/ai_test.exs
@@ -2,7 +2,7 @@ defmodule Destila.AITest do
   use ExUnit.Case, async: true
 
   describe "generate_title/2 (one-off, no session)" do
-    test "returns title for a chore/task" do
+    test "returns title for a brainstorm idea" do
       ClaudeCode.Test.stub(ClaudeCode, fn _query, _opts ->
         [
           ClaudeCode.Test.text("Dark Mode Toggle"),
@@ -11,10 +11,10 @@ defmodule Destila.AITest do
       end)
 
       assert {:ok, "Dark Mode Toggle"} =
-               Destila.AI.generate_title(:prompt_chore_task, "add dark mode")
+               Destila.AI.generate_title(:brainstorm_idea, "add dark mode")
     end
 
-    test "returns title for a chore task with different idea" do
+    test "returns title for a brainstorm idea with different idea" do
       ClaudeCode.Test.stub(ClaudeCode, fn _query, _opts ->
         [
           ClaudeCode.Test.text("Recipe Sharing Platform"),
@@ -23,7 +23,7 @@ defmodule Destila.AITest do
       end)
 
       assert {:ok, "Recipe Sharing Platform"} =
-               Destila.AI.generate_title(:prompt_chore_task, "a platform to share recipes")
+               Destila.AI.generate_title(:brainstorm_idea, "a platform to share recipes")
     end
 
     test "trims whitespace from the title" do
@@ -34,7 +34,7 @@ defmodule Destila.AITest do
         ]
       end)
 
-      assert {:ok, "Trimmed Title"} = Destila.AI.generate_title(:prompt_chore_task, "something")
+      assert {:ok, "Trimmed Title"} = Destila.AI.generate_title(:brainstorm_idea, "something")
     end
 
     test "returns error when response is empty" do
@@ -46,7 +46,7 @@ defmodule Destila.AITest do
       end)
 
       assert {:error, :empty_response} =
-               Destila.AI.generate_title(:prompt_chore_task, "something")
+               Destila.AI.generate_title(:brainstorm_idea, "something")
     end
 
     test "returns error when response is only whitespace" do
@@ -58,7 +58,7 @@ defmodule Destila.AITest do
       end)
 
       assert {:error, :empty_response} =
-               Destila.AI.generate_title(:prompt_chore_task, "something")
+               Destila.AI.generate_title(:brainstorm_idea, "something")
     end
 
     test "returns error on API failure" do
@@ -68,7 +68,7 @@ defmodule Destila.AITest do
         ]
       end)
 
-      assert {:error, _reason} = Destila.AI.generate_title(:prompt_chore_task, "something")
+      assert {:error, _reason} = Destila.AI.generate_title(:brainstorm_idea, "something")
     end
 
     test "passes correct options to ClaudeCode" do
@@ -83,12 +83,12 @@ defmodule Destila.AITest do
         ]
       end)
 
-      Destila.AI.generate_title(:prompt_chore_task, "test idea")
+      Destila.AI.generate_title(:brainstorm_idea, "test idea")
     end
 
     test "includes workflow type in the prompt" do
       ClaudeCode.Test.stub(ClaudeCode, fn query, _opts ->
-        assert query =~ "chore/task"
+        assert query =~ "brainstorm idea"
 
         [
           ClaudeCode.Test.text("Test Title"),
@@ -96,7 +96,7 @@ defmodule Destila.AITest do
         ]
       end)
 
-      Destila.AI.generate_title(:prompt_chore_task, "test idea")
+      Destila.AI.generate_title(:brainstorm_idea, "test idea")
     end
 
     test "includes idea in the prompt" do
@@ -109,7 +109,7 @@ defmodule Destila.AITest do
         ]
       end)
 
-      Destila.AI.generate_title(:prompt_chore_task, "build a REST API")
+      Destila.AI.generate_title(:brainstorm_idea, "build a REST API")
     end
   end
 end

--- a/test/destila/executions/engine_test.exs
+++ b/test/destila/executions/engine_test.exs
@@ -18,7 +18,7 @@ defmodule Destila.Executions.EngineTest do
   defp create_session(attrs) do
     default = %{
       title: "Test Session",
-      workflow_type: :prompt_chore_task,
+      workflow_type: :brainstorm_idea,
       current_phase: 3,
       total_phases: 6,
       phase_status: :awaiting_input

--- a/test/destila/executions_test.exs
+++ b/test/destila/executions_test.exs
@@ -7,7 +7,7 @@ defmodule Destila.ExecutionsTest do
     {:ok, ws} =
       Workflows.create_workflow_session(%{
         title: "Test Session",
-        workflow_type: :prompt_chore_task,
+        workflow_type: :brainstorm_idea,
         current_phase: 2,
         total_phases: 6
       })

--- a/test/destila/workflow_test.exs
+++ b/test/destila/workflow_test.exs
@@ -1,35 +1,35 @@
 defmodule Destila.WorkflowTest do
   use ExUnit.Case, async: true
 
-  alias Destila.Workflows.PromptChoreTaskWorkflow
+  alias Destila.Workflows.BrainstormIdeaWorkflow
   alias Destila.Workflows.ImplementGeneralPromptWorkflow
 
-  describe "Destila.Workflow behaviour via PromptChoreTaskWorkflow" do
+  describe "Destila.Workflow behaviour via BrainstormIdeaWorkflow" do
     test "total_phases/0 returns the correct count" do
-      assert PromptChoreTaskWorkflow.total_phases() == 6
+      assert BrainstormIdeaWorkflow.total_phases() == 6
     end
 
     test "phase_name/1 returns the correct name for valid phases" do
-      assert PromptChoreTaskWorkflow.phase_name(1) == "Project & Idea"
-      assert PromptChoreTaskWorkflow.phase_name(3) == "Task Description"
-      assert PromptChoreTaskWorkflow.phase_name(6) == "Prompt Generation"
+      assert BrainstormIdeaWorkflow.phase_name(1) == "Project & Idea"
+      assert BrainstormIdeaWorkflow.phase_name(3) == "Task Description"
+      assert BrainstormIdeaWorkflow.phase_name(6) == "Prompt Generation"
     end
 
     test "phase_name/1 returns nil for out-of-range or non-integer phases" do
-      assert is_nil(PromptChoreTaskWorkflow.phase_name(7))
-      assert is_nil(PromptChoreTaskWorkflow.phase_name("invalid"))
+      assert is_nil(BrainstormIdeaWorkflow.phase_name(7))
+      assert is_nil(BrainstormIdeaWorkflow.phase_name("invalid"))
     end
 
     test "phase_columns/0 includes all phases and done" do
-      columns = PromptChoreTaskWorkflow.phase_columns()
+      columns = BrainstormIdeaWorkflow.phase_columns()
       assert length(columns) == 7
       assert List.last(columns) == {:done, "Done"}
       assert hd(columns) == {1, "Project & Idea"}
     end
 
     test "session_strategy/1 defaults to :resume" do
-      assert PromptChoreTaskWorkflow.session_strategy(1) == :resume
-      assert PromptChoreTaskWorkflow.session_strategy(3) == :resume
+      assert BrainstormIdeaWorkflow.session_strategy(1) == :resume
+      assert BrainstormIdeaWorkflow.session_strategy(3) == :resume
     end
   end
 

--- a/test/destila/workflows_classify_test.exs
+++ b/test/destila/workflows_classify_test.exs
@@ -6,7 +6,7 @@ defmodule Destila.WorkflowsClassifyTest do
   defp create_session(attrs) do
     default = %{
       title: "Test Session",
-      workflow_type: :prompt_chore_task,
+      workflow_type: :brainstorm_idea,
       current_phase: 3,
       total_phases: 6,
       phase_status: :awaiting_input

--- a/test/destila/workflows_metadata_test.exs
+++ b/test/destila/workflows_metadata_test.exs
@@ -7,7 +7,7 @@ defmodule Destila.WorkflowsMetadataTest do
     {:ok, ws} =
       Workflows.create_workflow_session(%{
         title: "Test Session",
-        workflow_type: :prompt_chore_task,
+        workflow_type: :brainstorm_idea,
         current_phase: 2,
         total_phases: 6
       })

--- a/test/destila_web/live/archived_sessions_live_test.exs
+++ b/test/destila_web/live/archived_sessions_live_test.exs
@@ -24,7 +24,7 @@ defmodule DestilaWeb.ArchivedSessionsLiveTest do
   defp create_session(attrs) do
     defaults = %{
       title: "Test Session",
-      workflow_type: :prompt_chore_task,
+      workflow_type: :brainstorm_idea,
       current_phase: 1,
       total_phases: 6,
       position: System.unique_integer([:positive])

--- a/test/destila_web/live/brainstorm_idea_workflow_live_test.exs
+++ b/test/destila_web/live/brainstorm_idea_workflow_live_test.exs
@@ -1,13 +1,13 @@
-defmodule DestilaWeb.ChoreTaskWorkflowLiveTest do
+defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
   @moduledoc """
-  LiveView tests for the Chore/Task AI-Driven Workflow.
-  Feature: features/chore_task_workflow.feature
+  LiveView tests for the Brainstorm Idea AI-Driven Workflow.
+  Feature: features/brainstorm_idea_workflow.feature
   """
   use DestilaWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
 
-  @feature "chore_task_workflow"
+  @feature "brainstorm_idea_workflow"
 
   setup %{conn: conn} do
     ClaudeCode.Test.set_mode_to_shared()
@@ -35,7 +35,7 @@ defmodule DestilaWeb.ChoreTaskWorkflowLiveTest do
     project
   end
 
-  # Creates a chore_task session in the given phase with appropriate state.
+  # Creates a brainstorm_idea session in the given phase with appropriate state.
   defp create_session_in_phase(phase, opts \\ []) do
     phase_status = Keyword.get(opts, :phase_status, :awaiting_input)
     last_message_type = Keyword.get(opts, :last_message_type)
@@ -72,8 +72,8 @@ defmodule DestilaWeb.ChoreTaskWorkflowLiveTest do
 
     {:ok, ws} =
       Destila.Workflows.create_workflow_session(%{
-        title: "Test Chore Task",
-        workflow_type: :prompt_chore_task,
+        title: "Test Brainstorm Idea",
+        workflow_type: :brainstorm_idea,
         project_id: nil,
         current_phase: phase,
         total_phases: 6,
@@ -124,7 +124,7 @@ defmodule DestilaWeb.ChoreTaskWorkflowLiveTest do
     test "collects project and idea, creates session, redirects", %{conn: conn} do
       project = create_project()
 
-      {:ok, view, _html} = live(conn, ~p"/workflows/prompt_chore_task")
+      {:ok, view, _html} = live(conn, ~p"/workflows/brainstorm_idea")
 
       # Shows wizard form
       assert has_element?(view, "#project-list")
@@ -151,7 +151,7 @@ defmodule DestilaWeb.ChoreTaskWorkflowLiveTest do
     test "shows error when no project selected", %{conn: conn} do
       _project = create_project()
 
-      {:ok, view, _html} = live(conn, ~p"/workflows/prompt_chore_task")
+      {:ok, view, _html} = live(conn, ~p"/workflows/brainstorm_idea")
 
       # Submit without selecting project
       view
@@ -163,7 +163,7 @@ defmodule DestilaWeb.ChoreTaskWorkflowLiveTest do
 
     @tag feature: @feature, scenario: "Phase 1 - Wizard requires an idea"
     test "shows error when idea is empty", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/workflows/prompt_chore_task")
+      {:ok, view, _html} = live(conn, ~p"/workflows/brainstorm_idea")
 
       view
       |> form("#wizard-idea-form", %{"initial_idea" => ""})
@@ -181,7 +181,7 @@ defmodule DestilaWeb.ChoreTaskWorkflowLiveTest do
       {:ok, ws} =
         Destila.Workflows.create_workflow_session(%{
           title: "Test Session",
-          workflow_type: :prompt_chore_task,
+          workflow_type: :brainstorm_idea,
           current_phase: 2,
           total_phases: 6,
           phase_status: :setup,
@@ -395,7 +395,7 @@ defmodule DestilaWeb.ChoreTaskWorkflowLiveTest do
       {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
 
       # Title is displayed
-      assert render(view) =~ "Test Chore Task"
+      assert render(view) =~ "Test Brainstorm Idea"
 
       # Click to edit
       view |> element("button[phx-click='edit_title']") |> render_click()
@@ -424,7 +424,7 @@ defmodule DestilaWeb.ChoreTaskWorkflowLiveTest do
       {:ok, ws} =
         Destila.Workflows.create_workflow_session(%{
           title: "Test Session",
-          workflow_type: :prompt_chore_task,
+          workflow_type: :brainstorm_idea,
           current_phase: 2,
           total_phases: 6,
           phase_status: :setup,
@@ -562,7 +562,7 @@ defmodule DestilaWeb.ChoreTaskWorkflowLiveTest do
     {:ok, ws} =
       Destila.Workflows.create_workflow_session(%{
         title: "Test Options",
-        workflow_type: :prompt_chore_task,
+        workflow_type: :brainstorm_idea,
         current_phase: 3,
         total_phases: 6,
         phase_status: :awaiting_input
@@ -614,7 +614,7 @@ defmodule DestilaWeb.ChoreTaskWorkflowLiveTest do
     {:ok, ws} =
       Destila.Workflows.create_workflow_session(%{
         title: "Test Questions",
-        workflow_type: :prompt_chore_task,
+        workflow_type: :brainstorm_idea,
         current_phase: 3,
         total_phases: 6,
         phase_status: :awaiting_input

--- a/test/destila_web/live/crafting_board_live_test.exs
+++ b/test/destila_web/live/crafting_board_live_test.exs
@@ -30,7 +30,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
   defp create_prompt(attrs) do
     defaults = %{
       title: "Test Prompt",
-      workflow_type: :prompt_chore_task,
+      workflow_type: :brainstorm_idea,
       current_phase: 1,
       total_phases: 6,
       position: System.unique_integer([:positive])
@@ -79,7 +79,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
         create_prompt(%{
           title: "Active Prompt",
           phase_status: nil,
-          workflow_type: :prompt_chore_task,
+          workflow_type: :brainstorm_idea,
           project_id: project.id
         })
 
@@ -130,7 +130,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
         title: "Fix login bug",
         project_id: project.id,
         current_phase: 3,
-        workflow_type: :prompt_chore_task
+        workflow_type: :brainstorm_idea
       })
 
       {:ok, _view, html} = live(conn, ~p"/crafting")
@@ -235,7 +235,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
         create_prompt(%{
           title: "No Project",
           project_id: nil,
-          workflow_type: :prompt_chore_task
+          workflow_type: :brainstorm_idea
         })
 
       {:ok, view, _html} = live(conn, ~p"/crafting")
@@ -261,14 +261,14 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
     test "toggle shows workflow boards with phase columns", %{conn: conn, project_a: project} do
       create_prompt(%{
         title: "Chore Prompt",
-        workflow_type: :prompt_chore_task,
+        workflow_type: :brainstorm_idea,
         current_phase: 3,
         project_id: project.id
       })
 
       create_prompt(%{
         title: "Another Chore",
-        workflow_type: :prompt_chore_task,
+        workflow_type: :brainstorm_idea,
         current_phase: 4,
         project_id: project.id
       })
@@ -279,9 +279,9 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
       view |> element("#view-toggle button[phx-value-mode=workflow]") |> render_click()
 
       # Should see workflow board
-      assert has_element?(view, "#workflow-board-prompt_chore_task")
+      assert has_element?(view, "#workflow-board-brainstorm_idea")
 
-      # Chore/Task board should have phase columns
+      # Brainstorm Idea board should have phase columns
       html = render(view)
       assert html =~ "Task Description"
       assert html =~ "Gherkin Review"
@@ -291,20 +291,20 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
     test "hides workflow boards with no prompts", %{conn: conn, project_a: project} do
       create_prompt(%{
         title: "Chore Only",
-        workflow_type: :prompt_chore_task,
+        workflow_type: :brainstorm_idea,
         project_id: project.id
       })
 
       {:ok, view, _html} = live(conn, "/crafting?view=workflow")
 
-      assert has_element?(view, "#workflow-board-prompt_chore_task")
+      assert has_element?(view, "#workflow-board-brainstorm_idea")
     end
 
     @tag feature: @feature, scenario: "Boards are read-only (no drag and drop)"
     test "no sortable hooks on workflow boards", %{conn: conn, project_a: project} do
       create_prompt(%{
         title: "Test Prompt",
-        workflow_type: :prompt_chore_task,
+        workflow_type: :brainstorm_idea,
         project_id: project.id
       })
 
@@ -337,14 +337,14 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
       prompt_a =
         create_prompt(%{
           title: "Chore A",
-          workflow_type: :prompt_chore_task,
+          workflow_type: :brainstorm_idea,
           project_id: project_a.id
         })
 
       prompt_b =
         create_prompt(%{
           title: "Chore B",
-          workflow_type: :prompt_chore_task,
+          workflow_type: :brainstorm_idea,
           project_id: project_b.id
         })
 

--- a/test/destila_web/live/generated_prompt_viewing_live_test.exs
+++ b/test/destila_web/live/generated_prompt_viewing_live_test.exs
@@ -45,7 +45,7 @@ defmodule DestilaWeb.GeneratedPromptViewingLiveTest do
     {:ok, workflow_session} =
       Destila.Workflows.create_workflow_session(%{
         title: "Test Session",
-        workflow_type: :prompt_chore_task,
+        workflow_type: :brainstorm_idea,
         project_id: nil,
         done_at: DateTime.utc_now(),
         current_phase: 6,

--- a/test/destila_web/live/implement_general_prompt_workflow_live_test.exs
+++ b/test/destila_web/live/implement_general_prompt_workflow_live_test.exs
@@ -35,13 +35,13 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
     project
   end
 
-  defp create_completed_chore_task_session do
+  defp create_completed_brainstorm_idea_session do
     project = create_project()
 
     {:ok, ws} =
       Destila.Workflows.create_workflow_session(%{
-        title: "Completed Chore Task",
-        workflow_type: :prompt_chore_task,
+        title: "Completed Brainstorm Idea",
+        workflow_type: :brainstorm_idea,
         project_id: project.id,
         current_phase: 6,
         total_phases: 6,
@@ -123,8 +123,8 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
 
     @tag feature: @feature,
          scenario: "Phase 1 - Wizard with existing session prompt selection"
-    test "shows completed chore/task sessions for selection", %{conn: conn} do
-      {ws, _project} = create_completed_chore_task_session()
+    test "shows completed brainstorm idea sessions for selection", %{conn: conn} do
+      {ws, _project} = create_completed_brainstorm_idea_session()
       {:ok, view, _html} = live(conn, ~p"/workflows/implement_general_prompt")
 
       assert has_element?(view, "#session-#{ws.id}")
@@ -133,7 +133,7 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
     @tag feature: @feature,
          scenario: "Phase 1 - Wizard with existing session prompt selection"
     test "pre-selects project when existing session chosen", %{conn: conn} do
-      {ws, project} = create_completed_chore_task_session()
+      {ws, project} = create_completed_brainstorm_idea_session()
       {:ok, view, _html} = live(conn, ~p"/workflows/implement_general_prompt")
 
       # Select the existing session

--- a/test/destila_web/live/project_inline_creation_live_test.exs
+++ b/test/destila_web/live/project_inline_creation_live_test.exs
@@ -10,7 +10,7 @@ defmodule DestilaWeb.ProjectInlineCreationLiveTest do
   @feature "project_inline_creation"
 
   # Ensure the atom exists before tests run
-  _ = :prompt_chore_task
+  _ = :brainstorm_idea
 
   setup %{conn: conn} do
     # Create an existing project so #create-new-project-btn is available
@@ -27,7 +27,7 @@ defmodule DestilaWeb.ProjectInlineCreationLiveTest do
   describe "inline project creation" do
     @tag feature: @feature, scenario: "Create a project with a git repository URL"
     test "creates project with git URL and selects it", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/workflows/prompt_chore_task")
+      {:ok, view, _html} = live(conn, ~p"/workflows/brainstorm_idea")
 
       view |> element("#create-new-project-btn") |> render_click()
 
@@ -49,7 +49,7 @@ defmodule DestilaWeb.ProjectInlineCreationLiveTest do
 
     @tag feature: @feature, scenario: "Create a project with a local folder only"
     test "creates project with local folder and selects it", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/workflows/prompt_chore_task")
+      {:ok, view, _html} = live(conn, ~p"/workflows/brainstorm_idea")
 
       view |> element("#create-new-project-btn") |> render_click()
 
@@ -67,7 +67,7 @@ defmodule DestilaWeb.ProjectInlineCreationLiveTest do
 
     @tag feature: @feature, scenario: "Create a project with both git URL and local folder"
     test "creates project with both git URL and local folder", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/workflows/prompt_chore_task")
+      {:ok, view, _html} = live(conn, ~p"/workflows/brainstorm_idea")
 
       view |> element("#create-new-project-btn") |> render_click()
 
@@ -86,7 +86,7 @@ defmodule DestilaWeb.ProjectInlineCreationLiveTest do
 
     @tag feature: @feature, scenario: "Cannot create a project without git URL or local folder"
     test "shows error when neither git URL nor local folder provided", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/workflows/prompt_chore_task")
+      {:ok, view, _html} = live(conn, ~p"/workflows/brainstorm_idea")
 
       view |> element("#create-new-project-btn") |> render_click()
 
@@ -101,7 +101,7 @@ defmodule DestilaWeb.ProjectInlineCreationLiveTest do
 
     @tag feature: @feature, scenario: "Cannot create a project without a name"
     test "shows error when name is empty", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/workflows/prompt_chore_task")
+      {:ok, view, _html} = live(conn, ~p"/workflows/brainstorm_idea")
 
       view |> element("#create-new-project-btn") |> render_click()
 

--- a/test/destila_web/live/projects_live_test.exs
+++ b/test/destila_web/live/projects_live_test.exs
@@ -197,7 +197,7 @@ defmodule DestilaWeb.ProjectsLiveTest do
         Destila.Workflows.create_workflow_session(%{
           title: "Test Prompt",
           project_id: project.id,
-          workflow_type: :prompt_chore_task,
+          workflow_type: :brainstorm_idea,
           total_phases: 6
         })
 

--- a/test/destila_web/live/session_archiving_live_test.exs
+++ b/test/destila_web/live/session_archiving_live_test.exs
@@ -25,7 +25,7 @@ defmodule DestilaWeb.SessionArchivingLiveTest do
   defp create_session(attrs) do
     defaults = %{
       title: "Test Session",
-      workflow_type: :prompt_chore_task,
+      workflow_type: :brainstorm_idea,
       current_phase: 1,
       total_phases: 6,
       phase_status: :awaiting_input,

--- a/test/destila_web/live/workflow_type_selection_live_test.exs
+++ b/test/destila_web/live/workflow_type_selection_live_test.exs
@@ -10,7 +10,7 @@ defmodule DestilaWeb.WorkflowTypeSelectionLiveTest do
   @feature "workflow_type_selection"
 
   # Ensure the atom exists
-  _ = :prompt_chore_task
+  _ = :brainstorm_idea
 
   setup %{conn: conn} do
     conn = post(conn, "/login", %{"email" => "test@example.com"})
@@ -23,19 +23,19 @@ defmodule DestilaWeb.WorkflowTypeSelectionLiveTest do
       {:ok, _view, html} = live(conn, ~p"/workflows")
 
       assert html =~ "What are you creating?"
-      assert html =~ "Prompt for a Chore / Task"
+      assert html =~ "Brainstorm Idea"
       assert html =~ "Straightforward coding tasks"
-      assert has_element?(live(conn, ~p"/workflows") |> elem(1), "#type-prompt_chore_task")
+      assert has_element?(live(conn, ~p"/workflows") |> elem(1), "#type-brainstorm_idea")
     end
 
     @tag feature: @feature, scenario: "Select a workflow type to start"
     test "clicking a type navigates to its wizard", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/workflows")
 
-      view |> element("#type-prompt_chore_task") |> render_click()
+      view |> element("#type-brainstorm_idea") |> render_click()
 
       {path, _flash} = assert_redirect(view)
-      assert path == "/workflows/prompt_chore_task"
+      assert path == "/workflows/brainstorm_idea"
     end
   end
 end


### PR DESCRIPTION
## Summary

- Renames the "Prompt for a Chore / Task" workflow to "Brainstorm Idea" across all layers
- Database migration converts existing `prompt_chore_task` records to `brainstorm_idea`
- Updates UI labels, code identifiers, Ecto schema enum, tests, feature files, and memory files
- No behavioral changes — strictly a rename

## Changes

- **Migration:** `priv/repo/migrations/20260401000000_rename_prompt_chore_task_to_brainstorm_idea.exs`
- **Workflow module:** `prompt_chore_task_workflow.ex` → `brainstorm_idea_workflow.ex`
- **Registry & schema:** Updated workflow type atom in `workflows.ex` and `session.ex`
- **UI components:** Board badge label, AI title generation label, prompt wizard reference text
- **Tests:** 15 test files updated (module names, atoms, routes, assertions, feature tags)
- **Features:** 3 Gherkin feature files updated
- **Memory files:** 2 `.serena/memories/` files updated

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test` — 146/149 pass (3 pre-existing timing failures unrelated to rename)
- [x] Verification greps confirm zero stale references to old names

🤖 Generated with [Claude Code](https://claude.com/claude-code)