### PR TITLE
fix: Use white-compatible bg color for brainstorm idea badge

### DIFF
--- a/lib/destila_web/components/board_components.ex
+++ b/lib/destila_web/components/board_components.ex
@@ -186,7 +186,7 @@ defmodule DestilaWeb.BoardComponents do
   def workflow_label(:code_chat), do: "Code Chat"
   def workflow_label(_), do: "Workflow"
 
-  defp workflow_badge_class(:brainstorm_idea), do: "badge-warning"
+  defp workflow_badge_class(:brainstorm_idea), do: "bg-amber-600 text-white"
   defp workflow_badge_class(:implement_general_prompt), do: "badge-primary"
   defp workflow_badge_class(:code_chat), do: "badge-accent"
   defp workflow_badge_class(_), do: "badge-neutral"


### PR DESCRIPTION
## Summary
- Replace DaisyUI `badge-warning` class with `bg-amber-600 text-white` on the brainstorm idea workflow badge
- Ensures white foreground text with good contrast on a dark amber background

## Test plan
- [ ] Verify brainstorm idea badge renders with dark amber background and white text on the crafting board
- [ ] Verify badge appears correctly on the dashboard and archived sessions views

🤖 Generated with [Claude Code](https://claude.com/claude-code)