### PR TITLE
Change primary color from purple to hot pink

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -32,8 +32,8 @@
   --color-base-200: oklch(15% 0.008 260);
   --color-base-300: oklch(30% 0.015 260);
   --color-base-content: oklch(93% 0.005 260);
-  --color-primary: oklch(55% 0.2 265);
-  --color-primary-content: oklch(98% 0.01 265);
+  --color-primary: oklch(62% 0.28 345);
+  --color-primary-content: oklch(98% 0.01 345);
   --color-secondary: oklch(60% 0.15 290);
   --color-secondary-content: oklch(98% 0.01 290);
   --color-accent: oklch(70% 0.17 250);
@@ -68,8 +68,8 @@
   --color-base-200: oklch(97% 0.003 260);
   --color-base-300: oklch(93% 0.005 260);
   --color-base-content: oklch(25% 0.01 260);
-  --color-primary: oklch(55% 0.2 265);
-  --color-primary-content: oklch(98% 0.01 265);
+  --color-primary: oklch(62% 0.28 345);
+  --color-primary-content: oklch(98% 0.01 345);
   --color-secondary: oklch(55% 0.15 290);
   --color-secondary-content: oklch(98% 0.01 290);
   --color-accent: oklch(25% 0.01 260);
@@ -190,7 +190,7 @@ a, button, .card, .btn, input {
   border-color: oklch(0% 0 0 / 0.1);
 }
 .prose a {
-  color: oklch(55% 0.2 265);
+  color: oklch(62% 0.28 345);
   text-decoration: underline;
 }
 

--- a/docs/plans/2026-04-06-feat-primary-color-to-hot-pink-plan.md
+++ b/docs/plans/2026-04-06-feat-primary-color-to-hot-pink-plan.md
@@ -1,0 +1,107 @@
+# Plan: Change primary color from purple to hot pink
+
+## Summary
+
+Shift the primary color hue from 265 (purple/violet) to 345 (hot pink/fuchsia) across both light and dark themes, and update one hardcoded reference in prose link styling. This is a purely visual/CSS change — no Gherkin scenarios or tests are affected.
+
+## Changes
+
+**File:** `assets/css/app.css`
+
+There are **5 locations** where the primary purple hue (265) appears and must be updated:
+
+### 1. Dark theme `--color-primary` (line 35)
+
+**Before:**
+```css
+--color-primary: oklch(55% 0.2 265);
+```
+
+**After:**
+```css
+--color-primary: oklch(62% 0.28 345);
+```
+
+### 2. Dark theme `--color-primary-content` (line 36)
+
+**Before:**
+```css
+--color-primary-content: oklch(98% 0.01 265);
+```
+
+**After:**
+```css
+--color-primary-content: oklch(98% 0.01 345);
+```
+
+### 3. Light theme `--color-primary` (line 71)
+
+**Before:**
+```css
+--color-primary: oklch(55% 0.2 265);
+```
+
+**After:**
+```css
+--color-primary: oklch(62% 0.28 345);
+```
+
+### 4. Light theme `--color-primary-content` (line 72)
+
+**Before:**
+```css
+--color-primary-content: oklch(98% 0.01 265);
+```
+
+**After:**
+```css
+--color-primary-content: oklch(98% 0.01 345);
+```
+
+### 5. Prose link color (line 193)
+
+There is a hardcoded reference to the primary color in `.prose a` that does **not** use the CSS custom property. It must also be updated for consistency.
+
+**Before:**
+```css
+.prose a {
+  color: oklch(55% 0.2 265);
+```
+
+**After:**
+```css
+.prose a {
+  color: oklch(62% 0.28 345);
+```
+
+## Color rationale
+
+The OKLCH values were chosen as follows:
+
+| Channel    | Old value | New value | Reason |
+|------------|-----------|-----------|--------|
+| Lightness  | 55%       | 62%       | Hot pink is perceived as brighter than purple; 62% ensures vibrancy without washing out |
+| Chroma     | 0.2       | 0.28      | Higher saturation for a punchy, vibrant fuchsia (not pastel) |
+| Hue        | 265       | 345       | Center of the hot pink/fuchsia range in OKLCH (340-350) |
+
+**Content color** (`--color-primary-content`): only the hue shifts (265 → 345). Lightness stays at 98% and chroma at 0.01 — this produces a near-white with a barely perceptible pink tint, maintaining excellent contrast against the primary background.
+
+## Constraints
+
+- No other color variables (secondary, accent, neutral, info, success, warning, error) are modified
+- Both light and dark themes use identical primary values so the brand color is consistent
+- No Gherkin scenarios are affected
+- Run `mix precommit` after changes and fix any issues
+
+## Scope
+
+- **Files changed:** 1 (`assets/css/app.css`)
+- **Lines changed:** 5 (lines 35, 36, 71, 72, 193)
+- **Risk:** Low — CSS custom property value changes only, no logic involved
+
+## Verification
+
+- Visually inspect both light and dark themes to confirm primary elements render as vibrant hot pink
+- Check buttons, links, form focus rings, and any other elements using `primary` / `primary-content` daisyUI classes
+- Confirm `.prose a` links match the new primary color
+- Verify text on primary-colored backgrounds (`primary-content`) remains readable


### PR DESCRIPTION
## Summary

- Shifts the primary color hue from purple (265) to hot pink/fuchsia (345) in `assets/css/app.css`
- Updates all 5 OKLCH color references: dark theme primary + primary-content, light theme primary + primary-content, and the hardcoded `.prose a` link color
- Both themes use identical primary values for brand consistency

## Details

| Channel   | Before | After | Reason |
|-----------|--------|-------|--------|
| Lightness | 55%    | 62%   | Hot pink is perceived brighter; 62% ensures vibrancy |
| Chroma    | 0.2    | 0.28  | Higher saturation for punchy fuchsia |
| Hue       | 265    | 345   | Center of hot pink/fuchsia OKLCH range |

## Test plan

- [x] Code compiles successfully
- [x] No remaining references to old hue (265) in primary color variables
- [ ] Visually verify primary elements render as hot pink in both light and dark themes
- [ ] Check buttons, links, focus rings using `primary` / `primary-content` classes
- [ ] Confirm `.prose a` links match the new color

🤖 Generated with [Claude Code](https://claude.com/claude-code)