### PR TITLE
Change primary color to golden yellow

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -32,8 +32,8 @@
   --color-base-200: oklch(15% 0.008 260);
   --color-base-300: oklch(30% 0.015 260);
   --color-base-content: oklch(93% 0.005 260);
-  --color-primary: oklch(55% 0.2 265);
-  --color-primary-content: oklch(98% 0.01 265);
+  --color-primary: oklch(75% 0.18 85);
+  --color-primary-content: oklch(20% 0.02 85);
   --color-secondary: oklch(60% 0.15 290);
   --color-secondary-content: oklch(98% 0.01 290);
   --color-accent: oklch(70% 0.17 250);
@@ -68,8 +68,8 @@
   --color-base-200: oklch(97% 0.003 260);
   --color-base-300: oklch(93% 0.005 260);
   --color-base-content: oklch(25% 0.01 260);
-  --color-primary: oklch(55% 0.2 265);
-  --color-primary-content: oklch(98% 0.01 265);
+  --color-primary: oklch(75% 0.18 85);
+  --color-primary-content: oklch(20% 0.02 85);
   --color-secondary: oklch(55% 0.15 290);
   --color-secondary-content: oklch(98% 0.01 290);
   --color-accent: oklch(25% 0.01 260);
@@ -190,7 +190,7 @@ a, button, .card, .btn, input {
   border-color: oklch(0% 0 0 / 0.1);
 }
 .prose a {
-  color: oklch(55% 0.2 265);
+  color: oklch(75% 0.18 85);
   text-decoration: underline;
 }
 

--- a/docs/plans/2026-04-05-feat-golden-yellow-primary-color-plan.md
+++ b/docs/plans/2026-04-05-feat-golden-yellow-primary-color-plan.md
@@ -1,0 +1,99 @@
+# Plan: Change primary color from purple/blue to golden yellow
+
+## Summary
+
+Update the application's primary color from purple/blue (`oklch(55% 0.2 265)`) to golden yellow (`oklch(75% 0.18 85)`, approximately `#EAB308`) in both the light and dark daisyUI theme definitions in `assets/css/app.css`. Also update the `--color-primary-content` values to use the yellow hue, and fix the hardcoded purple link color in the `.prose a` rule.
+
+## Changes
+
+**File:** `assets/css/app.css`
+
+### 1. Dark theme primary color (line 35)
+
+**Before:**
+```css
+--color-primary: oklch(55% 0.2 265);
+```
+
+**After:**
+```css
+--color-primary: oklch(75% 0.18 85);
+```
+
+### 2. Dark theme primary-content hue (line 36)
+
+**Before:**
+```css
+--color-primary-content: oklch(98% 0.01 265);
+```
+
+**After:**
+```css
+--color-primary-content: oklch(20% 0.02 85);
+```
+
+The primary is now a bright yellow, so content on top of it should be dark for contrast (matching the existing warning-content pattern on line 48).
+
+### 3. Light theme primary color (line 71)
+
+**Before:**
+```css
+--color-primary: oklch(55% 0.2 265);
+```
+
+**After:**
+```css
+--color-primary: oklch(75% 0.18 85);
+```
+
+### 4. Light theme primary-content hue (line 72)
+
+**Before:**
+```css
+--color-primary-content: oklch(98% 0.01 265);
+```
+
+**After:**
+```css
+--color-primary-content: oklch(20% 0.02 85);
+```
+
+Same rationale — dark text on bright yellow background.
+
+### 5. Prose link color (line 193)
+
+**Before:**
+```css
+color: oklch(55% 0.2 265);
+```
+
+**After:**
+```css
+color: oklch(75% 0.18 85);
+```
+
+This hardcoded color mirrors the primary and should track the new value.
+
+## Details
+
+- The `oklch` color model uses three channels: Lightness (L), Chroma (C), and Hue (H).
+- The hue rotates from `265` (purple/blue) to `85` (yellow). Lightness increases from `55%` to `75%` since yellow needs higher lightness to appear vibrant. Chroma goes from `0.2` to `0.18`.
+- `oklch(75% 0.18 85)` converts to approximately `#EAB308` (Tailwind's `yellow-500`).
+- The `--color-primary-content` switches from light-on-dark to dark-on-light because yellow is a bright color that needs dark text for readable contrast (WCAG).
+- No other color variables (secondary, accent, neutral, info, success, warning, error) are modified.
+- All components using the daisyUI `primary` color token (buttons, badges, links, etc.) will automatically inherit the new color.
+
+## Scope
+
+- **Files changed:** 1 (`assets/css/app.css`)
+- **Lines changed:** 5 (lines 35, 36, 71, 72, 193)
+- **Risk:** Low — CSS custom property value changes only, no logic involved.
+- **Gherkin impact:** None — no feature scenarios reference specific colors.
+
+## Verification
+
+1. Run `mix precommit` to verify compilation and tests pass.
+2. Visually inspect both light and dark themes in a browser to confirm:
+   - Primary-colored elements (buttons, badges, links) appear golden yellow.
+   - Text on primary-colored backgrounds is readable (dark text on yellow).
+   - No other UI elements are unintentionally affected.


### PR DESCRIPTION
## Summary

- Update application primary color from purple/blue to golden yellow (`oklch(75% 0.18 85)` ≈ `#EAB308`)
- Update primary-content to dark text for WCAG contrast on bright yellow backgrounds
- Fix hardcoded prose link color to track the new primary

## Changes

- **File:** `assets/css/app.css` (5 lines changed)
- Both dark and light daisyUI theme definitions updated
- All components using the `primary` color token automatically inherit the new color

## Test plan

- [x] `mix precommit` passes (CSS-only, no logic changes)
- [ ] Visual inspection: primary buttons, badges, links appear golden yellow
- [ ] Text on primary backgrounds is readable (dark text on yellow)


🤖 Generated with [Claude Code](https://claude.com/claude-code)