### PR TITLE
Centralize workflow session creation in Workflows context

### DIFF
--- a/lib/destila/workers/prepare_workflow_session.ex
+++ b/lib/destila/workers/prepare_workflow_session.ex
@@ -1,4 +1,4 @@
-defmodule Destila.Workers.SetupWorker do
+defmodule Destila.Workers.PrepareWorkflowSession do
   use Oban.Worker, queue: :setup, max_attempts: 3
 
   alias Destila.{Git, Workflows}

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -33,6 +33,22 @@ defmodule Destila.Workflows do
   end
 
   def creation_config(workflow_type), do: workflow_module(workflow_type).creation_config()
+
+  def list_source_sessions(workflow_type) do
+    {source_key, _label, _dest_key} = creation_config(workflow_type)
+
+    if source_key do
+      list_sessions_with_exported_metadata(source_key)
+    else
+      []
+    end
+  end
+
+  def creation_label(workflow_type) do
+    {_source_key, label, _dest_key} = creation_config(workflow_type)
+    label
+  end
+
   def phases(workflow_type), do: workflow_module(workflow_type).phases()
   def total_phases(workflow_type), do: workflow_module(workflow_type).total_phases()
   def phase_name(workflow_type, phase), do: workflow_module(workflow_type).phase_name(phase)
@@ -94,12 +110,12 @@ defmodule Destila.Workflows do
   def create_workflow_session(params) do
     %{
       workflow_type: workflow_type,
-      input_text: input_text,
-      dest_metadata_key: dest_key
+      input_text: input_text
     } = params
 
     selected_session_id = Map.get(params, :selected_session_id)
     project_id = Map.get(params, :project_id)
+    {_source_key, _label, dest_key} = creation_config(workflow_type)
 
     title =
       if selected_session_id do

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -91,13 +91,65 @@ defmodule Destila.Workflows do
     Repo.get!(Session, id)
   end
 
-  def create_workflow_session(attrs) do
+  def create_workflow_session(params) do
+    %{
+      workflow_type: workflow_type,
+      input_text: input_text,
+      dest_metadata_key: dest_key
+    } = params
+
+    selected_session_id = Map.get(params, :selected_session_id)
+    project_id = Map.get(params, :project_id)
+
+    title =
+      if selected_session_id do
+        source = get_workflow_session(selected_session_id)
+        if source, do: source.title, else: default_title(workflow_type)
+      else
+        default_title(workflow_type)
+      end
+
+    title_generating = is_nil(selected_session_id)
+
+    session_attrs =
+      %{
+        title: title,
+        workflow_type: workflow_type,
+        current_phase: 1,
+        total_phases: total_phases(workflow_type),
+        phase_status: :setup,
+        title_generating: title_generating
+      }
+      |> maybe_put(:project_id, project_id)
+
+    with {:ok, ws} <- insert_workflow_session(session_attrs) do
+      upsert_metadata(ws.id, "creation", dest_key, %{"text" => input_text})
+
+      if selected_session_id do
+        upsert_metadata(ws.id, "creation", "source_session", %{"id" => selected_session_id})
+      end
+
+      prepare_workflow_session(ws)
+
+      {:ok, ws}
+    end
+  end
+
+  @doc false
+  def insert_workflow_session(attrs) do
     attrs = Map.put_new_lazy(attrs, :position, fn -> System.unique_integer([:positive]) end)
 
     %Session{}
     |> Session.changeset(attrs)
     |> Repo.insert()
     |> broadcast(:workflow_session_created)
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  def prepare_workflow_session(%Session{} = ws) do
+    Destila.Workflows.Setup.start(ws)
   end
 
   def update_workflow_session(%Session{} = workflow_session, attrs) do

--- a/lib/destila/workflows/setup.ex
+++ b/lib/destila/workflows/setup.ex
@@ -22,7 +22,7 @@ defmodule Destila.Workflows.Setup do
 
     if ws.project_id do
       %{"workflow_session_id" => ws.id}
-      |> Destila.Workers.SetupWorker.new()
+      |> Destila.Workers.PrepareWorkflowSession.new()
       |> Oban.insert()
     end
 

--- a/lib/destila_web/live/create_session_live.ex
+++ b/lib/destila_web/live/create_session_live.ex
@@ -166,52 +166,25 @@ defmodule DestilaWeb.CreateSessionLive do
         _ -> socket
       end
 
-    %{
-      workflow_type: workflow_type,
-      dest_metadata_key: dest_key,
-      input_text: input_text,
-      selected_session_id: selected_session_id,
-      project_id: project_id
-    } = socket.assigns
-
     errors = validate(socket.assigns)
 
     if errors == %{} do
-      # Determine title
-      title =
-        if selected_session_id do
-          source = Workflows.get_workflow_session(selected_session_id)
-          if source, do: source.title, else: Workflows.default_title(workflow_type)
-        else
-          Workflows.default_title(workflow_type)
-        end
+      %{
+        workflow_type: workflow_type,
+        dest_metadata_key: dest_key,
+        input_text: input_text,
+        selected_session_id: selected_session_id,
+        project_id: project_id
+      } = socket.assigns
 
-      title_generating = is_nil(selected_session_id)
-
-      session_attrs =
-        %{
-          title: title,
+      {:ok, ws} =
+        Workflows.create_workflow_session(%{
           workflow_type: workflow_type,
-          current_phase: 1,
-          total_phases: Workflows.total_phases(workflow_type),
-          phase_status: :setup,
-          title_generating: title_generating
-        }
-        |> maybe_put(:project_id, project_id)
-
-      {:ok, ws} = Workflows.create_workflow_session(session_attrs)
-
-      # Store creation metadata
-      Workflows.upsert_metadata(ws.id, "creation", dest_key, %{"text" => input_text})
-
-      if selected_session_id do
-        Workflows.upsert_metadata(ws.id, "creation", "source_session", %{
-          "id" => selected_session_id
+          input_text: input_text,
+          dest_metadata_key: dest_key,
+          selected_session_id: selected_session_id,
+          project_id: project_id
         })
-      end
-
-      # Start setup (title gen, repo sync, worktree)
-      Workflows.Setup.start(ws)
 
       {:noreply, push_navigate(socket, to: ~p"/sessions/#{ws.id}")}
     else
@@ -414,9 +387,6 @@ defmodule DestilaWeb.CreateSessionLive do
 
     errors
   end
-
-  defp maybe_put(map, _key, nil), do: map
-  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   defp non_blank(nil), do: nil
   defp non_blank(""), do: nil

--- a/lib/destila_web/live/create_session_live.ex
+++ b/lib/destila_web/live/create_session_live.ex
@@ -29,22 +29,13 @@ defmodule DestilaWeb.CreateSessionLive do
 
   defp mount_form(workflow_type_str, socket) do
     workflow_type = String.to_existing_atom(workflow_type_str)
-    {source_key, label, dest_key} = Workflows.creation_config(workflow_type)
-
-    source_sessions =
-      if source_key do
-        Workflows.list_sessions_with_exported_metadata(source_key)
-      else
-        []
-      end
+    source_sessions = Workflows.list_source_sessions(workflow_type)
 
     {:ok,
      socket
      |> assign(:view, :form)
      |> assign(:workflow_type, workflow_type)
-     |> assign(:source_metadata_key, source_key)
-     |> assign(:input_label, label)
-     |> assign(:dest_metadata_key, dest_key)
+     |> assign(:input_label, Workflows.creation_label(workflow_type))
      |> assign(:source_sessions, source_sessions)
      |> assign(:selected_session_id, nil)
      |> assign(:selected_text, nil)
@@ -171,7 +162,6 @@ defmodule DestilaWeb.CreateSessionLive do
     if errors == %{} do
       %{
         workflow_type: workflow_type,
-        dest_metadata_key: dest_key,
         input_text: input_text,
         selected_session_id: selected_session_id,
         project_id: project_id
@@ -181,7 +171,6 @@ defmodule DestilaWeb.CreateSessionLive do
         Workflows.create_workflow_session(%{
           workflow_type: workflow_type,
           input_text: input_text,
-          dest_metadata_key: dest_key,
           selected_session_id: selected_session_id,
           project_id: project_id
         })

--- a/lib/destila_web/live/phases/setup_phase.ex
+++ b/lib/destila_web/live/phases/setup_phase.ex
@@ -24,7 +24,7 @@ defmodule DestilaWeb.Phases.SetupPhase do
   end
 
   def handle_event("retry_setup", _params, socket) do
-    Destila.Workflows.Setup.start(socket.assigns.workflow_session)
+    Destila.Workflows.prepare_workflow_session(socket.assigns.workflow_session)
     {:noreply, socket}
   end
 

--- a/test/destila/executions/engine_test.exs
+++ b/test/destila/executions/engine_test.exs
@@ -24,7 +24,7 @@ defmodule Destila.Executions.EngineTest do
       phase_status: :awaiting_input
     }
 
-    {:ok, ws} = Workflows.create_workflow_session(Map.merge(default, attrs))
+    {:ok, ws} = Workflows.insert_workflow_session(Map.merge(default, attrs))
     ws
   end
 

--- a/test/destila/executions_test.exs
+++ b/test/destila/executions_test.exs
@@ -5,7 +5,7 @@ defmodule Destila.ExecutionsTest do
 
   defp create_session do
     {:ok, ws} =
-      Workflows.create_workflow_session(%{
+      Workflows.insert_workflow_session(%{
         title: "Test Session",
         workflow_type: :brainstorm_idea,
         current_phase: 1,

--- a/test/destila/workflows_classify_test.exs
+++ b/test/destila/workflows_classify_test.exs
@@ -12,7 +12,7 @@ defmodule Destila.WorkflowsClassifyTest do
       phase_status: :awaiting_input
     }
 
-    {:ok, ws} = Workflows.create_workflow_session(Map.merge(default, attrs))
+    {:ok, ws} = Workflows.insert_workflow_session(Map.merge(default, attrs))
     ws
   end
 

--- a/test/destila/workflows_metadata_test.exs
+++ b/test/destila/workflows_metadata_test.exs
@@ -5,7 +5,7 @@ defmodule Destila.WorkflowsMetadataTest do
 
   defp create_session do
     {:ok, ws} =
-      Workflows.create_workflow_session(%{
+      Workflows.insert_workflow_session(%{
         title: "Test Session",
         workflow_type: :brainstorm_idea,
         current_phase: 1,

--- a/test/destila_web/live/archived_sessions_live_test.exs
+++ b/test/destila_web/live/archived_sessions_live_test.exs
@@ -30,7 +30,7 @@ defmodule DestilaWeb.ArchivedSessionsLiveTest do
       position: System.unique_integer([:positive])
     }
 
-    {:ok, session} = Destila.Workflows.create_workflow_session(Map.merge(defaults, attrs))
+    {:ok, session} = Destila.Workflows.insert_workflow_session(Map.merge(defaults, attrs))
     session
   end
 

--- a/test/destila_web/live/brainstorm_idea_workflow_live_test.exs
+++ b/test/destila_web/live/brainstorm_idea_workflow_live_test.exs
@@ -71,7 +71,7 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
       end
 
     {:ok, ws} =
-      Destila.Workflows.create_workflow_session(%{
+      Destila.Workflows.insert_workflow_session(%{
         title: "Test Brainstorm Idea",
         workflow_type: :brainstorm_idea,
         project_id: nil,
@@ -177,7 +177,7 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
     @tag feature: @feature, scenario: "Setup displays progress"
     test "shows setup progress steps", %{conn: conn} do
       {:ok, ws} =
-        Destila.Workflows.create_workflow_session(%{
+        Destila.Workflows.insert_workflow_session(%{
           title: "Test Session",
           workflow_type: :brainstorm_idea,
           current_phase: 1,
@@ -420,7 +420,7 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
       project = create_project()
 
       {:ok, ws} =
-        Destila.Workflows.create_workflow_session(%{
+        Destila.Workflows.insert_workflow_session(%{
           title: "Test Session",
           workflow_type: :brainstorm_idea,
           current_phase: 1,
@@ -593,7 +593,7 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
 
   defp create_session_with_options(input_type) do
     {:ok, ws} =
-      Destila.Workflows.create_workflow_session(%{
+      Destila.Workflows.insert_workflow_session(%{
         title: "Test Options",
         workflow_type: :brainstorm_idea,
         current_phase: 1,
@@ -645,7 +645,7 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
 
   defp create_session_with_questions do
     {:ok, ws} =
-      Destila.Workflows.create_workflow_session(%{
+      Destila.Workflows.insert_workflow_session(%{
         title: "Test Questions",
         workflow_type: :brainstorm_idea,
         current_phase: 1,

--- a/test/destila_web/live/crafting_board_live_test.exs
+++ b/test/destila_web/live/crafting_board_live_test.exs
@@ -36,7 +36,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
       position: System.unique_integer([:positive])
     }
 
-    {:ok, prompt} = Destila.Workflows.create_workflow_session(Map.merge(defaults, attrs))
+    {:ok, prompt} = Destila.Workflows.insert_workflow_session(Map.merge(defaults, attrs))
     prompt
   end
 

--- a/test/destila_web/live/generated_prompt_viewing_live_test.exs
+++ b/test/destila_web/live/generated_prompt_viewing_live_test.exs
@@ -43,7 +43,7 @@ defmodule DestilaWeb.GeneratedPromptViewingLiveTest do
 
   defp create_session_with_generated_prompt do
     {:ok, workflow_session} =
-      Destila.Workflows.create_workflow_session(%{
+      Destila.Workflows.insert_workflow_session(%{
         title: "Test Session",
         workflow_type: :brainstorm_idea,
         project_id: nil,

--- a/test/destila_web/live/implement_general_prompt_workflow_live_test.exs
+++ b/test/destila_web/live/implement_general_prompt_workflow_live_test.exs
@@ -39,7 +39,7 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
     project = create_project()
 
     {:ok, ws} =
-      Destila.Workflows.create_workflow_session(%{
+      Destila.Workflows.insert_workflow_session(%{
         title: "Completed Brainstorm Idea",
         workflow_type: :brainstorm_idea,
         project_id: project.id,
@@ -64,7 +64,7 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
     project_id = Keyword.get(opts, :project_id)
 
     {:ok, ws} =
-      Destila.Workflows.create_workflow_session(%{
+      Destila.Workflows.insert_workflow_session(%{
         title: "Test Implementation",
         workflow_type: :implement_general_prompt,
         project_id: project_id,

--- a/test/destila_web/live/projects_live_test.exs
+++ b/test/destila_web/live/projects_live_test.exs
@@ -194,7 +194,7 @@ defmodule DestilaWeb.ProjectsLiveTest do
         })
 
       {:ok, _ws} =
-        Destila.Workflows.create_workflow_session(%{
+        Destila.Workflows.insert_workflow_session(%{
           title: "Test Prompt",
           project_id: project.id,
           workflow_type: :brainstorm_idea,

--- a/test/destila_web/live/session_archiving_live_test.exs
+++ b/test/destila_web/live/session_archiving_live_test.exs
@@ -32,7 +32,7 @@ defmodule DestilaWeb.SessionArchivingLiveTest do
       position: System.unique_integer([:positive])
     }
 
-    {:ok, session} = Destila.Workflows.create_workflow_session(Map.merge(defaults, attrs))
+    {:ok, session} = Destila.Workflows.insert_workflow_session(Map.merge(defaults, attrs))
     session
   end
 


### PR DESCRIPTION
## Summary
- Move title determination, metadata storage, and setup dispatching from `CreateSessionLive` into `Workflows.create_workflow_session` — the LiveView now just validates inputs and delegates
- Rename `SetupWorker` to `PrepareWorkflowSession` for clarity
- Add `Workflows.prepare_workflow_session/1` as the single entry point for setup, used by both creation and retry flows (replaces direct `Workflows.Setup.start` calls from UI)
- Extract `Workflows.insert_workflow_session/1` for test fixtures that need sessions in specific states without triggering the full creation flow

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test` — 186 tests, 1 pre-existing failure (unrelated `ClaudeSessionTest`)
- [ ] Manual: create a new brainstorm idea session and verify setup runs
- [ ] Manual: create a new implement prompt session from a completed brainstorm and verify title is inherited

🤖 Generated with [Claude Code](https://claude.com/claude-code)