### PR TITLE
refactor: Convert PhaseExecution.status from string to Ecto.Enum

### DIFF
--- a/docs/plans/2026-04-06-refactor-ecto-enum-phase-execution-status-plan.md
+++ b/docs/plans/2026-04-06-refactor-ecto-enum-phase-execution-status-plan.md
@@ -1,0 +1,160 @@
+---
+title: "refactor: Convert PhaseExecution.status from string to Ecto.Enum"
+type: refactor
+date: 2026-04-06
+---
+
+# refactor: Convert PhaseExecution.status from string to Ecto.Enum
+
+## Overview
+
+`Destila.Executions.PhaseExecution` stores `status` as a plain `:string` with a `@statuses` module attribute and `validate_inclusion` for validation. Meanwhile, `Destila.Workflows.Session` already uses `Ecto.Enum` for its `phase_status` field. This inconsistency means no compile-time safety on phase execution status values — a typo like `"procesing"` would silently pass the changeset.
+
+Converting to `Ecto.Enum` gives us:
+- Compile-time validation of status atoms
+- Consistent pattern with `Session.phase_status`
+- Automatic validation (no manual `validate_inclusion` needed)
+
+Since SQLite stores `Ecto.Enum` values as their string representation, no data migration is needed — existing `"pending"` rows are read back as `:pending` automatically.
+
+## Changes
+
+### Step 1: Update the PhaseExecution schema
+
+**File:** `lib/destila/executions/phase_execution.ex`
+
+1. Change `field(:status, :string, default: "pending")` → `field(:status, Ecto.Enum, values: [:pending, :processing, :awaiting_input, :awaiting_confirmation, :completed, :skipped, :failed], default: :pending)`
+2. Remove the `@statuses` module attribute (`~w(pending awaiting_input processing awaiting_confirmation completed skipped failed)`)
+3. Remove `validate_inclusion(:status, @statuses)` from `changeset/2` (Ecto.Enum handles validation)
+4. Remove the `def statuses` function (no longer needed — `Ecto.Enum.values/2` can be used if ever needed)
+
+### Step 2: Create a no-op migration
+
+Run `mix ecto.gen.migration convert_phase_execution_status_to_enum`.
+
+The migration body should be empty (no column changes needed) since SQLite stores `Ecto.Enum` as strings, which matches the existing column type. Add a comment explaining why.
+
+### Step 3: Update status references in `Destila.Executions`
+
+**File:** `lib/destila/executions.ex`
+
+All string status literals become atoms:
+
+| Location | Old | New |
+|---|---|---|
+| `create_phase_execution/3` (line 63) | `status: "pending"` | `status: :pending` |
+| `complete_phase/2` (line 78) | `"completed"` | `:completed` |
+| `stage_completion/2` (line 85) | `"awaiting_confirmation"` | `:awaiting_confirmation` |
+| `reject_completion/1` (line 93) | `"awaiting_input"` | `:awaiting_input` |
+| `skip_phase/2` (line 97) | `"skipped"` | `:skipped` |
+| `start_phase/2` (line 103) | `"processing"` (default arg) | `:processing` |
+
+### Step 4: Update status references in `Destila.Executions.Engine`
+
+**File:** `lib/destila/executions/engine.ex`
+
+| Location | Old | New |
+|---|---|---|
+| `start_session/1` (line 62) | `Executions.start_phase(pe, "processing")` | `Executions.start_phase(pe, :processing)` |
+| `phase_update/3` (line 119) | `pe.status in ["awaiting_input", "awaiting_confirmation"]` | `pe.status in [:awaiting_input, :awaiting_confirmation]` |
+| `phase_update/3` (line 120) | `Executions.update_phase_execution_status(pe, "processing")` | `Executions.update_phase_execution_status(pe, :processing)` |
+| `handle_awaiting_input/1` (line 165) | `pe.status == "processing"` | `pe.status == :processing` |
+| `handle_awaiting_input/1` (line 166) | `Executions.update_phase_execution_status(pe, "awaiting_input")` | `Executions.update_phase_execution_status(pe, :awaiting_input)` |
+| `transition_to_phase/2` (line 192) | `Executions.start_phase(pe, "processing")` | `Executions.start_phase(pe, :processing)` |
+| `handle_retry/1` (line 212) | `Executions.update_phase_execution_status(pe, "processing")` | `Executions.update_phase_execution_status(pe, :processing)` |
+| `complete_current_phase_execution/1` (line 221) | `pe.status in ["completed", "skipped"]` | `pe.status in [:completed, :skipped]` |
+
+### Step 5: Update status references in `WorkflowRunnerLive`
+
+**File:** `lib/destila_web/live/workflow_runner_live.ex`
+
+| Location | Old | New |
+|---|---|---|
+| `handle_event("decline_advance", ...)` (line 141) | `%{status: "awaiting_confirmation"}` | `%{status: :awaiting_confirmation}` |
+
+### Step 6: Update test files
+
+**File:** `test/destila/executions_test.exs`
+
+All status string assertions and inputs become atoms:
+
+| Line | Old | New |
+|---|---|---|
+| 26 | `assert pe.status == "pending"` | `assert pe.status == :pending` |
+| 35 | `%{status: "processing"}` | `%{status: :processing}` |
+| 37 | `assert pe.status == "processing"` | `assert pe.status == :processing` |
+| 71 | `assert pe.status == "completed"` | `assert pe.status == :completed` |
+| 81 | `assert pe.status == "skipped"` | `assert pe.status == :skipped` |
+| 91 | `assert pe.status == "awaiting_confirmation"` | `assert pe.status == :awaiting_confirmation` |
+| 95 | `assert pe.status == "completed"` | `assert pe.status == :completed` |
+| 106 | `assert pe.status == "awaiting_input"` | `assert pe.status == :awaiting_input` |
+| 115 | `assert pe.status == "processing"` | `assert pe.status == :processing` |
+
+**File:** `test/destila/executions/engine_test.exs`
+
+| Line | Old | New |
+|---|---|---|
+| 69 | `assert updated_pe.status == "awaiting_confirmation"` | `assert updated_pe.status == :awaiting_confirmation` |
+| 76 | `%{status: "processing"}` | `%{status: :processing}` |
+| 86 | `assert updated_pe.status == "awaiting_input"` | `assert updated_pe.status == :awaiting_input` |
+| 140 | `assert updated_pe.status == "completed"` | `assert updated_pe.status == :completed` |
+| 161 | `%{status: "awaiting_input"}` | `%{status: :awaiting_input}` |
+| 169 | `assert updated_pe.status == "processing"` | `assert updated_pe.status == :processing` |
+| 242 | `%{status: "awaiting_confirmation"}` | `%{status: :awaiting_confirmation}` |
+| 247 | `assert completed_pe.status == "completed"` | `assert completed_pe.status == :completed` |
+
+**File:** `test/destila_web/live/implement_general_prompt_workflow_live_test.exs`
+
+| Line | Old | New |
+|---|---|---|
+| 259 | `%{status: "awaiting_input"}` | `%{status: :awaiting_input}` |
+| 282 | `assert pe.status == "processing"` | `assert pe.status == :processing` |
+| 290 | `%{status: "awaiting_input"}` | `%{status: :awaiting_input}` |
+| 315 | `%{status: "awaiting_input"}` | `%{status: :awaiting_input}` |
+
+### Step 7: Verify no remaining string references
+
+Search for any remaining string status references related to phase execution:
+
+```
+grep -r '"pending"\|"processing"\|"awaiting_input"\|"awaiting_confirmation"\|"completed"\|"skipped"\|"failed"' lib/ test/
+```
+
+**Known false positives (do NOT change):**
+- `lib/destila/workflows/setup.ex` — `"completed"` refers to setup step metadata status, not phase execution status
+- `lib/destila_web/components/setup_components.ex` — `"completed"` / `"failed"` refer to setup step status rendering
+- `lib/destila/workers/prepare_workflow_session.ex` — `"completed"` / `"failed"` refer to setup metadata values
+- `lib/destila/workers/title_generation_worker.ex` — `"completed"` refers to title generation metadata status
+- `test/destila/workflows_metadata_test.exs` — `"completed"` refers to metadata values
+- `test/destila_web/live/brainstorm_idea_workflow_live_test.exs` — `"completed"` / `"failed"` refer to metadata values
+
+These are all metadata status strings stored in JSON maps (not `PhaseExecution.status`).
+
+### Step 8: Verify with `mix precommit`
+
+Run `mix precommit` to confirm compilation, tests, and any other checks pass.
+
+## Files modified
+
+| File | Type of change |
+|---|---|
+| `lib/destila/executions/phase_execution.ex` | Schema: string → Ecto.Enum, remove @statuses, validate_inclusion, statuses/0 |
+| `lib/destila/executions.ex` | String status args → atoms |
+| `lib/destila/executions/engine.ex` | String status comparisons/args → atoms |
+| `lib/destila_web/live/workflow_runner_live.ex` | String pattern match → atom |
+| `priv/repo/migrations/*_convert_phase_execution_status_to_enum.exs` | No-op migration |
+| `test/destila/executions_test.exs` | String assertions/inputs → atoms |
+| `test/destila/executions/engine_test.exs` | String assertions/inputs → atoms |
+| `test/destila_web/live/implement_general_prompt_workflow_live_test.exs` | String inputs/assertions → atoms |
+
+## Files NOT modified (confirmed no phase execution status references)
+
+- `lib/destila/ai/conversation.ex` — returns status atoms (`:processing`, `:awaiting_input`, etc.), no `PhaseExecution.status` references
+- `lib/destila/workflows/setup.ex` — uses `"completed"` for metadata, not phase execution status
+- `lib/destila_web/components/setup_components.ex` — uses `"completed"` / `"failed"` for setup step metadata
+- `lib/destila/workers/prepare_workflow_session.ex` — uses `"completed"` / `"failed"` for setup metadata
+- `lib/destila/workers/title_generation_worker.ex` — uses `"completed"` for title generation metadata
+
+## Risk assessment
+
+**Low risk.** Ecto.Enum stores atoms as their string representation in SQLite, so existing data is compatible without any column changes. The main risk is a missed string reference, which would cause a runtime pattern-match failure — mitigated by the comprehensive grep sweep in Step 7.

--- a/lib/destila/executions.ex
+++ b/lib/destila/executions.ex
@@ -60,7 +60,7 @@ defmodule Destila.Executions do
           workflow_session_id: workflow_session.id,
           phase_number: phase_number,
           phase_name: phase_name,
-          status: "pending"
+          status: :pending
         },
         attrs
       )
@@ -75,14 +75,14 @@ defmodule Destila.Executions do
   end
 
   def complete_phase(%PhaseExecution{} = pe, result \\ nil) do
-    update_phase_execution_status(pe, "completed", %{
+    update_phase_execution_status(pe, :completed, %{
       result: result,
       completed_at: DateTime.utc_now() |> DateTime.truncate(:second)
     })
   end
 
   def stage_completion(%PhaseExecution{} = pe, result) do
-    update_phase_execution_status(pe, "awaiting_confirmation", %{staged_result: result})
+    update_phase_execution_status(pe, :awaiting_confirmation, %{staged_result: result})
   end
 
   def confirm_completion(%PhaseExecution{} = pe) do
@@ -90,17 +90,17 @@ defmodule Destila.Executions do
   end
 
   def reject_completion(%PhaseExecution{} = pe) do
-    update_phase_execution_status(pe, "awaiting_input", %{staged_result: nil})
+    update_phase_execution_status(pe, :awaiting_input, %{staged_result: nil})
   end
 
   def skip_phase(%PhaseExecution{} = pe, reason \\ nil) do
-    update_phase_execution_status(pe, "skipped", %{
+    update_phase_execution_status(pe, :skipped, %{
       result: if(reason, do: %{"reason" => reason}, else: nil),
       completed_at: DateTime.utc_now() |> DateTime.truncate(:second)
     })
   end
 
-  def start_phase(%PhaseExecution{} = pe, status \\ "processing") do
+  def start_phase(%PhaseExecution{} = pe, status \\ :processing) do
     update_phase_execution_status(pe, status, %{
       started_at: DateTime.utc_now() |> DateTime.truncate(:second)
     })

--- a/lib/destila/executions/engine.ex
+++ b/lib/destila/executions/engine.ex
@@ -59,7 +59,7 @@ defmodule Destila.Executions.Engine do
     reloaded = Workflows.get_workflow_session!(ws.id)
 
     if reloaded.current_phase == phase do
-      Executions.start_phase(pe, "processing")
+      Executions.start_phase(pe, :processing)
       Workflows.update_workflow_session(reloaded, %{phase_status: :processing})
     end
   end
@@ -116,8 +116,8 @@ defmodule Destila.Executions.Engine do
           nil ->
             :ok
 
-          pe when pe.status in ["awaiting_input", "awaiting_confirmation"] ->
-            Executions.update_phase_execution_status(pe, "processing")
+          pe when pe.status in [:awaiting_input, :awaiting_confirmation] ->
+            Executions.update_phase_execution_status(pe, :processing)
 
           _pe ->
             :ok
@@ -162,8 +162,8 @@ defmodule Destila.Executions.Engine do
       nil ->
         :ok
 
-      pe when pe.status == "processing" ->
-        Executions.update_phase_execution_status(pe, "awaiting_input")
+      pe when pe.status == :processing ->
+        Executions.update_phase_execution_status(pe, :awaiting_input)
 
       _pe ->
         :ok
@@ -189,7 +189,7 @@ defmodule Destila.Executions.Engine do
     reloaded = Workflows.get_workflow_session!(ws.id)
 
     if reloaded.current_phase == next_phase do
-      Executions.start_phase(pe, "processing")
+      Executions.start_phase(pe, :processing)
       Workflows.update_workflow_session(reloaded, %{phase_status: :processing})
     end
   end
@@ -209,7 +209,7 @@ defmodule Destila.Executions.Engine do
 
     case Executions.get_current_phase_execution(ws.id) do
       nil -> :ok
-      pe -> Executions.update_phase_execution_status(pe, "processing")
+      pe -> Executions.update_phase_execution_status(pe, :processing)
     end
 
     Workflows.update_workflow_session(ws, %{phase_status: :processing})
@@ -218,7 +218,7 @@ defmodule Destila.Executions.Engine do
   defp complete_current_phase_execution(ws) do
     case Executions.get_current_phase_execution(ws.id) do
       nil -> :ok
-      pe when pe.status in ["completed", "skipped"] -> :ok
+      pe when pe.status in [:completed, :skipped] -> :ok
       pe -> Executions.complete_phase(pe)
     end
   end

--- a/lib/destila/executions/phase_execution.ex
+++ b/lib/destila/executions/phase_execution.ex
@@ -2,14 +2,25 @@ defmodule Destila.Executions.PhaseExecution do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @statuses ~w(pending awaiting_input processing awaiting_confirmation completed skipped failed)
-
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "phase_executions" do
     field(:phase_number, :integer)
     field(:phase_name, :string)
-    field(:status, :string, default: "pending")
+
+    field(:status, Ecto.Enum,
+      values: [
+        :pending,
+        :processing,
+        :awaiting_input,
+        :awaiting_confirmation,
+        :completed,
+        :skipped,
+        :failed
+      ],
+      default: :pending
+    )
+
     field(:result, :map)
     field(:staged_result, :map)
     field(:started_at, :utc_datetime)
@@ -33,9 +44,6 @@ defmodule Destila.Executions.PhaseExecution do
       :completed_at
     ])
     |> validate_required([:workflow_session_id, :phase_number, :phase_name, :status])
-    |> validate_inclusion(:status, @statuses)
     |> unique_constraint([:workflow_session_id, :phase_number])
   end
-
-  def statuses, do: @statuses
 end

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -138,7 +138,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
     ws = socket.assigns.workflow_session
 
     case Destila.Executions.get_current_phase_execution(ws.id) do
-      %{status: "awaiting_confirmation"} = pe -> Destila.Executions.reject_completion(pe)
+      %{status: :awaiting_confirmation} = pe -> Destila.Executions.reject_completion(pe)
       _ -> :ok
     end
 

--- a/priv/repo/migrations/20260406150010_convert_phase_execution_status_to_enum.exs
+++ b/priv/repo/migrations/20260406150010_convert_phase_execution_status_to_enum.exs
@@ -1,0 +1,9 @@
+defmodule Destila.Repo.Migrations.ConvertPhaseExecutionStatusToEnum do
+  use Ecto.Migration
+
+  def change do
+    # No column changes needed: SQLite stores Ecto.Enum values as their string
+    # representation, which matches the existing :string column type.
+    # This migration exists to record the schema change in the migration history.
+  end
+end

--- a/test/destila/executions/engine_test.exs
+++ b/test/destila/executions/engine_test.exs
@@ -66,14 +66,14 @@ defmodule Destila.Executions.EngineTest do
       assert updated_ws.phase_status == :advance_suggested
 
       updated_pe = Executions.get_phase_execution!(pe.id)
-      assert updated_pe.status == "awaiting_confirmation"
+      assert updated_pe.status == :awaiting_confirmation
     end
   end
 
   describe "phase_update/3 with continue conversation" do
     test "sets phase_status to conversing" do
       ws = create_session_with_ai(%{phase_status: :processing})
-      {:ok, pe} = Executions.create_phase_execution(ws, 1, %{status: "processing"})
+      {:ok, pe} = Executions.create_phase_execution(ws, 1, %{status: :processing})
 
       Engine.phase_update(ws.id, 1, %{
         ai_result: %{text: "More questions", result: "More questions"}
@@ -83,7 +83,7 @@ defmodule Destila.Executions.EngineTest do
       assert updated_ws.phase_status == :awaiting_input
 
       updated_pe = Executions.get_phase_execution!(pe.id)
-      assert updated_pe.status == "awaiting_input"
+      assert updated_pe.status == :awaiting_input
     end
   end
 
@@ -137,7 +137,7 @@ defmodule Destila.Executions.EngineTest do
 
       # Current phase execution should be completed
       updated_pe = Executions.get_phase_execution!(pe.id)
-      assert updated_pe.status == "completed"
+      assert updated_pe.status == :completed
 
       # New phase execution should exist for phase 2
       new_pe = Executions.get_phase_execution_by_number(ws.id, 2)
@@ -158,7 +158,7 @@ defmodule Destila.Executions.EngineTest do
 
     test "updates phase_execution status from awaiting_input to processing" do
       ws = create_session_with_ai(%{phase_status: :awaiting_input})
-      {:ok, pe} = Executions.create_phase_execution(ws, 1, %{status: "awaiting_input"})
+      {:ok, pe} = Executions.create_phase_execution(ws, 1, %{status: :awaiting_input})
 
       Engine.phase_update(ws.id, 1, %{message: "Hello"})
 
@@ -166,7 +166,7 @@ defmodule Destila.Executions.EngineTest do
       assert updated_ws.phase_status == :processing
 
       updated_pe = Executions.get_phase_execution!(pe.id)
-      assert updated_pe.status == "processing"
+      assert updated_pe.status == :processing
     end
   end
 
@@ -239,12 +239,12 @@ defmodule Destila.Executions.EngineTest do
 
     test "completes current phase execution before advancing" do
       ws = create_session_with_ai(%{current_phase: 1, total_phases: 4})
-      {:ok, pe} = Executions.create_phase_execution(ws, 1, %{status: "awaiting_confirmation"})
+      {:ok, pe} = Executions.create_phase_execution(ws, 1, %{status: :awaiting_confirmation})
 
       Engine.advance_to_next(ws)
 
       completed_pe = Executions.get_phase_execution!(pe.id)
-      assert completed_pe.status == "completed"
+      assert completed_pe.status == :completed
       assert completed_pe.completed_at != nil
     end
 

--- a/test/destila/executions_test.exs
+++ b/test/destila/executions_test.exs
@@ -23,7 +23,7 @@ defmodule Destila.ExecutionsTest do
       assert pe.workflow_session_id == ws.id
       assert pe.phase_number == 1
       assert pe.phase_name == "Task Description"
-      assert pe.status == "pending"
+      assert pe.status == :pending
       assert is_nil(pe.started_at)
       assert is_nil(pe.completed_at)
     end
@@ -32,9 +32,9 @@ defmodule Destila.ExecutionsTest do
       ws = create_session()
 
       {:ok, pe} =
-        Executions.create_phase_execution(ws, 2, %{status: "processing"})
+        Executions.create_phase_execution(ws, 2, %{status: :processing})
 
-      assert pe.status == "processing"
+      assert pe.status == :processing
     end
 
     test "enforces unique constraint on workflow_session_id + phase_number" do
@@ -68,7 +68,7 @@ defmodule Destila.ExecutionsTest do
       {:ok, pe} = Executions.create_phase_execution(ws, 3)
       {:ok, pe} = Executions.complete_phase(pe, %{"summary" => "done"})
 
-      assert pe.status == "completed"
+      assert pe.status == :completed
       assert pe.result == %{"summary" => "done"}
       assert pe.completed_at != nil
     end
@@ -78,7 +78,7 @@ defmodule Destila.ExecutionsTest do
       {:ok, pe} = Executions.create_phase_execution(ws, 3)
       {:ok, pe} = Executions.skip_phase(pe, "Not applicable")
 
-      assert pe.status == "skipped"
+      assert pe.status == :skipped
       assert pe.result == %{"reason" => "Not applicable"}
       assert pe.completed_at != nil
     end
@@ -88,11 +88,11 @@ defmodule Destila.ExecutionsTest do
       {:ok, pe} = Executions.create_phase_execution(ws, 3)
 
       {:ok, pe} = Executions.stage_completion(pe, %{"msg" => "ready"})
-      assert pe.status == "awaiting_confirmation"
+      assert pe.status == :awaiting_confirmation
       assert pe.staged_result == %{"msg" => "ready"}
 
       {:ok, pe} = Executions.confirm_completion(pe)
-      assert pe.status == "completed"
+      assert pe.status == :completed
       assert pe.result == %{"msg" => "ready"}
     end
 
@@ -103,7 +103,7 @@ defmodule Destila.ExecutionsTest do
       {:ok, pe} = Executions.stage_completion(pe, %{"msg" => "ready"})
       {:ok, pe} = Executions.reject_completion(pe)
 
-      assert pe.status == "awaiting_input"
+      assert pe.status == :awaiting_input
       assert is_nil(pe.staged_result)
     end
 
@@ -112,7 +112,7 @@ defmodule Destila.ExecutionsTest do
       {:ok, pe} = Executions.create_phase_execution(ws, 3)
       {:ok, pe} = Executions.start_phase(pe)
 
-      assert pe.status == "processing"
+      assert pe.status == :processing
       assert pe.started_at != nil
     end
   end

--- a/test/destila_web/live/implement_general_prompt_workflow_live_test.exs
+++ b/test/destila_web/live/implement_general_prompt_workflow_live_test.exs
@@ -256,7 +256,7 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
       ws = create_implement_session(1, phase_status: :awaiting_input)
 
       {:ok, _pe} =
-        Destila.Executions.create_phase_execution(ws, 1, %{status: "awaiting_input"})
+        Destila.Executions.create_phase_execution(ws, 1, %{status: :awaiting_input})
 
       {:ok, ai_session} = Destila.AI.get_or_create_ai_session(ws.id)
 
@@ -279,7 +279,7 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
 
       # Verify phase execution status updated
       pe = Destila.Executions.get_current_phase_execution(ws.id)
-      assert pe.status == "processing"
+      assert pe.status == :processing
     end
 
     @tag feature: @feature, scenario: "Non-interactive phase shows retry on error"
@@ -287,7 +287,7 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
       ws = create_implement_session(1, phase_status: :awaiting_input)
 
       {:ok, _pe} =
-        Destila.Executions.create_phase_execution(ws, 1, %{status: "awaiting_input"})
+        Destila.Executions.create_phase_execution(ws, 1, %{status: :awaiting_input})
 
       {:ok, ai_session} = Destila.AI.get_or_create_ai_session(ws.id)
 
@@ -312,7 +312,7 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
       ws = create_implement_session(1, phase_status: :awaiting_input)
 
       {:ok, _pe} =
-        Destila.Executions.create_phase_execution(ws, 1, %{status: "awaiting_input"})
+        Destila.Executions.create_phase_execution(ws, 1, %{status: :awaiting_input})
 
       {:ok, ai_session} = Destila.AI.get_or_create_ai_session(ws.id)
 


### PR DESCRIPTION
## Summary

- Converts `PhaseExecution.status` from a plain `:string` field with manual `validate_inclusion` to `Ecto.Enum`, matching the pattern already used by `Session.phase_status`
- Replaces all string status literals (`"pending"`, `"processing"`, etc.) with atoms (`:pending`, `:processing`, etc.) across source and test files
- Removes the `@statuses` module attribute, `validate_inclusion` call, and `statuses/0` function from `PhaseExecution` — Ecto.Enum handles validation automatically
- Adds a no-op migration to record the schema change (no column changes needed since SQLite stores Ecto.Enum as strings)

## Files changed

| File | Change |
|---|---|
| `lib/destila/executions/phase_execution.ex` | Schema: string → Ecto.Enum, remove @statuses/validate_inclusion/statuses() |
| `lib/destila/executions.ex` | String status args → atoms |
| `lib/destila/executions/engine.ex` | String status comparisons/args → atoms |
| `lib/destila_web/live/workflow_runner_live.ex` | String pattern match → atom |
| `priv/repo/migrations/*_convert_phase_execution_status_to_enum.exs` | No-op migration |
| `test/destila/executions_test.exs` | String assertions/inputs → atoms |
| `test/destila/executions/engine_test.exs` | String assertions/inputs → atoms |
| `test/destila_web/live/implement_general_prompt_workflow_live_test.exs` | String inputs/assertions → atoms |

## Test plan

- [x] All 184 tests pass with 0 failures
- [x] Compilation clean with `--warnings-as-errors`
- [x] Grep sweep confirms no remaining string status references (only metadata false positives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)