### PR TITLE
refactor: Eliminate phase_status from workflow_sessions

### DIFF
--- a/docs/plans/2026-04-06-refactor-eliminate-phase-status-from-workflow-sessions-plan.md
+++ b/docs/plans/2026-04-06-refactor-eliminate-phase-status-from-workflow-sessions-plan.md
@@ -1,0 +1,769 @@
+---
+title: "refactor: Eliminate phase_status from workflow_sessions"
+type: refactor
+date: 2026-04-06
+---
+
+# refactor: Eliminate phase_status from workflow_sessions
+
+## Overview
+
+The `workflow_sessions.phase_status` column duplicates state that already lives in `phase_executions.status`. The Engine currently writes to both in 6+ places, creating a desynchronization risk. This plan removes `phase_status` from the schema and database, making `phase_executions` the single source of truth.
+
+After this change, all status reads go through `Session.phase_status/1`, which derives the value from the latest `PhaseExecution` record via `Executions.current_status/1`.
+
+## Prerequisites
+
+- **F1** (Ecto.Enum conversion for PhaseExecution.status) — merged as `78d24a6`
+- **F2** (Explicit phase execution state machine) — merged as `a594cd1`
+
+## Mapping: PhaseExecution.status → derived phase_status
+
+| PhaseExecution.status | Derived phase_status |
+|----------------------|---------------------|
+| (no record exists)   | `:setup`            |
+| `:pending`           | `:processing`       |
+| `:processing`        | `:processing`       |
+| `:awaiting_input`    | `:awaiting_input`   |
+| `:awaiting_confirmation` | `:advance_suggested` |
+| `:completed`         | `nil`               |
+| `:skipped`           | `nil`               |
+| `:failed`            | `:processing`       |
+| (session done?)      | `nil`               |
+
+## Changes
+
+### Step 1: Add `Executions.current_status/1`
+
+**File:** `lib/destila/executions.ex`
+
+Add a new public function that derives the phase status from the latest phase execution:
+
+```elixir
+def current_status(workflow_session_id) do
+  case get_current_phase_execution(workflow_session_id) do
+    nil -> :setup
+    %{status: :processing} -> :processing
+    %{status: :pending} -> :processing
+    %{status: :awaiting_input} -> :awaiting_input
+    %{status: :awaiting_confirmation} -> :advance_suggested
+    %{status: :failed} -> :processing
+    %{status: s} when s in [:completed, :skipped] -> nil
+  end
+end
+```
+
+**Why `nil` for completed/skipped:** A completed phase execution with no next phase means the workflow is done (handled by `Session.done?/1`). If the workflow isn't done, the Engine is about to create the next phase execution — the transient `nil` is fine because it falls through to the default `:processing` bucket in `classify/1`.
+
+### Step 2: Add `Session.phase_status/1` virtual accessor
+
+**File:** `lib/destila/workflows/session.ex`
+
+1. Remove the `field(:phase_status, ...)` declaration (lines 14–16)
+2. Remove `:phase_status` from the changeset cast list (line 44)
+3. Add:
+
+```elixir
+def phase_status(%__MODULE__{} = ws) do
+  if done?(ws), do: nil, else: Destila.Executions.current_status(ws.id)
+end
+```
+
+**Important:** This function hits the database every call. Callers that need the status multiple times in one request should bind it to a variable. In practice, LiveView mounts/events call it once per render cycle, which is acceptable.
+
+### Step 3: Remove Engine writes to `phase_status`
+
+**File:** `lib/destila/executions/engine.ex`
+
+**Decision: Broadcast approach.** Add explicit `Workflows.broadcast({:ok, ws}, :workflow_session_updated)` in each Engine function where the removed `update_workflow_session` call was the only source of PubSub broadcast. This is preferred over broadcasting from `StateMachine.transition/3` because the StateMachine is a low-level persistence concern — it shouldn't know about PubSub. The Engine is the orchestrator and the right place for broadcast decisions.
+
+Add `alias Destila.Workflows.Session` to the alias line at the top.
+
+**Updated docstring (lines 2–16):** Remove the sentence about writing to `workflow_sessions.phase_status`.
+
+**`phase_retry/1` guard (line 84):** Change `if ws.phase_status == :processing` to `if Session.phase_status(ws) == :processing`.
+
+Below is the complete resulting code for every modified function:
+
+#### `start_session/1` — remove `update_workflow_session`, add broadcast
+
+```elixir
+def start_session(ws) do
+  phase = ws.current_phase
+  {:ok, pe} = Executions.ensure_phase_execution(ws, phase)
+  AI.Conversation.phase_start(ws)
+
+  # Reload to check if an inline worker already advanced past this phase.
+  reloaded = Workflows.get_workflow_session!(ws.id)
+
+  if reloaded.current_phase == phase do
+    Executions.start_phase(pe)
+    Workflows.broadcast({:ok, reloaded}, :workflow_session_updated)
+  end
+end
+```
+
+#### `phase_update/3` (setup branch) — remove both `update_workflow_session` calls
+
+```elixir
+def phase_update(workflow_session_id, _phase, %{setup_step_completed: _} = params) do
+  ws = Workflows.get_workflow_session!(workflow_session_id)
+
+  case Destila.Workflows.Setup.update(ws, params) do
+    :setup_complete ->
+      start_session(ws)
+
+    :processing ->
+      # Setup status is derived from no PE existing — no write needed.
+      # Broadcast so the LiveView refreshes setup step progress.
+      Workflows.broadcast({:ok, ws}, :workflow_session_updated)
+  end
+end
+```
+
+**Note:** Previously the `:setup_complete` branch did `update_workflow_session(ws, %{phase_status: nil})` then `start_session(ws)`. The `phase_status: nil` write is unnecessary — `start_session` creates a PE and transitions it to `:processing`, so `current_status/1` will return `:processing`. The `start_session` function now handles its own broadcast (see above).
+
+#### `phase_update/3` (main branch) — remove `update_workflow_session` on `:processing`
+
+```elixir
+def phase_update(workflow_session_id, phase, params) do
+  ws = Workflows.get_workflow_session!(workflow_session_id)
+
+  case AI.Conversation.phase_update(%{ws | current_phase: phase}, params) do
+    :processing ->
+      if pe = Executions.get_current_phase_execution(ws.id) do
+        Executions.process_phase(pe)
+      end
+
+      Workflows.broadcast({:ok, ws}, :workflow_session_updated)
+
+    :awaiting_input ->
+      handle_awaiting_input(ws)
+
+    :phase_complete ->
+      advance_to_next(ws)
+
+    :suggest_phase_complete ->
+      handle_suggest_advance(ws)
+  end
+end
+```
+
+#### `complete_workflow/1` — keep `update_workflow_session`, remove `phase_status: nil`
+
+```elixir
+defp complete_workflow(ws) do
+  Workflows.update_workflow_session(ws, %{done_at: DateTime.utc_now()})
+end
+```
+
+This still broadcasts via `update_workflow_session` → `broadcast(:workflow_session_updated)`.
+
+#### `handle_suggest_advance/1` — remove `update_workflow_session`, add broadcast
+
+```elixir
+defp handle_suggest_advance(ws) do
+  if pe = Executions.get_current_phase_execution(ws.id) do
+    Executions.await_confirmation(pe, nil)
+  end
+
+  Workflows.broadcast({:ok, ws}, :workflow_session_updated)
+end
+```
+
+#### `handle_awaiting_input/1` — remove `update_workflow_session`, add broadcast
+
+```elixir
+defp handle_awaiting_input(ws) do
+  if pe = Executions.get_current_phase_execution(ws.id) do
+    Executions.await_input(pe)
+  end
+
+  Workflows.broadcast({:ok, ws}, :workflow_session_updated)
+end
+```
+
+#### `transition_to_phase/2` — remove trailing `update_workflow_session`, add broadcast
+
+```elixir
+defp transition_to_phase(ws, next_phase) do
+  {:ok, pe} = Executions.ensure_phase_execution(ws, next_phase)
+  {:ok, ws} = Workflows.update_workflow_session(ws, %{current_phase: next_phase})
+
+  AI.Conversation.phase_start(ws)
+
+  reloaded = Workflows.get_workflow_session!(ws.id)
+
+  if reloaded.current_phase == next_phase do
+    Executions.start_phase(pe)
+    # The update_workflow_session above already broadcast for current_phase.
+    # This additional broadcast ensures the UI picks up the PE status change.
+    Workflows.broadcast({:ok, reloaded}, :workflow_session_updated)
+  end
+end
+```
+
+#### `handle_retry/1` — remove `update_workflow_session`, add broadcast
+
+```elixir
+defp handle_retry(ws) do
+  phase = ws.current_phase
+
+  AI.ClaudeSession.stop_for_workflow_session(ws.id)
+  AI.Conversation.handle_session_strategy(ws, phase)
+
+  ws = Workflows.get_workflow_session!(ws.id)
+  AI.Conversation.phase_start(ws)
+
+  case Executions.get_current_phase_execution(ws.id) do
+    nil ->
+      :ok
+
+    pe when pe.status == :awaiting_confirmation ->
+      {:ok, pe} = Executions.reject_completion(pe)
+      Executions.process_phase(pe)
+
+    pe ->
+      Executions.process_phase(pe)
+  end
+
+  Workflows.broadcast({:ok, ws}, :workflow_session_updated)
+end
+```
+
+### Step 4: Update `Workflows.classify/1`
+
+**File:** `lib/destila/workflows.ex`
+
+**Lines 159–165:** Replace `ws.phase_status` with `Session.phase_status(ws)`:
+
+```elixir
+def classify(%Session{} = ws) do
+  cond do
+    Session.done?(ws) -> :done
+    Session.phase_status(ws) in [:awaiting_input, :advance_suggested] -> :waiting_for_user
+    true -> :processing
+  end
+end
+```
+
+### Step 5: Update `Workflows.create_workflow_session/1`
+
+**File:** `lib/destila/workflows.ex`, line 113
+
+Remove `phase_status: :setup` from `session_attrs`. The initial status is derived from having no phase execution record (returns `:setup`).
+
+### Step 6: Update `Workflows.unarchive_workflow_session/1`
+
+**File:** `lib/destila/workflows.ex`, lines 212–222
+
+Remove the `if ws.phase_status == :processing` conditional. After unarchiving, the status is derived from `phase_executions`. If the PE was `:processing` when archived, the `ClaudeSession` was stopped by `archive_workflow_session/1`, but the PE status remains `:processing`. We need to transition the PE to `:awaiting_input` when unarchiving a session whose PE is `:processing`:
+
+```elixir
+def unarchive_workflow_session(%Session{} = ws) do
+  # If PE was processing when archived, transition to awaiting_input
+  # since the ClaudeSession was killed during archival
+  case Destila.Executions.get_current_phase_execution(ws.id) do
+    %{status: :processing} = pe -> Destila.Executions.await_input(pe)
+    _ -> :ok
+  end
+
+  ws
+  |> Session.changeset(%{archived_at: nil})
+  |> Repo.update()
+  |> broadcast(:workflow_session_updated)
+end
+```
+
+### Step 7: Update `WorkflowRunnerLive`
+
+**File:** `lib/destila_web/live/workflow_runner_live.ex`
+
+`alias Destila.Executions` is not currently imported — add it. `Session` is already aliased.
+
+Every `ws.phase_status` reference must be replaced with `Session.phase_status(ws)`. Since this is a function call (not a field access), compute it once per event handler and bind to a variable where used multiple times.
+
+Below are the complete rewritten functions for every affected handler:
+
+#### `decline_advance` (line 137) — remove `update_workflow_session`, reload instead
+
+The `reject_completion/1` call on line 141 already transitions the PE from `:awaiting_confirmation` to `:awaiting_input`. No need to write `phase_status` — just reload ws.
+
+```elixir
+def handle_event("decline_advance", _params, socket) do
+  ws = socket.assigns.workflow_session
+
+  case Destila.Executions.get_current_phase_execution(ws.id) do
+    %{status: :awaiting_confirmation} = pe -> Destila.Executions.reject_completion(pe)
+    _ -> :ok
+  end
+
+  ws = Workflows.get_workflow_session!(ws.id)
+  {:noreply, assign(socket, :workflow_session, ws)}
+end
+```
+
+#### `mark_done` (line 149) — remove `phase_status: nil`
+
+```elixir
+{:ok, ws} =
+  Workflows.update_workflow_session(ws, %{done_at: DateTime.utc_now()})
+```
+
+#### `mark_undone` (line 173) — remove `phase_status: nil`
+
+```elixir
+{:ok, ws} =
+  Workflows.update_workflow_session(ws, %{done_at: nil})
+```
+
+#### `send_text` (line 192) — replace field access with function call
+
+```elixir
+if Session.phase_status(ws) != :processing do
+```
+
+#### `retry_phase` (line 286) — replace field access
+
+```elixir
+if Session.phase_status(ws) != :processing do
+```
+
+#### `cancel_phase` (line 298) — replace field access and remove `update_workflow_session`
+
+The PE is already transitioned by `Executions.await_input(pe)` on line 305. Remove the `update_workflow_session` call and reload instead.
+
+```elixir
+def handle_event("cancel_phase", _params, socket) do
+  ws = socket.assigns.workflow_session
+
+  if Session.phase_status(ws) == :processing do
+    AI.ClaudeSession.stop_for_workflow_session(ws.id)
+
+    if pe = Destila.Executions.get_current_phase_execution(ws.id) do
+      Destila.Executions.await_input(pe)
+    end
+
+    ws = Workflows.get_workflow_session!(ws.id)
+    {:noreply, assign(socket, :workflow_session, ws)}
+  else
+    {:noreply, socket}
+  end
+end
+```
+
+#### `handle_info({:workflow_session_updated, ...})` (line 316) — replace field access
+
+```elixir
+|> assign(
+  :streaming_chunks,
+  if(Session.phase_status(ws) == :processing,
+    do: socket.assigns[:streaming_chunks],
+    else: nil
+  )
+)
+```
+
+#### `compute_current_step/2` (line 394) — replace field accesses
+
+```elixir
+defp compute_current_step(ws, messages) do
+  phase_status = Session.phase_status(ws)
+
+  cond do
+    Session.done?(ws) ->
+      %{input_type: nil, options: nil, questions: [], question_title: nil, completed: true}
+
+    phase_status == :advance_suggested ->
+      %{input_type: nil, options: nil, questions: [], question_title: nil, completed: false}
+
+    phase_status == :processing ->
+      %{input_type: :text, options: nil, questions: [], question_title: nil, completed: false}
+
+    true ->
+      # ... existing last_system message parsing logic unchanged ...
+  end
+end
+```
+
+#### `render_phase/1` (line 733) — replace pattern match with derived assign
+
+**Decision:** Use the derived-assign approach. This preserves multi-clause function dispatch (idiomatic Elixir) and avoids nested `if/else` in a function that returns HEEx.
+
+```elixir
+defp render_phase(assigns) do
+  phase_status = Session.phase_status(assigns.workflow_session)
+  assigns = assign(assigns, :phase_status, phase_status)
+  do_render_phase(assigns)
+end
+
+defp do_render_phase(%{phase_status: :setup} = assigns) do
+  ~H"""
+  <DestilaWeb.SetupComponents.setup
+    workflow_session={@workflow_session}
+    metadata={@metadata}
+  />
+  """
+end
+
+defp do_render_phase(%{phases: phases, current_phase: current_phase} = assigns) do
+  case Enum.at(phases, current_phase - 1) do
+    %Destila.Workflows.Phase{} = phase ->
+      assigns = assign(assigns, :phase_config, phase)
+
+      ~H"""
+      <.chat_phase
+        workflow_session={@workflow_session}
+        messages={@messages}
+        phase_number={@current_phase}
+        phase_config={@phase_config}
+        streaming_chunks={@streaming_chunks}
+        question_answers={@question_answers}
+        metadata={@metadata}
+        current_step={@current_step}
+        phase_status={@phase_status}
+      />
+      """
+
+    nil ->
+      ~H"""
+      <div class="text-base-content/50 text-center py-12">
+        Phase {@current_phase}
+      </div>
+      """
+  end
+end
+```
+
+**Key:** The `phase_status` assign computed in `render_phase/1` is passed down to `<.chat_phase>` — this is the single DB query point. All downstream components receive it as an attr (see Step 8).
+
+### Step 8: Update `ChatComponents`
+
+**File:** `lib/destila_web/components/chat_components.ex`
+
+The chat components receive `@workflow_session` as an assign and access `@workflow_session.phase_status` directly. Since `phase_status` is no longer a field, these must change.
+
+**Approach:** Receive `phase_status` as an attr from the parent. This is the single DB query point established in Step 7's `render_phase/1`.
+
+#### Changes to `chat_phase/1`
+
+1. Add `attr :phase_status, :atom, default: nil` to the attr declarations (after line 36)
+2. Replace all `@workflow_session.phase_status` references in the `chat_phase` template with `@phase_status`
+
+Affected lines within `chat_phase/1` template:
+- Line 71: `@workflow_session.phase_status == :processing` → `@phase_status == :processing`
+- Line 124: `@workflow_session.phase_status == :processing` → `@phase_status == :processing`
+- Line 132: `@workflow_session.phase_status == :awaiting_input` → `@phase_status == :awaiting_input`
+- Line 147: `@workflow_session.phase_status not in [:advance_suggested]` → `@phase_status not in [:advance_suggested]`
+- Line 152: `@workflow_session.phase_status == :processing` → `@phase_status == :processing`
+- Line 153: `@workflow_session.phase_status == :processing` → `@phase_status == :processing`
+- Line 154: `@workflow_session.phase_status == :awaiting_input` → `@phase_status == :awaiting_input`
+
+#### Changes to `chat_message/1` and `render_chat_message/1`
+
+Line 272 (`render_chat_message` for `:phase_advance`) accesses `@workflow_session.phase_status == :advance_suggested`. This is inside `render_chat_message/1`, which is called from `chat_message/1`.
+
+The `chat_message` component receives `workflow_session` as an attr (line 241). To avoid adding a DB query per message, pass `phase_status` through:
+
+1. Add `attr :phase_status, :atom, default: nil` to `chat_message/1` (after line 241)
+2. In `chat_phase/1` template, pass it: `<.chat_message :for={msg <- group} message={msg} workflow_session={@workflow_session} phase_status={@phase_status} />`
+3. In `render_chat_message` for `:phase_advance` (line 272): `@workflow_session.phase_status == :advance_suggested` → `@phase_status == :advance_suggested`
+
+### Step 9: Update `BoardComponents`
+
+**File:** `lib/destila_web/components/board_components.ex`
+
+The board components also access `phase_status` as a struct field via pattern matching. Since `phase_status` is removed from the schema, the struct won't have this key.
+
+**Approach:** Compute phase status externally and pass it or use `Session.phase_status/1`.
+
+**`should_be_alive?/1` (line 61):** Change from pattern match to function call:
+
+```elixir
+def should_be_alive?(session) do
+  Session.phase_status(session) == :processing
+end
+```
+
+**`status_dot_style/1` (lines 152–163):** Change from pattern matching to conditional:
+
+```elixir
+defp status_dot_style(card) do
+  phase_status = Session.phase_status(card)
+
+  cond do
+    Session.done?(card) -> {"bg-success", "Done"}
+    phase_status in [:awaiting_input, :advance_suggested] -> {"bg-warning", "Waiting for you"}
+    phase_status == :processing -> {"bg-info animate-pulse", "AI is responding"}
+    true -> {"bg-primary/40", "In progress"}
+  end
+end
+```
+
+**Performance note:** `Session.phase_status/1` queries the DB. On the crafting board, `status_dot_style/1` and `should_be_alive?/1` are called per card, giving 2 queries per session. For ~20 sessions, that's ~40 queries per render. To avoid this, compute phase_status once per card in `crafting_card/1` and pass it down:
+
+```elixir
+def crafting_card(assigns) do
+  phase_status = Session.phase_status(assigns.card)
+  assigns = assign(assigns, :card_phase_status, phase_status)
+  # ... use @card_phase_status in template and pass to status_dot/aliveness_dot
+end
+```
+
+Then update `should_be_alive?/1` and `status_dot_style/1` to accept the pre-computed value:
+
+```elixir
+def should_be_alive?(phase_status), do: phase_status == :processing
+
+defp status_dot_style(card, phase_status) do
+  cond do
+    Session.done?(card) -> {"bg-success", "Done"}
+    phase_status in [:awaiting_input, :advance_suggested] -> {"bg-warning", "Waiting for you"}
+    phase_status == :processing -> {"bg-info animate-pulse", "AI is responding"}
+    true -> {"bg-primary/40", "In progress"}
+  end
+end
+```
+
+This reduces to 1 query per card (~20 queries total). Still O(N) but acceptable at current scale. Future optimization: join-load the latest PE per session in `list_workflow_sessions/0`.
+
+**Note:** `should_be_alive?/1` is also called from `WorkflowRunnerLive` at line 447 via `<.aliveness_dot>`. In `WorkflowRunnerLive`, the `phase_status` is already computed once per render cycle, so pass it through: `<.aliveness_dot session={@workflow_session} alive?={@alive_session} phase_status={@phase_status} />`.
+
+### Step 10: Update `SetupComponents`
+
+**File:** `lib/destila_web/components/setup_components.ex`
+
+Line 5 (docstring) references `phase_status` being `:setup`. Update to reflect that setup is now derived from the absence of phase executions.
+
+### Step 11: Update `CraftingBoardLive`
+
+**File:** `lib/destila_web/live/crafting_board_live.ex`
+
+Line 139 calls `Workflows.classify/1` which is updated in Step 4. No direct `phase_status` references — no changes needed beyond what `classify/1` handles.
+
+### Step 12: Create migration to remove `phase_status` column
+
+**File:** `priv/repo/migrations/TIMESTAMP_remove_phase_status_from_workflow_sessions.exs`
+
+```elixir
+defmodule Destila.Repo.Migrations.RemovePhaseStatusFromWorkflowSessions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:workflow_sessions) do
+      remove :phase_status, :string
+    end
+  end
+end
+```
+
+### Step 13: Update tests
+
+There are 7 test files with ~70 `phase_status` references. Changes fall into 3 categories:
+
+#### Category A: Fixture helpers — remove `phase_status` from attrs, add PE creation
+
+**Pattern:** Every `create_session/create_prompt/create_session_in_phase` helper that sets `phase_status` must instead create a phase execution with the corresponding PE status.
+
+**Mapping for fixtures:**
+| Old fixture `phase_status` | New PE setup |
+|---------------------------|-------------|
+| `:setup` | No PE needed — `current_status/1` returns `:setup` when no PE exists |
+| `:awaiting_input` | `Executions.create_phase_execution(ws, phase, %{status: :awaiting_input})` |
+| `:processing` | `Executions.create_phase_execution(ws, phase, %{status: :processing})` |
+| `:advance_suggested` | `Executions.create_phase_execution(ws, phase, %{status: :awaiting_confirmation})` |
+| `nil` | `Executions.create_phase_execution(ws, phase, %{status: :completed})` |
+
+**Example — `workflows_classify_test.exs`:**
+
+Before:
+```elixir
+defp create_session(attrs) do
+  default = %{
+    title: "Test Session",
+    workflow_type: :brainstorm_idea,
+    current_phase: 1,
+    total_phases: 4,
+    phase_status: :awaiting_input
+  }
+
+  {:ok, ws} = Workflows.insert_workflow_session(Map.merge(default, attrs))
+  ws
+end
+
+test "returns :waiting_for_user when phase_status is awaiting_input" do
+  ws = create_session(%{phase_status: :awaiting_input})
+  assert Workflows.classify(ws) == :waiting_for_user
+end
+```
+
+After:
+```elixir
+defp create_session(attrs) do
+  {pe_status, attrs} = Map.pop(attrs, :pe_status)
+
+  default = %{
+    title: "Test Session",
+    workflow_type: :brainstorm_idea,
+    current_phase: 1,
+    total_phases: 4
+  }
+
+  {:ok, ws} = Workflows.insert_workflow_session(Map.merge(default, attrs))
+
+  if pe_status do
+    {:ok, _pe} = Destila.Executions.create_phase_execution(ws, ws.current_phase, %{status: pe_status})
+  end
+
+  ws
+end
+
+test "returns :waiting_for_user when PE is awaiting_input" do
+  ws = create_session(%{pe_status: :awaiting_input})
+  assert Workflows.classify(ws) == :waiting_for_user
+end
+
+test "returns :processing for sessions with no PE (setup)" do
+  ws = create_session(%{})
+  assert Workflows.classify(ws) == :processing
+end
+```
+
+**Example — `engine_test.exs`:**
+
+Before:
+```elixir
+defp create_session(attrs) do
+  default = %{..., phase_status: :awaiting_input}
+  {:ok, ws} = Workflows.insert_workflow_session(Map.merge(default, attrs))
+  ws
+end
+
+test "retries from awaiting_confirmation state" do
+  ws = create_session_with_ai(%{phase_status: :advance_suggested})
+  {:ok, pe} = Executions.create_phase_execution(ws, 1, %{status: :awaiting_confirmation})
+  ...
+  assert updated_ws.phase_status == :processing
+end
+```
+
+After:
+```elixir
+defp create_session(attrs) do
+  default = %{...,}  # no phase_status
+  {:ok, ws} = Workflows.insert_workflow_session(Map.merge(default, attrs))
+  ws
+end
+
+test "retries from awaiting_confirmation state" do
+  ws = create_session_with_ai(%{})
+  {:ok, pe} = Executions.create_phase_execution(ws, 1, %{status: :awaiting_confirmation})
+  # PE is already in :awaiting_confirmation → Session.phase_status returns :advance_suggested
+  ...
+  updated_pe = Executions.get_phase_execution!(pe.id)
+  assert updated_pe.status == :processing
+end
+```
+
+**Key insight for engine tests:** Prefer asserting on PE status directly (`updated_pe.status == :processing`) rather than `Session.phase_status(updated_ws) == :processing`. This tests the actual state change rather than the derived view.
+
+#### Category B: Assertions — replace `ws.phase_status` with PE status assertions
+
+**Pattern:** `assert updated_ws.phase_status == :X` → `assert updated_pe.status == :Y` or `assert Session.phase_status(updated_ws) == :X`
+
+Affected files:
+- `engine_test.exs`: 9 assertion sites — prefer PE status assertions
+- `brainstorm_idea_workflow_live_test.exs`: assertions after `mark_done`/advance — check PE status
+- `implement_general_prompt_workflow_live_test.exs`: similar pattern
+
+#### Category C: LiveView test fixtures — `create_session_in_phase` helper
+
+**File:** `brainstorm_idea_workflow_live_test.exs` (lines 39–81)
+
+The `create_session_in_phase` helper accepts `phase_status:` as an option. Rewrite to accept `pe_status:` instead and create the corresponding PE:
+
+Before:
+```elixir
+defp create_session_in_phase(phase, opts \\ []) do
+  phase_status = Keyword.get(opts, :phase_status, :awaiting_input)
+  ...
+  {:ok, ws} = Workflows.insert_workflow_session(%{..., phase_status: phase_status})
+  ...
+end
+```
+
+After:
+```elixir
+defp create_session_in_phase(phase, opts \\ []) do
+  pe_status = Keyword.get(opts, :pe_status, :awaiting_input)
+  ...
+  {:ok, ws} = Workflows.insert_workflow_session(%{..., current_phase: phase, ...})
+  {:ok, _pe} = Executions.create_phase_execution(ws, phase, %{status: pe_status})
+  ...
+end
+```
+
+Call-site updates throughout the test file:
+- `create_session_in_phase(1, phase_status: :advance_suggested)` → `create_session_in_phase(1, pe_status: :awaiting_confirmation)`
+- `create_session_in_phase(1, phase_status: :processing)` → `create_session_in_phase(1, pe_status: :processing)`
+- `create_session_in_phase(1, phase_status: :awaiting_input)` → `create_session_in_phase(1, pe_status: :awaiting_input)` (or just `create_session_in_phase(1)` since it's the default)
+- Sessions with `phase_status: :setup` → don't create a PE at all
+
+**File:** `crafting_board_live_test.exs`
+
+The `create_prompt` helper sets `phase_status` directly. Same pattern — extract PE creation:
+
+Before:
+```elixir
+create_prompt(%{title: "Waiting Prompt", phase_status: :awaiting_input, ...})
+```
+
+After:
+```elixir
+ws = create_prompt(%{title: "Waiting Prompt", ...})
+Executions.create_phase_execution(ws, ws.current_phase, %{status: :awaiting_input})
+```
+
+Or modify `create_prompt` to accept `pe_status:` and create the PE internally.
+
+**File:** `session_archiving_live_test.exs`
+
+Line 31: Remove `phase_status: :awaiting_input` from default attrs, create PE in setup.
+
+**File:** `generated_prompt_viewing_live_test.exs`
+
+Remove `phase_status` from fixture, create PE as needed.
+
+### Step 14: Update feature files
+
+**File:** `features/crafting_board.feature`, lines 16–18
+
+Update the Gherkin scenarios to reflect that classification is now derived from phase execution status, not `phase_status` field. The scenarios already use outdated enum values ("conversing", "generating") — update them to reflect the current architecture:
+
+```gherkin
+And sessions with no phase execution should appear under "Setup"
+And sessions with awaiting_input or awaiting_confirmation phase execution should appear under "Waiting for You"
+And sessions with processing phase execution should appear under "Processing"
+```
+
+### Step 15: Run `mix precommit`
+
+Run `mix precommit` to verify compilation, tests, and formatting all pass.
+
+## Risk assessment
+
+| Risk | Mitigation |
+|------|-----------|
+| N+1 queries on crafting board | Acceptable at current scale (~20 sessions). Can optimize with preloaded PE join later. |
+| Missing broadcasts after removing `update_workflow_session` calls | Explicitly broadcast from Engine after PE writes (Step 3). |
+| Race condition: PE not yet created when status queried | `current_status/1` returns `:setup` for nil PE, which is the correct initial state. |
+| Test fixtures rely on `phase_status` | All test helpers updated to create PEs instead (Step 13). |
+
+## Done when
+
+- The `phase_status` column is removed from the database
+- The `phase_status` field is removed from the `Session` schema
+- All status reads go through `Session.phase_status/1` → `Executions.current_status/1`
+- The Engine only writes to `phase_executions` for status changes (no more `%{phase_status: ...}` in `update_workflow_session` calls)
+- PubSub broadcasts still fire correctly after Engine status transitions
+- `mix precommit` passes

--- a/features/crafting_board.feature
+++ b/features/crafting_board.feature
@@ -13,11 +13,11 @@ Feature: Crafting Board
     Given there are sessions in various phases and statuses
     When I navigate to the crafting board
     Then I should see five sections: "Setup", "Waiting for You", "AI Processing", "In Progress", and "Done"
-    And sessions with phase_status "setup" should appear under "Setup"
-    And sessions with phase_status "conversing" or "advance_suggested" should appear under "Waiting for You"
-    And sessions with phase_status "generating" should appear under "AI Processing"
+    And sessions with no phase execution should appear under "Processing" (setup)
+    And sessions with awaiting_input or awaiting_confirmation phase execution should appear under "Waiting for You"
+    And sessions with processing phase execution should appear under "Processing"
     And sessions marked as done should appear under "Done"
-    And remaining sessions should appear under "In Progress"
+    And remaining sessions should appear under "Processing"
 
   Scenario: Session card displays title, project, and phase
     Given there is a session with title "Fix login bug", project "destila", and steps completed 2

--- a/lib/destila/executions.ex
+++ b/lib/destila/executions.ex
@@ -47,6 +47,21 @@ defmodule Destila.Executions do
     )
   end
 
+  @doc """
+  Derives the phase status from the latest phase execution.
+  Returns the status that `Session.phase_status/1` uses for classification and UI rendering.
+  """
+  def current_status(workflow_session_id) do
+    case get_current_phase_execution(workflow_session_id) do
+      nil -> :setup
+      %{status: :processing} -> :processing
+      %{status: :awaiting_input} -> :awaiting_input
+      %{status: :awaiting_confirmation} -> :awaiting_confirmation
+      %{status: :failed} -> :processing
+      %{status: :completed} -> nil
+    end
+  end
+
   # --- Mutations ---
 
   def create_phase_execution(workflow_session, phase_number, attrs \\ %{}) do
@@ -61,7 +76,8 @@ defmodule Destila.Executions do
           workflow_session_id: workflow_session.id,
           phase_number: phase_number,
           phase_name: phase_name,
-          status: :pending
+          status: :processing,
+          started_at: DateTime.utc_now() |> DateTime.truncate(:second)
         },
         attrs
       )
@@ -97,12 +113,6 @@ defmodule Destila.Executions do
 
   def reject_completion(%PhaseExecution{} = pe) do
     StateMachine.transition(pe, :awaiting_input, %{staged_result: nil})
-  end
-
-  def start_phase(%PhaseExecution{} = pe) do
-    StateMachine.transition(pe, :processing, %{
-      started_at: DateTime.utc_now() |> DateTime.truncate(:second)
-    })
   end
 
   @doc """

--- a/lib/destila/executions/engine.ex
+++ b/lib/destila/executions/engine.ex
@@ -5,17 +5,15 @@ defmodule Destila.Executions.Engine do
   The Engine is responsible for:
   - Advancing workflows to the next phase
   - Routing phase updates to `AI.Conversation` and acting on the result
-  - Updating phase execution and workflow session status
+  - Updating phase execution status
   - Broadcasting state changes via PubSub
 
   AI conversation mechanics (enqueuing workers, saving messages, parsing
   AI responses) are handled by `Destila.AI.Conversation`.
-
-  The Engine writes to both `phase_executions` (for execution history) and
-  `workflow_sessions.phase_status` (for classification and UI rendering).
   """
 
   alias Destila.{AI, Executions, Workflows}
+  alias Destila.Workflows.Session
 
   @doc """
   Advances the workflow to the next phase after the current phase completes.
@@ -53,15 +51,14 @@ defmodule Destila.Executions.Engine do
   """
   def start_session(ws) do
     phase = ws.current_phase
-    {:ok, pe} = Executions.ensure_phase_execution(ws, phase)
+    {:ok, _pe} = Executions.ensure_phase_execution(ws, phase)
     AI.Conversation.phase_start(ws)
 
     # Reload to check if an inline worker already advanced past this phase.
     reloaded = Workflows.get_workflow_session!(ws.id)
 
     if reloaded.current_phase == phase do
-      Executions.start_phase(pe)
-      Workflows.update_workflow_session(reloaded, %{phase_status: :processing})
+      Workflows.broadcast({:ok, reloaded}, :workflow_session_updated)
     end
   end
 
@@ -72,7 +69,7 @@ defmodule Destila.Executions.Engine do
   - `:resume` — stops the running ClaudeSession (prompt may be re-sent by the worker)
   - `:new` — stops the ClaudeSession and creates a fresh AI session
 
-  Updates both phase execution and workflow session status.
+  Updates phase execution status.
   Returns `{:ok, ws}` on success, or `:noop` if the phase is already processing.
   """
   def phase_retry(workflow_session_id) when is_binary(workflow_session_id) do
@@ -81,7 +78,7 @@ defmodule Destila.Executions.Engine do
   end
 
   def phase_retry(ws) do
-    if ws.phase_status == :processing do
+    if Session.phase_status(ws) == :processing do
       :noop
     else
       handle_retry(ws)
@@ -100,11 +97,12 @@ defmodule Destila.Executions.Engine do
 
     case Destila.Workflows.Setup.update(ws, params) do
       :setup_complete ->
-        {:ok, ws} = Workflows.update_workflow_session(ws, %{phase_status: nil})
         start_session(ws)
 
       :processing ->
-        Workflows.update_workflow_session(ws, %{phase_status: :setup})
+        # Setup status is derived from no PE existing — no write needed.
+        # Broadcast so the LiveView refreshes setup step progress.
+        Workflows.broadcast({:ok, ws}, :workflow_session_updated)
     end
   end
 
@@ -117,7 +115,7 @@ defmodule Destila.Executions.Engine do
           Executions.process_phase(pe)
         end
 
-        Workflows.update_workflow_session(ws, %{phase_status: :processing})
+        Workflows.broadcast({:ok, ws}, :workflow_session_updated)
 
       :awaiting_input ->
         handle_awaiting_input(ws)
@@ -133,10 +131,7 @@ defmodule Destila.Executions.Engine do
   # --- Private ---
 
   defp complete_workflow(ws) do
-    Workflows.update_workflow_session(ws, %{
-      done_at: DateTime.utc_now(),
-      phase_status: nil
-    })
+    Workflows.update_workflow_session(ws, %{done_at: DateTime.utc_now()})
   end
 
   defp handle_suggest_advance(ws) do
@@ -144,7 +139,7 @@ defmodule Destila.Executions.Engine do
       Executions.await_confirmation(pe, nil)
     end
 
-    Workflows.update_workflow_session(ws, %{phase_status: :advance_suggested})
+    Workflows.broadcast({:ok, ws}, :workflow_session_updated)
   end
 
   defp handle_awaiting_input(ws) do
@@ -152,41 +147,28 @@ defmodule Destila.Executions.Engine do
       Executions.await_input(pe)
     end
 
-    Workflows.update_workflow_session(ws, %{phase_status: :awaiting_input})
+    Workflows.broadcast({:ok, ws}, :workflow_session_updated)
   end
 
   defp transition_to_phase(ws, next_phase) do
-    # Get or create phase execution for the new phase (idempotent to handle concurrent calls)
-    {:ok, pe} = Executions.ensure_phase_execution(ws, next_phase)
-
-    # Update current_phase BEFORE starting the phase so that any inline
-    # worker execution (Oban testing mode) sees the correct state.
+    {:ok, _pe} = Executions.ensure_phase_execution(ws, next_phase)
     {:ok, ws} = Workflows.update_workflow_session(ws, %{current_phase: next_phase})
 
-    # Delegate phase startup to the workflow. In test/inline mode, this may
-    # trigger a full worker execution chain (including nested transitions).
     AI.Conversation.phase_start(ws)
 
-    # Reload to check if a nested transition (from an inline worker auto-advancing)
-    # has already moved past this phase. If so, skip the status update.
     reloaded = Workflows.get_workflow_session!(ws.id)
 
     if reloaded.current_phase == next_phase do
-      Executions.start_phase(pe)
-      Workflows.update_workflow_session(reloaded, %{phase_status: :processing})
+      Workflows.broadcast({:ok, reloaded}, :workflow_session_updated)
     end
   end
 
   defp handle_retry(ws) do
     phase = ws.current_phase
 
-    # Stop the running ClaudeSession for all strategies
     AI.ClaudeSession.stop_for_workflow_session(ws.id)
-
-    # Apply the phase's session strategy (create fresh AI session if :new)
     AI.Conversation.handle_session_strategy(ws, phase)
 
-    # Reload from DB to get fresh state after stopping the session
     ws = Workflows.get_workflow_session!(ws.id)
     AI.Conversation.phase_start(ws)
 
@@ -202,6 +184,6 @@ defmodule Destila.Executions.Engine do
         Executions.process_phase(pe)
     end
 
-    Workflows.update_workflow_session(ws, %{phase_status: :processing})
+    Workflows.broadcast({:ok, ws}, :workflow_session_updated)
   end
 end

--- a/lib/destila/executions/phase_execution.ex
+++ b/lib/destila/executions/phase_execution.ex
@@ -10,14 +10,13 @@ defmodule Destila.Executions.PhaseExecution do
 
     field(:status, Ecto.Enum,
       values: [
-        :pending,
         :processing,
         :awaiting_input,
         :awaiting_confirmation,
         :completed,
         :failed
       ],
-      default: :pending
+      default: :processing
     )
 
     field(:result, :map)

--- a/lib/destila/executions/state_machine.ex
+++ b/lib/destila/executions/state_machine.ex
@@ -8,7 +8,6 @@ defmodule Destila.Executions.StateMachine do
   alias Destila.Executions.PhaseExecution
 
   @transitions %{
-    pending: [:processing],
     processing: [:awaiting_input, :awaiting_confirmation, :completed, :failed],
     awaiting_input: [:processing],
     awaiting_confirmation: [:completed, :awaiting_input],

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -110,7 +110,6 @@ defmodule Destila.Workflows do
         workflow_type: workflow_type,
         current_phase: 1,
         total_phases: total_phases(workflow_type),
-        phase_status: :setup,
         title_generating: title_generating
       }
       |> maybe_put(:project_id, project_id)
@@ -159,7 +158,7 @@ defmodule Destila.Workflows do
   def classify(%Session{} = ws) do
     cond do
       Session.done?(ws) -> :done
-      ws.phase_status in [:awaiting_input, :advance_suggested] -> :waiting_for_user
+      Session.phase_status(ws) in [:awaiting_input, :awaiting_confirmation] -> :waiting_for_user
       true -> :processing
     end
   end
@@ -210,13 +209,15 @@ defmodule Destila.Workflows do
   end
 
   def unarchive_workflow_session(%Session{} = ws) do
-    attrs =
-      if ws.phase_status == :processing,
-        do: %{archived_at: nil, phase_status: :awaiting_input},
-        else: %{archived_at: nil}
+    # If PE was processing when archived, transition to awaiting_input
+    # since the ClaudeSession was killed during archival
+    case Destila.Executions.get_current_phase_execution(ws.id) do
+      %{status: :processing} = pe -> Destila.Executions.await_input(pe)
+      _ -> :ok
+    end
 
     ws
-    |> Session.changeset(attrs)
+    |> Session.changeset(%{archived_at: nil})
     |> Repo.update()
     |> broadcast(:workflow_session_updated)
   end

--- a/lib/destila/workflows/session.ex
+++ b/lib/destila/workflows/session.ex
@@ -11,10 +11,6 @@ defmodule Destila.Workflows.Session do
     field(:current_phase, :integer, default: 1)
     field(:total_phases, :integer)
 
-    field(:phase_status, Ecto.Enum,
-      values: [:setup, :processing, :awaiting_input, :advance_suggested]
-    )
-
     field(:title_generating, :boolean, default: false)
     field(:position, :integer)
     field(:done_at, :utc_datetime)
@@ -41,7 +37,6 @@ defmodule Destila.Workflows.Session do
       :done_at,
       :current_phase,
       :total_phases,
-      :phase_status,
       :title_generating,
       :position,
       :archived_at
@@ -50,4 +45,8 @@ defmodule Destila.Workflows.Session do
   end
 
   def done?(%__MODULE__{done_at: done_at}), do: not is_nil(done_at)
+
+  def phase_status(%__MODULE__{} = ws) do
+    if done?(ws), do: nil, else: Destila.Executions.current_status(ws.id)
+  end
 end

--- a/lib/destila_web/components/board_components.ex
+++ b/lib/destila_web/components/board_components.ex
@@ -37,9 +37,11 @@ defmodule DestilaWeb.BoardComponents do
 
   attr :session, :map, required: true
   attr :alive?, :boolean, required: true
+  attr :phase_status, :atom, default: nil
 
   def aliveness_dot(assigns) do
-    assigns = assign(assigns, :aliveness_state, aliveness_state(assigns.session, assigns.alive?))
+    phase_status = assigns[:phase_status] || Session.phase_status(assigns.session)
+    assigns = assign(assigns, :aliveness_state, aliveness_state(phase_status, assigns.alive?))
 
     ~H"""
     <span
@@ -49,17 +51,16 @@ defmodule DestilaWeb.BoardComponents do
     """
   end
 
-  defp aliveness_state(_session, true), do: :alive
+  defp aliveness_state(_phase_status, true), do: :alive
 
-  defp aliveness_state(session, false) do
-    if should_be_alive?(session), do: :unexpected_down, else: :expected_down
+  defp aliveness_state(phase_status, false) do
+    if should_be_alive?(phase_status), do: :unexpected_down, else: :expected_down
   end
 
   @doc """
   Returns true if the session is in a state where a ClaudeSession GenServer should be running.
   """
-  def should_be_alive?(%{phase_status: :processing}), do: true
-  def should_be_alive?(_session), do: false
+  def should_be_alive?(phase_status) when is_atom(phase_status), do: phase_status == :processing
 
   defp aliveness_color(:alive), do: "bg-success"
   defp aliveness_color(:expected_down), do: "bg-base-content/20"
@@ -75,6 +76,9 @@ defmodule DestilaWeb.BoardComponents do
   attr :alive?, :boolean, default: false
 
   def crafting_card(assigns) do
+    card_phase_status = Session.phase_status(assigns.card)
+    assigns = assign(assigns, :card_phase_status, card_phase_status)
+
     ~H"""
     <div
       id={"crafting-card-#{@card.id}"}
@@ -82,7 +86,7 @@ defmodule DestilaWeb.BoardComponents do
     >
       <div class={["card-body gap-2", if(@compact, do: "p-3", else: "p-4")]}>
         <div class={["flex gap-2", if(@compact, do: "items-start", else: "items-center")]}>
-          <.aliveness_dot session={@card} alive?={@alive?} />
+          <.aliveness_dot session={@card} alive?={@alive?} phase_status={@card_phase_status} />
           <.link
             navigate={"/sessions/#{@card.id}"}
             class={[
@@ -97,7 +101,7 @@ defmodule DestilaWeb.BoardComponents do
             </span>
           </.link>
           <div :if={@compact} class="flex items-center gap-1 shrink-0">
-            <.status_dot card={@card} />
+            <.status_dot card={@card} phase_status={@card_phase_status} />
           </div>
         </div>
 
@@ -139,9 +143,10 @@ defmodule DestilaWeb.BoardComponents do
   end
 
   attr :card, :map, required: true
+  attr :phase_status, :atom, default: nil
 
   defp status_dot(assigns) do
-    {color, title} = status_dot_style(assigns.card)
+    {color, title} = status_dot_style(assigns.card, assigns.phase_status)
     assigns = assigns |> assign(:dot_color, color) |> assign(:dot_title, title)
 
     ~H"""
@@ -149,17 +154,19 @@ defmodule DestilaWeb.BoardComponents do
     """
   end
 
-  defp status_dot_style(%{phase_status: s}) when s in [:awaiting_input, :advance_suggested],
-    do: {"bg-warning", "Waiting for you"}
+  defp status_dot_style(card, phase_status) do
+    cond do
+      Session.done?(card) ->
+        {"bg-success", "Done"}
 
-  defp status_dot_style(%{phase_status: :processing}),
-    do: {"bg-info animate-pulse", "AI is responding"}
+      phase_status in [:awaiting_input, :awaiting_confirmation] ->
+        {"bg-warning", "Waiting for you"}
 
-  defp status_dot_style(card) do
-    if Session.done?(card) do
-      {"bg-success", "Done"}
-    else
-      {"bg-primary/40", "In progress"}
+      phase_status == :processing ->
+        {"bg-info animate-pulse", "AI is responding"}
+
+      true ->
+        {"bg-primary/40", "In progress"}
     end
   end
 

--- a/lib/destila_web/components/chat_components.ex
+++ b/lib/destila_web/components/chat_components.ex
@@ -34,6 +34,7 @@ defmodule DestilaWeb.ChatComponents do
   attr :question_answers, :map, required: true
   attr :metadata, :map, required: true
   attr :current_step, :map, required: true
+  attr :phase_status, :atom, default: nil
 
   def chat_phase(assigns) do
     non_interactive = assigns.phase_config.non_interactive
@@ -67,8 +68,9 @@ defmodule DestilaWeb.ChatComponents do
                 :for={msg <- group}
                 message={msg}
                 workflow_session={@workflow_session}
+                phase_status={@phase_status}
               />
-              <%= if phase == @phase_number && @workflow_session.phase_status == :processing do %>
+              <%= if phase == @phase_number && @phase_status == :processing do %>
                 <%= if @streaming_chunks && @streaming_chunks != [] do %>
                   <.chat_stream_debug chunks={@streaming_chunks} />
                 <% else %>
@@ -121,7 +123,7 @@ defmodule DestilaWeb.ChatComponents do
       >
         <div class="flex items-center justify-center gap-3">
           <button
-            :if={@workflow_session.phase_status == :processing}
+            :if={@phase_status == :processing}
             phx-click="cancel_phase"
             id="cancel-phase-btn"
             class="btn btn-outline btn-error btn-sm"
@@ -129,7 +131,7 @@ defmodule DestilaWeb.ChatComponents do
             <.icon name="hero-stop-micro" class="size-4" /> Cancel
           </button>
           <button
-            :if={@workflow_session.phase_status == :awaiting_input}
+            :if={@phase_status == :awaiting_input}
             phx-click="retry_phase"
             id="retry-phase-btn"
             class="btn btn-primary btn-sm"
@@ -144,14 +146,14 @@ defmodule DestilaWeb.ChatComponents do
         :if={
           !@non_interactive &&
             !@current_step.completed &&
-            @workflow_session.phase_status not in [:advance_suggested]
+            @phase_status not in [:awaiting_confirmation]
         }
         class="max-w-2xl mx-auto w-full px-6 pb-4"
       >
         <.text_input
-          disabled={@workflow_session.phase_status == :processing}
-          show_cancel={@workflow_session.phase_status == :processing}
-          show_retry={@workflow_session.phase_status == :awaiting_input}
+          disabled={@phase_status == :processing}
+          show_cancel={@phase_status == :processing}
+          show_retry={@phase_status == :awaiting_input}
         />
       </div>
 
@@ -239,6 +241,7 @@ defmodule DestilaWeb.ChatComponents do
 
   attr :message, :map, required: true
   attr :workflow_session, :map, default: %{}
+  attr :phase_status, :atom, default: nil
 
   def chat_message(assigns) do
     processed = Destila.AI.process_message(assigns.message, assigns.workflow_session)
@@ -269,7 +272,7 @@ defmodule DestilaWeb.ChatComponents do
           {raw(markdown_to_html(@message.content))}
         </div>
 
-        <%= if @workflow_session.phase_status == :advance_suggested do %>
+        <%= if @phase_status == :awaiting_confirmation do %>
           <div class="flex gap-2 mt-2">
             <button
               phx-click="confirm_advance"

--- a/lib/destila_web/components/setup_components.ex
+++ b/lib/destila_web/components/setup_components.ex
@@ -1,8 +1,8 @@
 defmodule DestilaWeb.SetupComponents do
   @moduledoc """
   Function component for setup status — displays setup progress (title generation,
-  repo sync, worktree creation). Rendered by WorkflowRunnerLive when
-  `phase_status` is `:setup`.
+  repo sync, worktree creation). Rendered by WorkflowRunnerLive when no phase
+  execution exists yet (derived status is `:setup`).
   """
 
   use DestilaWeb, :html

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -142,8 +142,12 @@ defmodule DestilaWeb.WorkflowRunnerLive do
       _ -> :ok
     end
 
-    {:ok, ws} = Workflows.update_workflow_session(ws, %{phase_status: :awaiting_input})
-    {:noreply, assign(socket, :workflow_session, ws)}
+    ws = Workflows.get_workflow_session!(ws.id)
+
+    {:noreply,
+     socket
+     |> assign(:workflow_session, ws)
+     |> assign_ai_state(ws)}
   end
 
   def handle_event("mark_done", _params, socket) do
@@ -159,10 +163,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
     end
 
     {:ok, ws} =
-      Workflows.update_workflow_session(ws, %{
-        done_at: DateTime.utc_now(),
-        phase_status: nil
-      })
+      Workflows.update_workflow_session(ws, %{done_at: DateTime.utc_now()})
 
     {:noreply,
      socket
@@ -174,10 +175,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
     ws = socket.assigns.workflow_session
 
     {:ok, ws} =
-      Workflows.update_workflow_session(ws, %{
-        done_at: nil,
-        phase_status: nil
-      })
+      Workflows.update_workflow_session(ws, %{done_at: nil})
 
     {:noreply, assign(socket, :workflow_session, ws)}
   end
@@ -192,7 +190,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
   def handle_event("send_text", %{"content" => content}, socket) when content != "" do
     ws = socket.assigns.workflow_session
 
-    if ws.phase_status not in [:processing] do
+    if Session.phase_status(ws) != :processing do
       Destila.Executions.Engine.phase_update(ws.id, ws.current_phase, %{message: content})
 
       ws = Workflows.get_workflow_session!(ws.id)
@@ -286,7 +284,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
   def handle_event("retry_phase", _params, socket) do
     ws = socket.assigns.workflow_session
 
-    if ws.phase_status != :processing do
+    if Session.phase_status(ws) != :processing do
       Destila.Executions.Engine.phase_retry(ws)
       ws = Workflows.get_workflow_session!(ws.id)
       {:noreply, assign(socket, :workflow_session, ws)}
@@ -298,14 +296,14 @@ defmodule DestilaWeb.WorkflowRunnerLive do
   def handle_event("cancel_phase", _params, socket) do
     ws = socket.assigns.workflow_session
 
-    if ws.phase_status == :processing do
+    if Session.phase_status(ws) == :processing do
       AI.ClaudeSession.stop_for_workflow_session(ws.id)
 
       if pe = Destila.Executions.get_current_phase_execution(ws.id) do
         Destila.Executions.await_input(pe)
       end
 
-      {:ok, ws} = Workflows.update_workflow_session(ws, %{phase_status: :awaiting_input})
+      ws = Workflows.get_workflow_session!(ws.id)
       {:noreply, assign(socket, :workflow_session, ws)}
     else
       {:noreply, socket}
@@ -325,7 +323,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
        |> assign(:page_title, ws.title)
        |> assign(
          :streaming_chunks,
-         if(ws.phase_status == :processing,
+         if(Session.phase_status(ws) == :processing,
            do: socket.assigns[:streaming_chunks],
            else: nil
          )
@@ -392,14 +390,16 @@ defmodule DestilaWeb.WorkflowRunnerLive do
   end
 
   defp compute_current_step(ws, messages) do
+    phase_status = Session.phase_status(ws)
+
     cond do
       Session.done?(ws) ->
         %{input_type: nil, options: nil, questions: [], question_title: nil, completed: true}
 
-      ws.phase_status == :advance_suggested ->
+      phase_status == :awaiting_confirmation ->
         %{input_type: nil, options: nil, questions: [], question_title: nil, completed: false}
 
-      ws.phase_status == :processing ->
+      phase_status == :processing ->
         %{input_type: :text, options: nil, questions: [], question_title: nil, completed: false}
 
       true ->
@@ -730,7 +730,13 @@ defmodule DestilaWeb.WorkflowRunnerLive do
 
   # --- Generic phase rendering ---
 
-  defp render_phase(%{workflow_session: %{phase_status: :setup}} = assigns) do
+  defp render_phase(assigns) do
+    phase_status = Session.phase_status(assigns.workflow_session)
+    assigns = assign(assigns, :phase_status, phase_status)
+    do_render_phase(assigns)
+  end
+
+  defp do_render_phase(%{phase_status: :setup} = assigns) do
     ~H"""
     <DestilaWeb.SetupComponents.setup
       workflow_session={@workflow_session}
@@ -739,7 +745,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
     """
   end
 
-  defp render_phase(%{phases: phases, current_phase: current_phase} = assigns) do
+  defp do_render_phase(%{phases: phases, current_phase: current_phase} = assigns) do
     case Enum.at(phases, current_phase - 1) do
       %Destila.Workflows.Phase{} = phase ->
         assigns = assign(assigns, :phase_config, phase)
@@ -754,6 +760,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
           question_answers={@question_answers}
           metadata={@metadata}
           current_step={@current_step}
+          phase_status={@phase_status}
         />
         """
 

--- a/priv/repo/migrations/20260406194834_remove_phase_status_from_workflow_sessions.exs
+++ b/priv/repo/migrations/20260406194834_remove_phase_status_from_workflow_sessions.exs
@@ -1,0 +1,9 @@
+defmodule Destila.Repo.Migrations.RemovePhaseStatusFromWorkflowSessions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:workflow_sessions) do
+      remove :phase_status, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20260406200000_remove_pending_status_from_phase_executions.exs
+++ b/priv/repo/migrations/20260406200000_remove_pending_status_from_phase_executions.exs
@@ -1,0 +1,15 @@
+defmodule Destila.Repo.Migrations.RemovePendingStatusFromPhaseExecutions do
+  use Ecto.Migration
+
+  def up do
+    # Migrate any existing pending rows to processing.
+    # The Ecto schema default handles new inserts; SQLite doesn't support ALTER COLUMN
+    # so we only need the data migration.
+    execute("UPDATE phase_executions SET status = 'processing' WHERE status = 'pending'")
+  end
+
+  def down do
+    # No-op: the Ecto schema controls the default, not the DB column
+    :ok
+  end
+end

--- a/test/destila/executions/engine_test.exs
+++ b/test/destila/executions/engine_test.exs
@@ -3,6 +3,7 @@ defmodule Destila.Executions.EngineTest do
 
   alias Destila.{AI, Executions, Workflows}
   alias Destila.Executions.Engine
+  alias Destila.Workflows.Session
 
   setup do
     ClaudeCode.Test.stub(ClaudeCode, fn _query, _opts ->
@@ -16,15 +17,21 @@ defmodule Destila.Executions.EngineTest do
   end
 
   defp create_session(attrs) do
+    {pe_status, attrs} = Map.pop(attrs, :pe_status)
+
     default = %{
       title: "Test Session",
       workflow_type: :brainstorm_idea,
       current_phase: 1,
-      total_phases: 4,
-      phase_status: :awaiting_input
+      total_phases: 4
     }
 
     {:ok, ws} = Workflows.insert_workflow_session(Map.merge(default, attrs))
+
+    if pe_status do
+      {:ok, _pe} = Executions.create_phase_execution(ws, ws.current_phase, %{status: pe_status})
+    end
+
     ws
   end
 
@@ -35,10 +42,9 @@ defmodule Destila.Executions.EngineTest do
   end
 
   describe "phase_update/3 with suggest_phase_complete" do
-    test "sets phase_status to advance_suggested" do
+    test "sets PE to awaiting_confirmation" do
       ws = create_session_with_ai(%{})
       {:ok, pe} = Executions.create_phase_execution(ws, 1)
-      Executions.start_phase(pe)
 
       # Simulate AI response that suggests phase complete
       ai_session = AI.get_ai_session_for_workflow(ws.id)
@@ -62,28 +68,27 @@ defmodule Destila.Executions.EngineTest do
         }
       })
 
-      updated_ws = Workflows.get_workflow_session!(ws.id)
-      assert updated_ws.phase_status == :advance_suggested
-
       updated_pe = Executions.get_phase_execution!(pe.id)
       assert updated_pe.status == :awaiting_confirmation
+
+      updated_ws = Workflows.get_workflow_session!(ws.id)
+      assert Session.phase_status(updated_ws) == :awaiting_confirmation
     end
   end
 
   describe "phase_update/3 with continue conversation" do
-    test "sets phase_status to conversing" do
-      ws = create_session_with_ai(%{phase_status: :processing})
-      {:ok, pe} = Executions.create_phase_execution(ws, 1, %{status: :processing})
+    test "sets PE to awaiting_input" do
+      ws = create_session_with_ai(%{pe_status: :processing})
 
       Engine.phase_update(ws.id, 1, %{
         ai_result: %{text: "More questions", result: "More questions"}
       })
 
-      updated_ws = Workflows.get_workflow_session!(ws.id)
-      assert updated_ws.phase_status == :awaiting_input
+      pe = Executions.get_current_phase_execution(ws.id)
+      assert pe.status == :awaiting_input
 
-      updated_pe = Executions.get_phase_execution!(pe.id)
-      assert updated_pe.status == :awaiting_input
+      updated_ws = Workflows.get_workflow_session!(ws.id)
+      assert Session.phase_status(updated_ws) == :awaiting_input
     end
   end
 
@@ -107,7 +112,7 @@ defmodule Destila.Executions.EngineTest do
 
       updated_ws = Workflows.get_workflow_session!(ws.id)
       assert updated_ws.done_at != nil
-      assert is_nil(updated_ws.phase_status)
+      assert is_nil(Session.phase_status(updated_ws))
     end
   end
 
@@ -115,7 +120,6 @@ defmodule Destila.Executions.EngineTest do
     test "auto-advances to next phase and creates phase execution" do
       ws = create_session_with_ai(%{current_phase: 1, total_phases: 4})
       {:ok, pe} = Executions.create_phase_execution(ws, 1)
-      Executions.start_phase(pe)
 
       Engine.phase_update(ws.id, 1, %{
         ai_result: %{
@@ -147,32 +151,31 @@ defmodule Destila.Executions.EngineTest do
   end
 
   describe "phase_update/3 with user message" do
-    test "enqueues worker and sets status to generating" do
-      ws = create_session_with_ai(%{})
+    test "enqueues worker and sets PE status to processing" do
+      ws = create_session_with_ai(%{pe_status: :awaiting_input})
 
       Engine.phase_update(ws.id, 1, %{message: "Hello"})
 
+      pe = Executions.get_current_phase_execution(ws.id)
+      assert pe.status == :processing
+
       updated_ws = Workflows.get_workflow_session!(ws.id)
-      assert updated_ws.phase_status == :processing
+      assert Session.phase_status(updated_ws) == :processing
     end
 
     test "updates phase_execution status from awaiting_input to processing" do
-      ws = create_session_with_ai(%{phase_status: :awaiting_input})
-      {:ok, pe} = Executions.create_phase_execution(ws, 1, %{status: :awaiting_input})
+      ws = create_session_with_ai(%{pe_status: :awaiting_input})
 
       Engine.phase_update(ws.id, 1, %{message: "Hello"})
 
-      updated_ws = Workflows.get_workflow_session!(ws.id)
-      assert updated_ws.phase_status == :processing
-
-      updated_pe = Executions.get_phase_execution!(pe.id)
-      assert updated_pe.status == :processing
+      pe = Executions.get_current_phase_execution(ws.id)
+      assert pe.status == :processing
     end
   end
 
   describe "phase_update/3 with setup_step_completed" do
     test "transitions from setup to phase 1 when all setup steps complete" do
-      ws = create_session_with_ai(%{phase_status: :setup})
+      ws = create_session_with_ai(%{})
 
       Workflows.upsert_metadata(ws.id, "creation", "title_gen", %{"status" => "completed"})
       Workflows.upsert_metadata(ws.id, "creation", "repo_sync", %{"status" => "completed"})
@@ -182,12 +185,12 @@ defmodule Destila.Executions.EngineTest do
 
       updated_ws = Workflows.get_workflow_session!(ws.id)
       assert updated_ws.current_phase == 1
-      assert updated_ws.phase_status == :processing
-      refute updated_ws.phase_status == :setup
+      # Phase execution exists (not in :setup), status depends on AI worker outcome
+      assert Session.phase_status(updated_ws) != :setup
     end
 
     test "stays in setup when not all steps complete" do
-      ws = create_session(%{phase_status: :setup})
+      ws = create_session(%{})
 
       Workflows.upsert_metadata(ws.id, "creation", "title_gen", %{"status" => "completed"})
       Workflows.upsert_metadata(ws.id, "creation", "repo_sync", %{"status" => "in_progress"})
@@ -195,11 +198,11 @@ defmodule Destila.Executions.EngineTest do
       Engine.phase_update(ws.id, 1, %{setup_step_completed: true})
 
       updated_ws = Workflows.get_workflow_session!(ws.id)
-      assert updated_ws.phase_status == :setup
+      assert Session.phase_status(updated_ws) == :setup
     end
 
     test "creates phase execution for phase 1 after setup completes" do
-      ws = create_session_with_ai(%{phase_status: :setup})
+      ws = create_session_with_ai(%{})
 
       Workflows.upsert_metadata(ws.id, "creation", "title_gen", %{"status" => "completed"})
       Workflows.upsert_metadata(ws.id, "creation", "repo_sync", %{"status" => "completed"})
@@ -260,33 +263,31 @@ defmodule Destila.Executions.EngineTest do
 
   describe "phase_retry/1" do
     test "retries from awaiting_confirmation state" do
-      ws = create_session_with_ai(%{phase_status: :advance_suggested})
-      {:ok, pe} = Executions.create_phase_execution(ws, 1, %{status: :awaiting_confirmation})
+      ws = create_session_with_ai(%{pe_status: :awaiting_confirmation})
 
       Engine.phase_retry(ws)
 
-      updated_pe = Executions.get_phase_execution!(pe.id)
-      assert updated_pe.status == :processing
+      pe = Executions.get_current_phase_execution(ws.id)
+      assert pe.status == :processing
 
       updated_ws = Workflows.get_workflow_session!(ws.id)
-      assert updated_ws.phase_status == :processing
+      assert Session.phase_status(updated_ws) == :processing
     end
 
     test "retries from awaiting_input state" do
-      ws = create_session_with_ai(%{phase_status: :awaiting_input})
-      {:ok, pe} = Executions.create_phase_execution(ws, 1, %{status: :awaiting_input})
+      ws = create_session_with_ai(%{pe_status: :awaiting_input})
 
       Engine.phase_retry(ws)
 
-      updated_pe = Executions.get_phase_execution!(pe.id)
-      assert updated_pe.status == :processing
+      pe = Executions.get_current_phase_execution(ws.id)
+      assert pe.status == :processing
 
       updated_ws = Workflows.get_workflow_session!(ws.id)
-      assert updated_ws.phase_status == :processing
+      assert Session.phase_status(updated_ws) == :processing
     end
 
     test "returns noop when already processing" do
-      ws = create_session_with_ai(%{phase_status: :processing})
+      ws = create_session_with_ai(%{pe_status: :processing})
 
       assert Engine.phase_retry(ws) == :noop
     end

--- a/test/destila/executions/state_machine_test.exs
+++ b/test/destila/executions/state_machine_test.exs
@@ -23,7 +23,6 @@ defmodule Destila.Executions.StateMachineTest do
 
   describe "valid_transition?/2" do
     test "allows valid transitions" do
-      assert StateMachine.valid_transition?(:pending, :processing)
       assert StateMachine.valid_transition?(:processing, :awaiting_input)
       assert StateMachine.valid_transition?(:processing, :awaiting_confirmation)
       assert StateMachine.valid_transition?(:processing, :completed)
@@ -35,8 +34,6 @@ defmodule Destila.Executions.StateMachineTest do
     end
 
     test "rejects invalid transitions" do
-      refute StateMachine.valid_transition?(:pending, :completed)
-      refute StateMachine.valid_transition?(:pending, :awaiting_input)
       refute StateMachine.valid_transition?(:completed, :processing)
       refute StateMachine.valid_transition?(:awaiting_input, :completed)
       refute StateMachine.valid_transition?(:failed, :completed)
@@ -63,15 +60,13 @@ defmodule Destila.Executions.StateMachineTest do
   end
 
   describe "transition/3 happy paths" do
-    test "pending -> processing with started_at" do
+    test "processing -> awaiting_input" do
       ws = create_session()
       pe = create_pe(ws, 1)
-      now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-      {:ok, updated} = StateMachine.transition(pe, :processing, %{started_at: now})
+      {:ok, updated} = StateMachine.transition(pe, :awaiting_input)
 
-      assert updated.status == :processing
-      assert updated.started_at == now
+      assert updated.status == :awaiting_input
     end
 
     test "processing -> completed with result and completed_at" do
@@ -121,12 +116,12 @@ defmodule Destila.Executions.StateMachineTest do
       assert message =~ "invalid phase execution transition: completed -> processing"
     end
 
-    test "pending -> awaiting_input returns error" do
+    test "processing -> processing returns error (self-transition)" do
       ws = create_session()
       pe = create_pe(ws, 1)
 
-      assert {:error, message} = StateMachine.transition(pe, :awaiting_input)
-      assert message =~ "invalid phase execution transition: pending -> awaiting_input"
+      assert {:error, message} = StateMachine.transition(pe, :processing)
+      assert message =~ "invalid phase execution transition: processing -> processing"
     end
   end
 

--- a/test/destila/executions_test.exs
+++ b/test/destila/executions_test.exs
@@ -23,8 +23,8 @@ defmodule Destila.ExecutionsTest do
       assert pe.workflow_session_id == ws.id
       assert pe.phase_number == 1
       assert pe.phase_name == "Task Description"
-      assert pe.status == :pending
-      assert is_nil(pe.started_at)
+      assert pe.status == :processing
+      assert pe.started_at != nil
       assert is_nil(pe.completed_at)
     end
 
@@ -66,7 +66,6 @@ defmodule Destila.ExecutionsTest do
     test "complete_phase sets status and completed_at" do
       ws = create_session()
       {:ok, pe} = Executions.create_phase_execution(ws, 3)
-      {:ok, pe} = Executions.start_phase(pe)
       {:ok, pe} = Executions.complete_phase(pe, %{"summary" => "done"})
 
       assert pe.status == :completed
@@ -77,7 +76,6 @@ defmodule Destila.ExecutionsTest do
     test "await_confirmation and confirm_completion" do
       ws = create_session()
       {:ok, pe} = Executions.create_phase_execution(ws, 3)
-      {:ok, pe} = Executions.start_phase(pe)
 
       {:ok, pe} = Executions.await_confirmation(pe, %{"msg" => "ready"})
       assert pe.status == :awaiting_confirmation
@@ -91,7 +89,6 @@ defmodule Destila.ExecutionsTest do
     test "await_confirmation and reject_completion" do
       ws = create_session()
       {:ok, pe} = Executions.create_phase_execution(ws, 3)
-      {:ok, pe} = Executions.start_phase(pe)
 
       {:ok, pe} = Executions.await_confirmation(pe, %{"msg" => "ready"})
       {:ok, pe} = Executions.reject_completion(pe)
@@ -100,13 +97,64 @@ defmodule Destila.ExecutionsTest do
       assert is_nil(pe.staged_result)
     end
 
-    test "start_phase sets started_at and status" do
+    test "create_phase_execution sets started_at and processing status by default" do
       ws = create_session()
       {:ok, pe} = Executions.create_phase_execution(ws, 3)
-      {:ok, pe} = Executions.start_phase(pe)
 
       assert pe.status == :processing
       assert pe.started_at != nil
+    end
+  end
+
+  describe "current_status/1" do
+    test "returns :setup when no phase execution exists" do
+      ws = create_session()
+      assert Executions.current_status(ws.id) == :setup
+    end
+
+    test "returns :processing for processing PE (default status)" do
+      ws = create_session()
+      {:ok, _pe} = Executions.create_phase_execution(ws, 1)
+      assert Executions.current_status(ws.id) == :processing
+    end
+
+    test "returns :processing for explicitly processing PE" do
+      ws = create_session()
+      {:ok, _pe} = Executions.create_phase_execution(ws, 1, %{status: :processing})
+      assert Executions.current_status(ws.id) == :processing
+    end
+
+    test "returns :awaiting_input for awaiting_input PE" do
+      ws = create_session()
+      {:ok, _pe} = Executions.create_phase_execution(ws, 1, %{status: :awaiting_input})
+      assert Executions.current_status(ws.id) == :awaiting_input
+    end
+
+    test "returns :awaiting_confirmation for awaiting_confirmation PE" do
+      ws = create_session()
+      {:ok, _pe} = Executions.create_phase_execution(ws, 1, %{status: :awaiting_confirmation})
+      assert Executions.current_status(ws.id) == :awaiting_confirmation
+    end
+
+    test "returns :processing for failed PE" do
+      ws = create_session()
+      {:ok, _pe} = Executions.create_phase_execution(ws, 1)
+      # Simulate failure by direct status set
+      {:ok, _pe} = Executions.create_phase_execution(ws, 2, %{status: :failed})
+      assert Executions.current_status(ws.id) == :processing
+    end
+
+    test "returns nil for completed PE" do
+      ws = create_session()
+      {:ok, _pe} = Executions.create_phase_execution(ws, 1, %{status: :completed})
+      assert is_nil(Executions.current_status(ws.id))
+    end
+
+    test "returns status of highest phase number PE" do
+      ws = create_session()
+      {:ok, _pe1} = Executions.create_phase_execution(ws, 1, %{status: :completed})
+      {:ok, _pe2} = Executions.create_phase_execution(ws, 2, %{status: :awaiting_input})
+      assert Executions.current_status(ws.id) == :awaiting_input
     end
   end
 

--- a/test/destila/workflows_classify_test.exs
+++ b/test/destila/workflows_classify_test.exs
@@ -1,18 +1,24 @@
 defmodule Destila.WorkflowsClassifyTest do
   use DestilaWeb.ConnCase, async: false
 
-  alias Destila.Workflows
+  alias Destila.{Executions, Workflows}
 
   defp create_session(attrs) do
+    {pe_status, attrs} = Map.pop(attrs, :pe_status)
+
     default = %{
       title: "Test Session",
       workflow_type: :brainstorm_idea,
       current_phase: 1,
-      total_phases: 4,
-      phase_status: :awaiting_input
+      total_phases: 4
     }
 
     {:ok, ws} = Workflows.insert_workflow_session(Map.merge(default, attrs))
+
+    if pe_status do
+      {:ok, _pe} = Executions.create_phase_execution(ws, ws.current_phase, %{status: pe_status})
+    end
+
     ws
   end
 
@@ -22,28 +28,28 @@ defmodule Destila.WorkflowsClassifyTest do
       assert Workflows.classify(ws) == :done
     end
 
-    test "returns :processing for sessions in setup phase_status" do
-      ws = create_session(%{phase_status: :setup})
+    test "returns :processing for sessions with no PE (setup)" do
+      ws = create_session(%{})
       assert Workflows.classify(ws) == :processing
     end
 
-    test "returns :waiting_for_user when phase_status is awaiting_input" do
-      ws = create_session(%{phase_status: :awaiting_input})
+    test "returns :waiting_for_user when PE is awaiting_input" do
+      ws = create_session(%{pe_status: :awaiting_input})
       assert Workflows.classify(ws) == :waiting_for_user
     end
 
-    test "returns :waiting_for_user when phase_status is advance_suggested" do
-      ws = create_session(%{phase_status: :advance_suggested})
+    test "returns :waiting_for_user when PE is awaiting_confirmation" do
+      ws = create_session(%{pe_status: :awaiting_confirmation})
       assert Workflows.classify(ws) == :waiting_for_user
     end
 
-    test "returns :processing when phase_status is processing" do
-      ws = create_session(%{phase_status: :processing})
+    test "returns :processing when PE is processing" do
+      ws = create_session(%{pe_status: :processing})
       assert Workflows.classify(ws) == :processing
     end
 
-    test "returns :processing when phase_status is nil" do
-      ws = create_session(%{phase_status: nil})
+    test "returns :processing when PE is completed" do
+      ws = create_session(%{pe_status: :completed})
       assert Workflows.classify(ws) == :processing
     end
   end

--- a/test/destila_web/live/brainstorm_idea_workflow_live_test.exs
+++ b/test/destila_web/live/brainstorm_idea_workflow_live_test.exs
@@ -7,6 +7,8 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
 
   import Phoenix.LiveViewTest
 
+  alias Destila.Executions
+
   @feature "brainstorm_idea_workflow"
 
   setup %{conn: conn} do
@@ -37,7 +39,7 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
 
   # Creates a brainstorm_idea session in the given phase with appropriate state.
   defp create_session_in_phase(phase, opts \\ []) do
-    phase_status = Keyword.get(opts, :phase_status, :awaiting_input)
+    pe_status = Keyword.get(opts, :pe_status, :awaiting_input)
     last_message_type = Keyword.get(opts, :last_message_type)
 
     {last_content, session_tool_uses} =
@@ -76,9 +78,11 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
         workflow_type: :brainstorm_idea,
         project_id: nil,
         current_phase: phase,
-        total_phases: 4,
-        phase_status: phase_status
+        total_phases: 4
       })
+
+    # Create PE to derive the phase status
+    {:ok, _pe} = Executions.create_phase_execution(ws, phase, %{status: pe_status})
 
     {:ok, ai_session} = Destila.AI.get_or_create_ai_session(ws.id)
 
@@ -182,10 +186,11 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
           workflow_type: :brainstorm_idea,
           current_phase: 1,
           total_phases: 4,
-          phase_status: :setup,
           title_generating: true,
           project_id: create_project().id
         })
+
+      # No PE created — derived status is :setup
 
       Destila.Workflows.upsert_metadata(ws.id, "creation", "title_gen", %{
         "status" => "completed"
@@ -233,7 +238,7 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
     test "shows advance button and advances on confirm", %{conn: conn} do
       ws =
         create_session_in_phase(1,
-          phase_status: :advance_suggested,
+          pe_status: :awaiting_confirmation,
           last_message_type: :phase_advance
         )
 
@@ -252,7 +257,7 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
     test "re-enables input when declining advance", %{conn: conn} do
       ws =
         create_session_in_phase(1,
-          phase_status: :advance_suggested,
+          pe_status: :awaiting_confirmation,
           last_message_type: :phase_advance
         )
 
@@ -291,7 +296,7 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
 
       ws =
         create_session_in_phase(1,
-          phase_status: :advance_suggested,
+          pe_status: :awaiting_confirmation,
           last_message_type: :phase_advance
         )
 
@@ -363,10 +368,7 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
       ws = create_session_in_phase(4)
       # Mark as done first
       {:ok, ws} =
-        Destila.Workflows.update_workflow_session(ws, %{
-          done_at: DateTime.utc_now(),
-          phase_status: nil
-        })
+        Destila.Workflows.update_workflow_session(ws, %{done_at: DateTime.utc_now()})
 
       {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
 
@@ -425,9 +427,10 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
           workflow_type: :brainstorm_idea,
           current_phase: 1,
           total_phases: 4,
-          phase_status: :setup,
           project_id: project.id
         })
+
+      # No PE — derived status is :setup
 
       Destila.Workflows.upsert_metadata(ws.id, "creation", "title_gen", %{
         "status" => "completed"
@@ -527,7 +530,7 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
   describe "AI streaming" do
     @tag feature: @feature, scenario: "Streams AI response chunks to the chat UI"
     test "streams AI response chunks to the chat UI", %{conn: conn} do
-      ws = create_session_in_phase(1, phase_status: :processing)
+      ws = create_session_in_phase(1, pe_status: :processing)
       {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
 
       # Initially shows typing indicator
@@ -597,9 +600,10 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
         title: "Test Options",
         workflow_type: :brainstorm_idea,
         current_phase: 1,
-        total_phases: 4,
-        phase_status: :awaiting_input
+        total_phases: 4
       })
+
+    {:ok, _pe} = Executions.create_phase_execution(ws, 1, %{status: :awaiting_input})
 
     {:ok, ai_session} = Destila.AI.get_or_create_ai_session(ws.id)
 
@@ -649,9 +653,10 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
         title: "Test Questions",
         workflow_type: :brainstorm_idea,
         current_phase: 1,
-        total_phases: 4,
-        phase_status: :awaiting_input
+        total_phases: 4
       })
+
+    {:ok, _pe} = Executions.create_phase_execution(ws, 1, %{status: :awaiting_input})
 
     {:ok, ai_session} = Destila.AI.get_or_create_ai_session(ws.id)
 
@@ -776,7 +781,7 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
     @tag feature: @feature,
          scenario: "Workflow runner shows gray indicator when GenServer is not expected"
     test "shows gray dot when GenServer is not running and not expected", %{conn: conn} do
-      ws = create_session_in_phase(1, phase_status: :awaiting_input)
+      ws = create_session_in_phase(1, pe_status: :awaiting_input)
 
       {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
 
@@ -787,7 +792,7 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
          scenario:
            "Workflow runner shows red indicator when GenServer is unexpectedly not running"
     test "shows red dot when GenServer should be running but is not", %{conn: conn} do
-      ws = create_session_in_phase(1, phase_status: :processing)
+      ws = create_session_in_phase(1, pe_status: :processing)
 
       {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
 
@@ -797,7 +802,7 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
     @tag feature: @feature,
          scenario: "Workflow runner shows green indicator when Claude Code GenServer is running"
     test "shows green dot when GenServer is running", %{conn: conn} do
-      ws = create_session_in_phase(1, phase_status: :processing)
+      ws = create_session_in_phase(1, pe_status: :processing)
 
       {:ok, _pid} =
         Agent.start_link(fn -> nil end,
@@ -812,7 +817,7 @@ defmodule DestilaWeb.BrainstormIdeaWorkflowLiveTest do
     @tag feature: @feature,
          scenario: "Workflow runner indicator updates in real-time when GenServer stops"
     test "updates from green to red when GenServer stops", %{conn: conn} do
-      ws = create_session_in_phase(1, phase_status: :processing)
+      ws = create_session_in_phase(1, pe_status: :processing)
 
       {:ok, pid} =
         Agent.start_link(fn -> nil end,

--- a/test/destila_web/live/crafting_board_live_test.exs
+++ b/test/destila_web/live/crafting_board_live_test.exs
@@ -7,6 +7,8 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
 
   import Phoenix.LiveViewTest
 
+  alias Destila.Executions
+
   @feature "crafting_board"
 
   setup %{conn: conn} do
@@ -28,6 +30,8 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
   end
 
   defp create_prompt(attrs) do
+    {pe_status, attrs} = Map.pop(attrs, :pe_status)
+
     defaults = %{
       title: "Test Prompt",
       workflow_type: :brainstorm_idea,
@@ -37,6 +41,12 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
     }
 
     {:ok, prompt} = Destila.Workflows.insert_workflow_session(Map.merge(defaults, attrs))
+
+    if pe_status do
+      {:ok, _pe} =
+        Executions.create_phase_execution(prompt, prompt.current_phase, %{status: pe_status})
+    end
+
     prompt
   end
 
@@ -57,28 +67,29 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
       setup_prompt =
         create_prompt(%{
           title: "Setup Prompt",
-          phase_status: :setup,
           project_id: project.id
         })
+
+      # No PE — derived status is :setup → classified as :processing
 
       waiting_prompt =
         create_prompt(%{
           title: "Waiting Prompt",
-          phase_status: :awaiting_input,
+          pe_status: :awaiting_input,
           project_id: project.id
         })
 
       generating_prompt =
         create_prompt(%{
           title: "Generating Prompt",
-          phase_status: :processing,
+          pe_status: :processing,
           project_id: project.id
         })
 
       in_progress_prompt =
         create_prompt(%{
           title: "Active Prompt",
-          phase_status: nil,
+          pe_status: :completed,
           workflow_type: :brainstorm_idea,
           project_id: project.id
         })
@@ -95,10 +106,10 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
       # Setup sessions now appear in Processing section
       assert has_element?(view, "#section-processing #crafting-card-#{setup_prompt.id}")
 
-      # Waiting for You section (conversing and advance_suggested)
+      # Waiting for You section (awaiting_input and awaiting_confirmation)
       assert has_element?(view, "#section-waiting_for_user #crafting-card-#{waiting_prompt.id}")
 
-      # Processing section (generating and catch-all)
+      # Processing section (processing and catch-all)
       assert has_element?(view, "#section-processing #crafting-card-#{generating_prompt.id}")
       assert has_element?(view, "#section-processing #crafting-card-#{in_progress_prompt.id}")
 
@@ -107,14 +118,14 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
     end
 
     @tag feature: @feature, scenario: "View sessions in sectioned list"
-    test "advance_suggested appears in waiting for user section", %{
+    test "awaiting_confirmation appears in waiting for user section", %{
       conn: conn,
       project_a: project
     } do
       prompt =
         create_prompt(%{
           title: "Advance Prompt",
-          phase_status: :advance_suggested,
+          pe_status: :awaiting_confirmation,
           project_id: project.id
         })
 
@@ -448,7 +459,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
         create_prompt(%{
           title: "Idle Session",
           project_id: project.id,
-          phase_status: :awaiting_input
+          pe_status: :awaiting_input
         })
 
       {:ok, view, _html} = live(conn, ~p"/crafting")
@@ -467,7 +478,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
           title: "Stuck Session",
           project_id: project.id,
           current_phase: 1,
-          phase_status: :processing,
+          pe_status: :processing,
           workflow_type: :brainstorm_idea
         })
 
@@ -487,7 +498,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
           title: "Active Session",
           project_id: project.id,
           current_phase: 1,
-          phase_status: :processing,
+          pe_status: :processing,
           workflow_type: :brainstorm_idea
         })
 
@@ -510,7 +521,7 @@ defmodule DestilaWeb.CraftingBoardLiveTest do
           title: "Active Session",
           project_id: project.id,
           current_phase: 1,
-          phase_status: :processing,
+          pe_status: :processing,
           workflow_type: :brainstorm_idea
         })
 

--- a/test/destila_web/live/generated_prompt_viewing_live_test.exs
+++ b/test/destila_web/live/generated_prompt_viewing_live_test.exs
@@ -49,8 +49,7 @@ defmodule DestilaWeb.GeneratedPromptViewingLiveTest do
         project_id: nil,
         done_at: DateTime.utc_now(),
         current_phase: 4,
-        total_phases: 4,
-        phase_status: nil
+        total_phases: 4
       })
 
     {:ok, ai_session} = Destila.AI.get_or_create_ai_session(workflow_session.id)

--- a/test/destila_web/live/implement_general_prompt_workflow_live_test.exs
+++ b/test/destila_web/live/implement_general_prompt_workflow_live_test.exs
@@ -60,7 +60,7 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
   end
 
   defp create_implement_session(phase, opts) do
-    phase_status = Keyword.get(opts, :phase_status, :processing)
+    pe_status = Keyword.get(opts, :pe_status, :processing)
     project_id = Keyword.get(opts, :project_id)
 
     {:ok, ws} =
@@ -70,9 +70,13 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
         project_id: project_id,
         current_phase: phase,
         total_phases: 7,
-        phase_status: phase_status,
         title_generating: Keyword.get(opts, :title_generating, true)
       })
+
+    # Create PE unless we want setup status (no PE)
+    unless pe_status == :setup do
+      {:ok, _pe} = Destila.Executions.create_phase_execution(ws, phase, %{status: pe_status})
+    end
 
     Destila.Workflows.upsert_metadata(ws.id, "creation", "prompt", %{
       "text" => "Implement the login feature"
@@ -182,7 +186,7 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
     @tag feature: @feature,
          scenario: "Setup skips title generation for source session"
     test "skips title generation when source session selected", %{conn: conn} do
-      ws = create_implement_session(1, phase_status: :setup, title_generating: false)
+      ws = create_implement_session(1, pe_status: :setup, title_generating: false)
 
       {:ok, _view, html} = live(conn, ~p"/sessions/#{ws.id}")
       refute html =~ "Generating title..."
@@ -192,7 +196,7 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
     test "shows title generation for manual prompt", %{conn: conn} do
       ws =
         create_implement_session(1,
-          phase_status: :setup,
+          pe_status: :setup,
           title_generating: true,
           project_id: create_project().id
         )
@@ -211,7 +215,7 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
   describe "Non-interactive AI phases" do
     @tag feature: @feature, scenario: "Phase 1 - Non-interactive AI generates plan"
     test "non-interactive phase hides text input", %{conn: conn} do
-      ws = create_implement_session(1, phase_status: :processing)
+      ws = create_implement_session(1, pe_status: :processing)
 
       {:ok, ai_session} = Destila.AI.get_or_create_ai_session(ws.id)
 
@@ -232,7 +236,7 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
 
     @tag feature: @feature, scenario: "Non-interactive phase shows retry on error"
     test "non-interactive phase shows retry when conversing (error state)", %{conn: conn} do
-      ws = create_implement_session(1, phase_status: :awaiting_input)
+      ws = create_implement_session(1, pe_status: :awaiting_input)
 
       {:ok, ai_session} = Destila.AI.get_or_create_ai_session(ws.id)
 
@@ -253,10 +257,7 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
     test "retry transitions both workflow session and phase execution to processing", %{
       conn: conn
     } do
-      ws = create_implement_session(1, phase_status: :awaiting_input)
-
-      {:ok, _pe} =
-        Destila.Executions.create_phase_execution(ws, 1, %{status: :awaiting_input})
+      ws = create_implement_session(1, pe_status: :awaiting_input)
 
       {:ok, ai_session} = Destila.AI.get_or_create_ai_session(ws.id)
 
@@ -273,21 +274,18 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
 
       view |> element("#retry-phase-btn") |> render_click()
 
-      # Verify workflow session phase_status updated
-      ws = Destila.Workflows.get_workflow_session!(ws.id)
-      assert ws.phase_status == :processing
-
       # Verify phase execution status updated
       pe = Destila.Executions.get_current_phase_execution(ws.id)
       assert pe.status == :processing
+
+      # Verify derived phase_status
+      ws = Destila.Workflows.get_workflow_session!(ws.id)
+      assert Destila.Workflows.Session.phase_status(ws) == :processing
     end
 
     @tag feature: @feature, scenario: "Non-interactive phase shows retry on error"
     test "retry shows processing UI (typing indicator, cancel button)", %{conn: conn} do
-      ws = create_implement_session(1, phase_status: :awaiting_input)
-
-      {:ok, _pe} =
-        Destila.Executions.create_phase_execution(ws, 1, %{status: :awaiting_input})
+      ws = create_implement_session(1, pe_status: :awaiting_input)
 
       {:ok, ai_session} = Destila.AI.get_or_create_ai_session(ws.id)
 
@@ -309,10 +307,7 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
 
     @tag feature: @feature, scenario: "Non-interactive phase shows retry on error"
     test "workflow classified as :processing after retry", %{conn: conn} do
-      ws = create_implement_session(1, phase_status: :awaiting_input)
-
-      {:ok, _pe} =
-        Destila.Executions.create_phase_execution(ws, 1, %{status: :awaiting_input})
+      ws = create_implement_session(1, pe_status: :awaiting_input)
 
       {:ok, ai_session} = Destila.AI.get_or_create_ai_session(ws.id)
 
@@ -359,7 +354,7 @@ defmodule DestilaWeb.ImplementGeneralPromptWorkflowLiveTest do
   describe "Crafting board" do
     @tag feature: @feature, scenario: "Crafting board shows implementation workflow"
     test "shows implementation badge on crafting board", %{conn: conn} do
-      _ws = create_implement_session(1, phase_status: :processing)
+      _ws = create_implement_session(1, pe_status: :processing)
 
       {:ok, _view, html} = live(conn, ~p"/crafting")
       assert html =~ "Implementation"

--- a/test/destila_web/live/session_archiving_live_test.exs
+++ b/test/destila_web/live/session_archiving_live_test.exs
@@ -28,11 +28,17 @@ defmodule DestilaWeb.SessionArchivingLiveTest do
       workflow_type: :brainstorm_idea,
       current_phase: 1,
       total_phases: 4,
-      phase_status: :awaiting_input,
       position: System.unique_integer([:positive])
     }
 
     {:ok, session} = Destila.Workflows.insert_workflow_session(Map.merge(defaults, attrs))
+
+    # Create PE so derived status is :awaiting_input
+    {:ok, _pe} =
+      Destila.Executions.create_phase_execution(session, session.current_phase, %{
+        status: :awaiting_input
+      })
+
     session
   end
 
@@ -97,6 +103,56 @@ defmodule DestilaWeb.SessionArchivingLiveTest do
       assert has_element?(view, "#archive-btn")
       refute has_element?(view, "#unarchive-btn")
       assert render(view) =~ "Session restored"
+    end
+  end
+
+  # --- Unarchive PE transition ---
+
+  describe "unarchive PE transition" do
+    @tag feature: @feature, scenario: "Unarchive transitions processing PE to awaiting_input"
+    test "transitions PE from processing to awaiting_input on unarchive", %{
+      conn: _conn,
+      project: project
+    } do
+      # Create session with a processing PE
+      {:ok, ws} =
+        Destila.Workflows.insert_workflow_session(%{
+          title: "Processing Session",
+          workflow_type: :brainstorm_idea,
+          current_phase: 1,
+          total_phases: 4,
+          project_id: project.id
+        })
+
+      {:ok, _pe} =
+        Destila.Executions.create_phase_execution(ws, 1, %{status: :processing})
+
+      # Archive (kills ClaudeSession, but PE stays :processing)
+      {:ok, archived} = Destila.Workflows.archive_workflow_session(ws)
+
+      pe = Destila.Executions.get_current_phase_execution(archived.id)
+      assert pe.status == :processing
+
+      # Unarchive should transition PE to awaiting_input
+      {:ok, _restored} = Destila.Workflows.unarchive_workflow_session(archived)
+
+      pe = Destila.Executions.get_current_phase_execution(ws.id)
+      assert pe.status == :awaiting_input
+    end
+
+    @tag feature: @feature, scenario: "Unarchive preserves non-processing PE status"
+    test "does not change PE when status is not processing", %{
+      conn: _conn,
+      project: project
+    } do
+      ws = create_session(%{project_id: project.id})
+      # PE is created with :awaiting_input in create_session helper
+
+      {:ok, archived} = Destila.Workflows.archive_workflow_session(ws)
+      {:ok, _restored} = Destila.Workflows.unarchive_workflow_session(archived)
+
+      pe = Destila.Executions.get_current_phase_execution(ws.id)
+      assert pe.status == :awaiting_input
     end
   end
 


### PR DESCRIPTION
## Summary

- Remove the `phase_status` column from `workflow_sessions` — it duplicated state already tracked in `phase_executions.status`
- Add `Session.phase_status/1` which derives the value from the latest `PhaseExecution` via `Executions.current_status/1`
- Remove `:pending` PE status — PEs now default to `:processing` with `started_at` set at creation
- Remove `start_phase/1` (was only used on newly created PEs, now redundant)
- Replace all Engine writes to `phase_status` with explicit PubSub broadcasts
- Rename derived UI status `:advance_suggested` → `:awaiting_confirmation` to match PE status directly
- Thread `phase_status` as a computed attr through chat and board components
- Update all tests; add `current_status/1` mapping tests and unarchive PE transition tests

## Test plan

- [x] All 208 tests pass (`mix precommit`)
- [x] `Executions.current_status/1` maps each PE status correctly
- [x] `Session.phase_status/1` returns nil for done sessions, delegates otherwise
- [x] Engine broadcasts fire correctly without `update_workflow_session` calls
- [x] Unarchiving a session with `:processing` PE transitions it to `:awaiting_input`
- [x] Crafting board classification works with derived status
- [x] Migrations run cleanly on SQLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)