### PR TITLE
feat: Add typed metadata exports to the workflow system

### DIFF
--- a/docs/plans/2026-04-08-feat-typed-metadata-exports-plan.md
+++ b/docs/plans/2026-04-08-feat-typed-metadata-exports-plan.md
@@ -1,0 +1,484 @@
+---
+title: "feat: Add typed metadata exports to the workflow system"
+type: feat
+date: 2026-04-08
+---
+
+# feat: Add typed metadata exports to the workflow system
+
+## Overview
+
+Currently, all exported metadata values are stored as `%{"text" => value}` — a map with a single `"text"` key. This change extends the system so the LLM (via the MCP `session` tool's `export` action) and internal code (via `upsert_metadata`) can specify a type for each export. The type determines how the value should be interpreted and, eventually, rendered.
+
+The supported types are: `text` (default), `text_file`, `markdown`, and `video_file`. The type is encoded as the key of the value map itself:
+
+- `%{"text" => "hello world"}` — plain text (backward-compatible with all existing data)
+- `%{"markdown" => "# Title\nSome content"}` — markdown content
+- `%{"text_file" => "/absolute/path/to/file.txt"}` — path to a text file on disk
+- `%{"video_file" => "/absolute/path/to/video.mp4"}` — path to a video file on disk
+
+No database migration is needed — the existing `value` map column already supports this. Existing `%{"text" => value}` data is automatically backward-compatible as the `text` type.
+
+## Current state
+
+- **Tool definition** (`lib/destila/ai/tools.ex:42-70`): The `:session` tool has `action`, `message`, `key`, and `value` fields. No `type` field exists.
+- **Export extraction** (`lib/destila/ai/response_processor.ex:155-171`): `do_extract_export_actions/1` returns `%{key: key, value: value}` maps — no type extracted.
+- **Value wrapping** (`lib/destila/ai/conversation.ex:92`): Hardcoded `%{"text" => value}` for all exports.
+- **Metadata persistence** (`lib/destila/workflows.ex:230-255`): `upsert_metadata/5` accepts an opaque `value` map and passes it through. No type validation.
+- **Metadata listing** (`lib/destila/workflows.ex:183`): `list_sessions_with_exported_metadata/1` extracts `value["text"]` — only recognizes the `text` type.
+- **Metadata display** (`lib/destila_web/live/workflow_runner_live.ex:763-765`): `format_metadata_value/1` pattern-matches `%{"text" => text}`, falls back to JSON for other maps.
+- **Creation metadata** (`lib/destila/workflows.ex:119`): `create_workflow_session/1` stores creation metadata as `%{"text" => input_text}` — these are internal (not AI exports) and use the `text` type correctly.
+
+## Key design decisions
+
+### 1. Type validation uses a module attribute allowlist
+
+Define `@valid_metadata_types ~w(text text_file markdown video_file)` in `Destila.Workflows`. Both the MCP tool path (via `conversation.ex`) and `upsert_metadata` validate against this list. Unknown types are rejected — not silently accepted.
+
+### 2. Validation in `upsert_metadata` is the single enforcement point
+
+Rather than scattering validation, `upsert_metadata` validates that the value map's key is one of the allowed types. This covers both the MCP export path and any internal callers. The MCP path additionally validates the `type` field *before* constructing the value map (to return a clear error), but `upsert_metadata` is the backstop.
+
+### 3. The `type` field defaults to `"text"` when omitted
+
+For backward compatibility, when the LLM calls `export` without a `type` field, the system defaults to `"text"`. This means existing prompts and workflows work without modification.
+
+### 4. `list_sessions_with_exported_metadata/1` extracts value from any valid type key
+
+Instead of hardcoding `value["text"]`, it finds the first key in the value map that is a valid type and extracts the value from it. This makes the function work with any type.
+
+### 5. The type is surfaced to the LiveView via the existing value map structure
+
+The `meta.value` map already reaches the template (passed to `metadata_value_block`). The type *is* the key of that map. No new assigns or computed fields are needed — `format_metadata_value/1` pattern-matches on the type key, and future rendering components can do the same.
+
+### 6. No Gherkin scenario changes
+
+This is internal plumbing. The user-facing behavior (metadata appears in sidebar, updates in real-time) is unchanged. All four types render as plain text pass-through for now.
+
+## Changes
+
+### Step 1: Add `type` field to the `:session` tool definition
+
+**File:** `lib/destila/ai/tools.ex`
+
+Add a `type` field to the `:session` tool, between `value` and the closing `end`:
+
+```elixir
+field(:type, :string,
+  description:
+    "Type of the exported value. One of: text (default), text_file, markdown, video_file. " <>
+      "Determines how the value is interpreted and rendered."
+)
+```
+
+The field is optional — when omitted, the system defaults to `"text"`.
+
+### Step 2: Extract `type` in `ResponseProcessor.extract_export_actions/1`
+
+**File:** `lib/destila/ai/response_processor.ex`
+
+Update `do_extract_export_actions/1` (line 163) to include the type in the returned map:
+
+```elixir
+# Before (line 163):
+[%{key: access(input, :key), value: access(input, :value)}]
+
+# After:
+[%{key: access(input, :key), value: access(input, :value), type: access(input, :type)}]
+```
+
+When the LLM omits `type`, `access(input, :type)` returns `nil` — the downstream code defaults it to `"text"`.
+
+### Step 3: Add type validation and build typed value map in `conversation.ex`
+
+**File:** `lib/destila/ai/conversation.ex`
+
+**3a. Add a module attribute for valid types (top of module):**
+
+```elixir
+@valid_metadata_types ~w(text text_file markdown video_file)
+```
+
+**3b. Update the export processing block (lines 87-95):**
+
+```elixir
+# Before (lines 87-95):
+for %{key: key, value: value} <- export_actions, key != nil do
+  Workflows.upsert_metadata(
+    ws.id,
+    phase_name,
+    key,
+    %{"text" => value},
+    exported: true
+  )
+end
+
+# After:
+for %{key: key, value: value, type: type} <- export_actions,
+    key != nil,
+    type = type || "text",
+    type in @valid_metadata_types do
+  Workflows.upsert_metadata(
+    ws.id,
+    phase_name,
+    key,
+    %{type => value},
+    exported: true
+  )
+end
+```
+
+Key details:
+- `type = type || "text"` defaults nil to `"text"` (rebinding in generator is valid)
+- `type in @valid_metadata_types` silently skips exports with invalid types (malformed LLM output is filtered, not crashed on)
+- `%{type => value}` builds the typed value map dynamically instead of hardcoding `"text"`
+
+### Step 4: Add type validation in `upsert_metadata`
+
+**File:** `lib/destila/workflows.ex`
+
+**4a. Add a module attribute for valid types (near the top, after imports):**
+
+```elixir
+@valid_metadata_types ~w(text text_file markdown video_file)
+```
+
+**4b. Add a validation guard at the top of `upsert_metadata/5` (line 230):**
+
+```elixir
+def upsert_metadata(workflow_session_id, phase_name, key, value, opts \\ [])
+
+def upsert_metadata(workflow_session_id, phase_name, key, value, opts)
+    when is_map(value) do
+  # Validate that the value map's key is a valid metadata type (if it looks like a typed value)
+  # Non-typed value maps (like %{"id" => ...} for source_session) pass through
+  value_keys = Map.keys(value)
+
+  if length(value_keys) == 1 and hd(value_keys) not in @valid_metadata_types ++ ["id"] do
+    {:error, :invalid_metadata_type}
+  else
+    exported = Keyword.get(opts, :exported, false)
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    # ... rest of existing implementation unchanged
+  end
+end
+```
+
+Wait — this approach is overly complex. The existing `upsert_metadata` already accepts arbitrary value maps (like `%{"id" => session_id}` for source_session metadata, and `%{"status" => "done"}` for internal metadata). Adding type validation here would require distinguishing "typed export values" from "arbitrary internal metadata maps."
+
+**Revised approach:** Only validate for exported metadata. When `exported: true` is passed, enforce that the value map contains exactly one key that is a valid metadata type. When `exported: false` (the default), pass through without type validation.
+
+```elixir
+def upsert_metadata(workflow_session_id, phase_name, key, value, opts \\ []) do
+  exported = Keyword.get(opts, :exported, false)
+
+  if exported and not valid_exported_value?(value) do
+    {:error, :invalid_metadata_type}
+  else
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    # ... existing insert logic unchanged
+  end
+end
+
+defp valid_exported_value?(value) when is_map(value) do
+  case Map.keys(value) do
+    [type] -> type in @valid_metadata_types
+    _ -> false
+  end
+end
+
+defp valid_exported_value?(_), do: false
+```
+
+This validates that exported metadata has exactly one key and it's a valid type. Non-exported metadata (creation metadata, internal state) is unaffected.
+
+### Step 5: Update `list_sessions_with_exported_metadata/1`
+
+**File:** `lib/destila/workflows.ex`
+
+Update line 183 to extract the value from any valid type key, not just `"text"`:
+
+```elixir
+# Before (line 183):
+|> Enum.map(fn {ws, value} -> {ws, value["text"]} end)
+
+# After:
+|> Enum.map(fn {ws, value} -> {ws, extract_metadata_text(value)} end)
+```
+
+**Add a helper function:**
+
+```elixir
+@doc false
+defp extract_metadata_text(value) when is_map(value) do
+  Enum.find_value(@valid_metadata_types, fn type -> value[type] end)
+end
+
+defp extract_metadata_text(_), do: nil
+```
+
+This tries each valid type key in order (`text` first, then `text_file`, `markdown`, `video_file`) and returns the first non-nil value. Since typed value maps have exactly one key, the order doesn't matter — but `text` being first means existing data is found on the first try.
+
+### Step 6: Update `format_metadata_value/1` in the LiveView
+
+**File:** `lib/destila_web/live/workflow_runner_live.ex`
+
+Expand `format_metadata_value/1` (lines 763-765) to pattern-match on all four type keys:
+
+```elixir
+# Before:
+defp format_metadata_value(%{"text" => text}) when is_binary(text), do: text
+defp format_metadata_value(value) when is_map(value), do: Jason.encode!(value, pretty: true)
+defp format_metadata_value(value), do: inspect(value)
+
+# After:
+defp format_metadata_value(%{"text" => text}) when is_binary(text), do: text
+defp format_metadata_value(%{"markdown" => md}) when is_binary(md), do: md
+defp format_metadata_value(%{"text_file" => path}) when is_binary(path), do: path
+defp format_metadata_value(%{"video_file" => path}) when is_binary(path), do: path
+defp format_metadata_value(value) when is_map(value), do: Jason.encode!(value, pretty: true)
+defp format_metadata_value(value), do: inspect(value)
+```
+
+All four types render as plain text pass-through for now. Specialized rendering components (markdown rendering, file preview, video player) will be added later and will dispatch on the type key in `metadata_value_block/1`.
+
+### Step 7: Update `@tool_instructions` and `@non_interactive_tool_instructions`
+
+**File:** `lib/destila/workflows/brainstorm_idea_workflow.ex`
+
+Update the "Exporting Data" section in `@tool_instructions` to document the `type` parameter:
+
+```elixir
+## Exporting Data
+
+To store a key-value pair as session metadata, call `mcp__destila__session` with \
+`action: "export"`, a `key` string, and a `value` string. You may call export \
+multiple times in a single response and may combine it with a phase transition action.
+
+You can optionally specify a `type` string to indicate how the value should be \
+interpreted: `text` (default), `text_file` (absolute path to a text file), \
+`markdown` (markdown content), or `video_file` (absolute path to a video file).
+```
+
+**File:** `lib/destila/workflows/implement_general_prompt_workflow.ex`
+
+Apply the same update to `@non_interactive_tool_instructions`.
+
+### Step 8: Add tests
+
+**File:** `test/destila/workflows_metadata_test.exs`
+
+**8a. Add tests for type validation in `upsert_metadata`:**
+
+```elixir
+describe "upsert_metadata/5 type validation" do
+  test "accepts valid metadata types for exported metadata" do
+    ws = insert_workflow_session()
+
+    for type <- ~w(text text_file markdown video_file) do
+      assert {:ok, _} =
+               Workflows.upsert_metadata(
+                 ws.id, "phase", "key_#{type}", %{type => "value"},
+                 exported: true
+               )
+    end
+  end
+
+  test "rejects invalid type for exported metadata" do
+    ws = insert_workflow_session()
+
+    assert {:error, :invalid_metadata_type} =
+             Workflows.upsert_metadata(
+               ws.id, "phase", "key", %{"invalid_type" => "value"},
+               exported: true
+             )
+  end
+
+  test "allows arbitrary value maps for non-exported metadata" do
+    ws = insert_workflow_session()
+
+    assert {:ok, _} =
+             Workflows.upsert_metadata(
+               ws.id, "creation", "source_session", %{"id" => "some-uuid"}
+             )
+  end
+end
+```
+
+**8b. Add test for `list_sessions_with_exported_metadata` with non-text types:**
+
+```elixir
+test "returns value for non-text metadata types" do
+  ws = insert_workflow_session(%{done_at: DateTime.utc_now()})
+
+  Workflows.upsert_metadata(
+    ws.id, "phase", "my_export", %{"markdown" => "# Hello"},
+    exported: true
+  )
+
+  result = Workflows.list_sessions_with_exported_metadata("my_export")
+  assert [{^ws_id, "# Hello"}] = [{elem(hd(result), 0).id, elem(hd(result), 1)}]
+end
+```
+
+**File:** `test/destila/ai/response_processor_test.exs` (or relevant test file)
+
+**8c. Add test for type extraction in `extract_export_actions`:**
+
+```elixir
+test "extracts type from export actions" do
+  result = %{
+    mcp_tool_uses: [
+      %{
+        name: "mcp__destila__session",
+        input: %{action: "export", key: "doc", value: "# Title", type: "markdown"}
+      }
+    ]
+  }
+
+  assert [%{key: "doc", value: "# Title", type: "markdown"}] =
+           ResponseProcessor.extract_export_actions(result)
+end
+
+test "type is nil when omitted" do
+  result = %{
+    mcp_tool_uses: [
+      %{
+        name: "mcp__destila__session",
+        input: %{action: "export", key: "doc", value: "plain text"}
+      }
+    ]
+  }
+
+  assert [%{key: "doc", value: "plain text", type: nil}] =
+           ResponseProcessor.extract_export_actions(result)
+end
+```
+
+**File:** `test/destila/executions/engine_test.exs`
+
+**8d. Add engine integration test for typed exports:**
+
+```elixir
+test "stores typed metadata from AI export action" do
+  ws = create_session_with_ai(%{pe_status: :processing})
+
+  Engine.phase_update(ws.id, 1, %{
+    ai_result: %{
+      text: "Here is markdown output",
+      result: "Here is markdown output",
+      mcp_tool_uses: [
+        %{
+          name: "mcp__destila__session",
+          input: %{
+            action: "export",
+            key: "plan_doc",
+            value: "# Plan\nDo the thing",
+            type: "markdown"
+          }
+        }
+      ]
+    }
+  })
+
+  all_metadata = Workflows.get_all_metadata(ws.id)
+  exported = Enum.find(all_metadata, &(&1.key == "plan_doc"))
+  assert exported != nil
+  assert exported.value == %{"markdown" => "# Plan\nDo the thing"}
+  assert exported.exported == true
+end
+
+test "defaults to text type when type is omitted" do
+  ws = create_session_with_ai(%{pe_status: :processing})
+
+  Engine.phase_update(ws.id, 1, %{
+    ai_result: %{
+      text: "Output",
+      result: "Output",
+      mcp_tool_uses: [
+        %{
+          name: "mcp__destila__session",
+          input: %{action: "export", key: "result", value: "plain text"}
+        }
+      ]
+    }
+  })
+
+  all_metadata = Workflows.get_all_metadata(ws.id)
+  exported = Enum.find(all_metadata, &(&1.key == "result"))
+  assert exported.value == %{"text" => "plain text"}
+end
+
+test "skips export with invalid type" do
+  ws = create_session_with_ai(%{pe_status: :processing})
+
+  Engine.phase_update(ws.id, 1, %{
+    ai_result: %{
+      text: "Output",
+      result: "Output",
+      mcp_tool_uses: [
+        %{
+          name: "mcp__destila__session",
+          input: %{action: "export", key: "bad", value: "v", type: "html"}
+        }
+      ]
+    }
+  })
+
+  all_metadata = Workflows.get_all_metadata(ws.id)
+  assert all_metadata == []
+end
+```
+
+### Step 9: Run `mix precommit`
+
+Verify compilation, formatting, and tests pass.
+
+## What does NOT change
+
+- **Database schema**: No migration. The `value` map column already stores arbitrary maps. The type is encoded as the key of the map.
+- **Existing data**: All existing `%{"text" => value}` entries are automatically backward-compatible — `"text"` is a valid type.
+- **Creation metadata**: `create_workflow_session/1` (line 119) stores `%{"text" => input_text}` — this is the `text` type, already valid.
+- **Internal metadata**: Non-exported metadata like `%{"id" => session_id}` and `%{"status" => "done"}` are not validated (only exported metadata is type-checked).
+- **Gherkin feature files**: No scenario changes. This is internal plumbing.
+- **Rendering**: All four types render as plain text for now. Specialized rendering components will be built separately.
+- **`metadata_value_block/1`**: The function component structure stays the same — it calls `format_metadata_value/1` which now handles all four types.
+
+## Execution order
+
+1. Step 1 (tool definition) — add `type` field to `:session` tool
+2. Step 2 (ResponseProcessor) — extract `type` from export actions
+3. Steps 3-4 (Conversation + Workflows) — build typed value maps and validate
+4. Step 5 (Workflows) — update `list_sessions_with_exported_metadata`
+5. Step 6 (LiveView) — expand `format_metadata_value` for all types
+6. Step 7 (tool instructions) — document the `type` parameter
+7. Step 8 (tests) — verify type extraction, validation, persistence, and display
+8. Step 9 (precommit) — validate
+
+## Files modified
+
+- `lib/destila/ai/tools.ex` — add `type` field to `:session` tool
+- `lib/destila/ai/response_processor.ex` — extract `type` in `do_extract_export_actions`
+- `lib/destila/ai/conversation.ex` — build `%{type => value}` map, validate type
+- `lib/destila/workflows.ex` — validate exported metadata type, update `list_sessions_with_exported_metadata`, add `extract_metadata_text` helper
+- `lib/destila_web/live/workflow_runner_live.ex` — expand `format_metadata_value` for all four types
+- `lib/destila/workflows/brainstorm_idea_workflow.ex` — update `@tool_instructions`
+- `lib/destila/workflows/implement_general_prompt_workflow.ex` — update `@non_interactive_tool_instructions`
+- `test/destila/workflows_metadata_test.exs` — type validation tests
+- `test/destila/executions/engine_test.exs` — typed export integration tests
+- `test/destila/ai/response_processor_test.exs` — type extraction tests
+
+## Done when
+
+- The `:session` tool accepts an optional `type` field for export actions
+- `extract_export_actions/1` returns `%{key: ..., value: ..., type: ...}` maps
+- `conversation.ex` builds `%{type => value}` instead of hardcoded `%{"text" => value}`
+- Unknown types are rejected in both the export path and `upsert_metadata` (for exported metadata)
+- `list_sessions_with_exported_metadata/1` extracts values from any valid type key
+- `format_metadata_value/1` pattern-matches on all four type keys
+- Type defaults to `"text"` when omitted by the LLM
+- Existing `%{"text" => value}` data is fully backward-compatible
+- No database migration needed
+- All tests pass, `mix precommit` passes

--- a/docs/plans/2026-04-08-feat-typed-metadata-exports-plan.md
+++ b/docs/plans/2026-04-08-feat-typed-metadata-exports-plan.md
@@ -28,16 +28,22 @@ No database migration is needed — the existing `value` map column already supp
 - **Metadata listing** (`lib/destila/workflows.ex:183`): `list_sessions_with_exported_metadata/1` extracts `value["text"]` — only recognizes the `text` type.
 - **Metadata display** (`lib/destila_web/live/workflow_runner_live.ex:763-765`): `format_metadata_value/1` pattern-matches `%{"text" => text}`, falls back to JSON for other maps.
 - **Creation metadata** (`lib/destila/workflows.ex:119`): `create_workflow_session/1` stores creation metadata as `%{"text" => input_text}` — these are internal (not AI exports) and use the `text` type correctly.
+- **Workflow prompt reads** — three workflows read creation metadata via `get_in(metadata, ["key", "text"])`:
+  - `brainstorm_idea_workflow.ex:86` — `get_in(metadata, ["idea", "text"])`
+  - `implement_general_prompt_workflow.ex:120` — `get_in(metadata, ["prompt", "text"])`
+  - `code_chat_workflow.ex:52` — `get_in(metadata, ["user_prompt", "text"])`
+
+  These all read non-exported creation metadata which is always `%{"text" => value}`, so they do not need changes.
 
 ## Key design decisions
 
-### 1. Type validation uses a module attribute allowlist
+### 1. Single source of truth for valid types in `Destila.Workflows`
 
-Define `@valid_metadata_types ~w(text text_file markdown video_file)` in `Destila.Workflows`. Both the MCP tool path (via `conversation.ex`) and `upsert_metadata` validate against this list. Unknown types are rejected — not silently accepted.
+Define `@valid_metadata_types ~w(text text_file markdown video_file)` as a module attribute in `Destila.Workflows` alongside a public function `valid_metadata_types/0` that returns the list. `Conversation` calls `Workflows.valid_metadata_types()` rather than duplicating the allowlist. This ensures adding a new type only requires a one-line change.
 
-### 2. Validation in `upsert_metadata` is the single enforcement point
+### 2. Validation in `upsert_metadata` only applies to exported metadata
 
-Rather than scattering validation, `upsert_metadata` validates that the value map's key is one of the allowed types. This covers both the MCP export path and any internal callers. The MCP path additionally validates the `type` field *before* constructing the value map (to return a clear error), but `upsert_metadata` is the backstop.
+The existing `upsert_metadata/5` accepts arbitrary value maps for internal metadata (e.g., `%{"id" => session_id}` for source_session, `%{"status" => "done"}` for title_gen). Type validation only triggers when `exported: true` is passed — it enforces that the value map contains exactly one key that is a valid metadata type. Non-exported metadata passes through without type validation.
 
 ### 3. The `type` field defaults to `"text"` when omitted
 
@@ -45,13 +51,17 @@ For backward compatibility, when the LLM calls `export` without a `type` field, 
 
 ### 4. `list_sessions_with_exported_metadata/1` extracts value from any valid type key
 
-Instead of hardcoding `value["text"]`, it finds the first key in the value map that is a valid type and extracts the value from it. This makes the function work with any type.
+Instead of hardcoding `value["text"]`, it finds the first key in the value map that is a valid type and extracts the value from it. Since typed value maps have exactly one key, the order of iteration doesn't matter functionally — but trying `text` first optimizes for existing data.
 
 ### 5. The type is surfaced to the LiveView via the existing value map structure
 
 The `meta.value` map already reaches the template (passed to `metadata_value_block`). The type *is* the key of that map. No new assigns or computed fields are needed — `format_metadata_value/1` pattern-matches on the type key, and future rendering components can do the same.
 
-### 6. No Gherkin scenario changes
+### 6. Invalid types are silently filtered in the export path, validated in `upsert_metadata`
+
+In `conversation.ex`, the `for` comprehension's `type in valid_types` filter silently skips exports with invalid types — this is the right behavior for malformed LLM output (don't crash, just skip). In `upsert_metadata`, the validation returns `{:error, :invalid_metadata_type}` — this is the backstop for programmatic callers who should know better.
+
+### 7. No Gherkin scenario changes
 
 This is internal plumbing. The user-facing behavior (metadata appears in sidebar, updates in real-time) is unchanged. All four types render as plain text pass-through for now.
 
@@ -61,7 +71,7 @@ This is internal plumbing. The user-facing behavior (metadata appears in sidebar
 
 **File:** `lib/destila/ai/tools.ex`
 
-Add a `type` field to the `:session` tool, between `value` and the closing `end`:
+Add a `type` field to the `:session` tool, between the `value` field (line 63) and the closing `end`:
 
 ```elixir
 field(:type, :string,
@@ -77,7 +87,7 @@ The field is optional — when omitted, the system defaults to `"text"`.
 
 **File:** `lib/destila/ai/response_processor.ex`
 
-Update `do_extract_export_actions/1` (line 163) to include the type in the returned map:
+Update `do_extract_export_actions/1` at line 163 to include the type in the returned map:
 
 ```elixir
 # Before (line 163):
@@ -89,17 +99,89 @@ Update `do_extract_export_actions/1` (line 163) to include the type in the retur
 
 When the LLM omits `type`, `access(input, :type)` returns `nil` — the downstream code defaults it to `"text"`.
 
-### Step 3: Add type validation and build typed value map in `conversation.ex`
+Also update the `@doc` for `extract_export_actions/1` (line 117):
 
-**File:** `lib/destila/ai/conversation.ex`
+```elixir
+# Before:
+Returns a list of `%{key: key, value: value}` maps.
 
-**3a. Add a module attribute for valid types (top of module):**
+# After:
+Returns a list of `%{key: key, value: value, type: type}` maps. Type is `nil` when omitted.
+```
+
+### Step 3: Add valid types to `Destila.Workflows` and expose via public function
+
+**File:** `lib/destila/workflows.ex`
+
+Add near the top of the module (after `alias` statements):
 
 ```elixir
 @valid_metadata_types ~w(text text_file markdown video_file)
+
+@doc """
+Returns the list of valid metadata types for exported metadata values.
+"""
+def valid_metadata_types, do: @valid_metadata_types
 ```
 
-**3b. Update the export processing block (lines 87-95):**
+### Step 4: Add type validation in `upsert_metadata`
+
+**File:** `lib/destila/workflows.ex`
+
+Restructure `upsert_metadata/5` (lines 230-255) to validate exported metadata types. Since we're adding a head with a default value and a second clause, we need a function head:
+
+```elixir
+def upsert_metadata(workflow_session_id, phase_name, key, value, opts \\ [])
+
+def upsert_metadata(workflow_session_id, phase_name, key, value, opts) do
+  exported = Keyword.get(opts, :exported, false)
+
+  if exported and not valid_exported_value?(value) do
+    {:error, :invalid_metadata_type}
+  else
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    %SessionMetadata{}
+    |> SessionMetadata.changeset(%{
+      workflow_session_id: workflow_session_id,
+      phase_name: phase_name,
+      key: key,
+      value: value,
+      exported: exported
+    })
+    |> Repo.insert(
+      on_conflict: {:replace, [:value, :exported, :updated_at]},
+      conflict_target: [:workflow_session_id, :phase_name, :key],
+      set: [updated_at: now]
+    )
+    |> case do
+      {:ok, metadata} ->
+        Destila.PubSubHelper.broadcast_event(:metadata_updated, workflow_session_id)
+        {:ok, metadata}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+end
+
+defp valid_exported_value?(value) when is_map(value) do
+  case Map.keys(value) do
+    [type] -> type in @valid_metadata_types
+    _ -> false
+  end
+end
+
+defp valid_exported_value?(_), do: false
+```
+
+**Why only validate exported metadata**: Non-exported metadata uses arbitrary value maps like `%{"id" => session_id}` (source_session at line 122) and `%{"status" => "done"}` (historical title_gen). These are internal and don't represent typed content. The `exported: true` flag reliably distinguishes AI exports from internal metadata.
+
+### Step 5: Build typed value map in `conversation.ex`
+
+**File:** `lib/destila/ai/conversation.ex`
+
+Update the export processing block (lines 87-95):
 
 ```elixir
 # Before (lines 87-95):
@@ -114,10 +196,12 @@ for %{key: key, value: value} <- export_actions, key != nil do
 end
 
 # After:
+valid_types = Workflows.valid_metadata_types()
+
 for %{key: key, value: value, type: type} <- export_actions,
     key != nil,
     type = type || "text",
-    type in @valid_metadata_types do
+    type in valid_types do
   Workflows.upsert_metadata(
     ws.id,
     phase_name,
@@ -128,77 +212,20 @@ for %{key: key, value: value, type: type} <- export_actions,
 end
 ```
 
-Key details:
-- `type = type || "text"` defaults nil to `"text"` (rebinding in generator is valid)
-- `type in @valid_metadata_types` silently skips exports with invalid types (malformed LLM output is filtered, not crashed on)
-- `%{type => value}` builds the typed value map dynamically instead of hardcoding `"text"`
+**How the `for` generators work:**
 
-### Step 4: Add type validation in `upsert_metadata`
+- `%{key: key, value: value, type: type} <- export_actions` — destructures each export action
+- `key != nil` — filter: skips malformed exports with nil key
+- `type = type || "text"` — generator that rebinds `type`, defaulting `nil` to `"text"`. In Elixir `for` comprehensions, `=` in a generator always matches (it's a pattern match that can also rebind), so this never filters — it transforms.
+- `type in valid_types` — filter: silently skips exports with invalid types
 
-**File:** `lib/destila/workflows.ex`
+**Why filter instead of error**: The LLM may produce malformed output. Silently skipping invalid types is safer than crashing. The `upsert_metadata` validation (Step 4) is the backstop for programmatic callers.
 
-**4a. Add a module attribute for valid types (near the top, after imports):**
-
-```elixir
-@valid_metadata_types ~w(text text_file markdown video_file)
-```
-
-**4b. Add a validation guard at the top of `upsert_metadata/5` (line 230):**
-
-```elixir
-def upsert_metadata(workflow_session_id, phase_name, key, value, opts \\ [])
-
-def upsert_metadata(workflow_session_id, phase_name, key, value, opts)
-    when is_map(value) do
-  # Validate that the value map's key is a valid metadata type (if it looks like a typed value)
-  # Non-typed value maps (like %{"id" => ...} for source_session) pass through
-  value_keys = Map.keys(value)
-
-  if length(value_keys) == 1 and hd(value_keys) not in @valid_metadata_types ++ ["id"] do
-    {:error, :invalid_metadata_type}
-  else
-    exported = Keyword.get(opts, :exported, false)
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
-
-    # ... rest of existing implementation unchanged
-  end
-end
-```
-
-Wait — this approach is overly complex. The existing `upsert_metadata` already accepts arbitrary value maps (like `%{"id" => session_id}` for source_session metadata, and `%{"status" => "done"}` for internal metadata). Adding type validation here would require distinguishing "typed export values" from "arbitrary internal metadata maps."
-
-**Revised approach:** Only validate for exported metadata. When `exported: true` is passed, enforce that the value map contains exactly one key that is a valid metadata type. When `exported: false` (the default), pass through without type validation.
-
-```elixir
-def upsert_metadata(workflow_session_id, phase_name, key, value, opts \\ []) do
-  exported = Keyword.get(opts, :exported, false)
-
-  if exported and not valid_exported_value?(value) do
-    {:error, :invalid_metadata_type}
-  else
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
-
-    # ... existing insert logic unchanged
-  end
-end
-
-defp valid_exported_value?(value) when is_map(value) do
-  case Map.keys(value) do
-    [type] -> type in @valid_metadata_types
-    _ -> false
-  end
-end
-
-defp valid_exported_value?(_), do: false
-```
-
-This validates that exported metadata has exactly one key and it's a valid type. Non-exported metadata (creation metadata, internal state) is unaffected.
-
-### Step 5: Update `list_sessions_with_exported_metadata/1`
+### Step 6: Update `list_sessions_with_exported_metadata/1`
 
 **File:** `lib/destila/workflows.ex`
 
-Update line 183 to extract the value from any valid type key, not just `"text"`:
+Update line 183 to extract the value from any valid type key:
 
 ```elixir
 # Before (line 183):
@@ -208,10 +235,9 @@ Update line 183 to extract the value from any valid type key, not just `"text"`:
 |> Enum.map(fn {ws, value} -> {ws, extract_metadata_text(value)} end)
 ```
 
-**Add a helper function:**
+Add the helper after `list_sessions_with_exported_metadata/1`:
 
 ```elixir
-@doc false
 defp extract_metadata_text(value) when is_map(value) do
   Enum.find_value(@valid_metadata_types, fn type -> value[type] end)
 end
@@ -219,9 +245,9 @@ end
 defp extract_metadata_text(_), do: nil
 ```
 
-This tries each valid type key in order (`text` first, then `text_file`, `markdown`, `video_file`) and returns the first non-nil value. Since typed value maps have exactly one key, the order doesn't matter — but `text` being first means existing data is found on the first try.
+This iterates `@valid_metadata_types` in definition order (`text` first) and returns the first non-nil value. Since typed value maps have exactly one key, only one iteration will match.
 
-### Step 6: Update `format_metadata_value/1` in the LiveView
+### Step 7: Update `format_metadata_value/1` in the LiveView
 
 **File:** `lib/destila_web/live/workflow_runner_live.ex`
 
@@ -244,11 +270,11 @@ defp format_metadata_value(value), do: inspect(value)
 
 All four types render as plain text pass-through for now. Specialized rendering components (markdown rendering, file preview, video player) will be added later and will dispatch on the type key in `metadata_value_block/1`.
 
-### Step 7: Update `@tool_instructions` and `@non_interactive_tool_instructions`
+### Step 8: Update tool instructions in all three workflows
 
-**File:** `lib/destila/workflows/brainstorm_idea_workflow.ex`
+**8a. File:** `lib/destila/workflows/brainstorm_idea_workflow.ex`
 
-Update the "Exporting Data" section in `@tool_instructions` to document the `type` parameter:
+Update the "Exporting Data" section in `@tool_instructions` (line 48) to document the `type` parameter:
 
 ```elixir
 ## Exporting Data
@@ -262,20 +288,35 @@ interpreted: `text` (default), `text_file` (absolute path to a text file), \
 `markdown` (markdown content), or `video_file` (absolute path to a video file).
 ```
 
-**File:** `lib/destila/workflows/implement_general_prompt_workflow.ex`
+**8b. File:** `lib/destila/workflows/implement_general_prompt_workflow.ex`
 
-Apply the same update to `@non_interactive_tool_instructions`.
+Apply the same update to the "Exporting Data" section in `@non_interactive_tool_instructions` (line 36).
 
-### Step 8: Add tests
+**8c. File:** `lib/destila/workflows/code_chat_workflow.ex`
 
-**File:** `test/destila/workflows_metadata_test.exs`
-
-**8a. Add tests for type validation in `upsert_metadata`:**
+Update the inline export instructions at lines 82-83:
 
 ```elixir
-describe "upsert_metadata/5 type validation" do
-  test "accepts valid metadata types for exported metadata" do
-    ws = insert_workflow_session()
+# Before (lines 82-83):
+To store a key-value pair as session metadata, call `mcp__destila__session` with \
+`action: "export"`, a `key` string, and a `value` string.
+
+# After:
+To store a key-value pair as session metadata, call `mcp__destila__session` with \
+`action: "export"`, a `key` string, and a `value` string. You can optionally \
+specify a `type` string: `text` (default), `text_file`, `markdown`, or `video_file`.
+```
+
+### Step 9: Add tests
+
+**9a. File:** `test/destila/workflows_metadata_test.exs`
+
+Add a new `describe` block for type validation in `upsert_metadata`:
+
+```elixir
+describe "upsert_metadata/5 type validation for exported metadata" do
+  test "accepts all valid metadata types" do
+    ws = create_session()
 
     for type <- ~w(text text_file markdown video_file) do
       assert {:ok, _} =
@@ -287,17 +328,27 @@ describe "upsert_metadata/5 type validation" do
   end
 
   test "rejects invalid type for exported metadata" do
-    ws = insert_workflow_session()
+    ws = create_session()
 
     assert {:error, :invalid_metadata_type} =
              Workflows.upsert_metadata(
-               ws.id, "phase", "key", %{"invalid_type" => "value"},
+               ws.id, "phase", "key", %{"html" => "<p>bad</p>"},
+               exported: true
+             )
+  end
+
+  test "rejects multi-key value maps for exported metadata" do
+    ws = create_session()
+
+    assert {:error, :invalid_metadata_type} =
+             Workflows.upsert_metadata(
+               ws.id, "phase", "key", %{"text" => "a", "extra" => "b"},
                exported: true
              )
   end
 
   test "allows arbitrary value maps for non-exported metadata" do
-    ws = insert_workflow_session()
+    ws = create_session()
 
     assert {:ok, _} =
              Workflows.upsert_metadata(
@@ -307,132 +358,125 @@ describe "upsert_metadata/5 type validation" do
 end
 ```
 
-**8b. Add test for `list_sessions_with_exported_metadata` with non-text types:**
+**9b.** Add a test inside the existing `describe "list_sessions_with_exported_metadata/1"` block:
 
 ```elixir
 test "returns value for non-text metadata types" do
-  ws = insert_workflow_session(%{done_at: DateTime.utc_now()})
+  ws = create_session()
+  {:ok, _} = Workflows.update_workflow_session(ws, %{done_at: DateTime.utc_now()})
 
   Workflows.upsert_metadata(
-    ws.id, "phase", "my_export", %{"markdown" => "# Hello"},
+    ws.id, "phase", "my_doc", %{"markdown" => "# Hello"},
     exported: true
   )
 
-  result = Workflows.list_sessions_with_exported_metadata("my_export")
-  assert [{^ws_id, "# Hello"}] = [{elem(hd(result), 0).id, elem(hd(result), 1)}]
+  result = Workflows.list_sessions_with_exported_metadata("my_doc")
+  assert [{session, text}] = result
+  assert session.id == ws.id
+  assert text == "# Hello"
 end
 ```
 
-**File:** `test/destila/ai/response_processor_test.exs` (or relevant test file)
-
-**8c. Add test for type extraction in `extract_export_actions`:**
+**9c. File:** `test/destila/ai/response_processor_test.exs` (**new file** — no ResponseProcessor tests exist yet)
 
 ```elixir
-test "extracts type from export actions" do
-  result = %{
-    mcp_tool_uses: [
-      %{
-        name: "mcp__destila__session",
-        input: %{action: "export", key: "doc", value: "# Title", type: "markdown"}
-      }
-    ]
-  }
+defmodule Destila.AI.ResponseProcessorTest do
+  use ExUnit.Case, async: true
 
-  assert [%{key: "doc", value: "# Title", type: "markdown"}] =
-           ResponseProcessor.extract_export_actions(result)
-end
+  alias Destila.AI.ResponseProcessor
 
-test "type is nil when omitted" do
-  result = %{
-    mcp_tool_uses: [
-      %{
-        name: "mcp__destila__session",
-        input: %{action: "export", key: "doc", value: "plain text"}
-      }
-    ]
-  }
-
-  assert [%{key: "doc", value: "plain text", type: nil}] =
-           ResponseProcessor.extract_export_actions(result)
-end
-```
-
-**File:** `test/destila/executions/engine_test.exs`
-
-**8d. Add engine integration test for typed exports:**
-
-```elixir
-test "stores typed metadata from AI export action" do
-  ws = create_session_with_ai(%{pe_status: :processing})
-
-  Engine.phase_update(ws.id, 1, %{
-    ai_result: %{
-      text: "Here is markdown output",
-      result: "Here is markdown output",
-      mcp_tool_uses: [
-        %{
-          name: "mcp__destila__session",
-          input: %{
-            action: "export",
-            key: "plan_doc",
-            value: "# Plan\nDo the thing",
-            type: "markdown"
+  describe "extract_export_actions/1" do
+    test "extracts type from export actions (atom keys)" do
+      result = %{
+        mcp_tool_uses: [
+          %{
+            name: "mcp__destila__session",
+            input: %{action: "export", key: "doc", value: "# Title", type: "markdown"}
           }
-        }
-      ]
-    }
-  })
+        ]
+      }
 
-  all_metadata = Workflows.get_all_metadata(ws.id)
-  exported = Enum.find(all_metadata, &(&1.key == "plan_doc"))
-  assert exported != nil
-  assert exported.value == %{"markdown" => "# Plan\nDo the thing"}
-  assert exported.exported == true
-end
+      assert [%{key: "doc", value: "# Title", type: "markdown"}] =
+               ResponseProcessor.extract_export_actions(result)
+    end
 
-test "defaults to text type when type is omitted" do
-  ws = create_session_with_ai(%{pe_status: :processing})
+    test "extracts type from export actions (string keys)" do
+      result = %{
+        "mcp_tool_uses" => [
+          %{
+            "name" => "mcp__destila__session",
+            "input" => %{
+              "action" => "export",
+              "key" => "doc",
+              "value" => "# Title",
+              "type" => "markdown"
+            }
+          }
+        ]
+      }
 
-  Engine.phase_update(ws.id, 1, %{
-    ai_result: %{
-      text: "Output",
-      result: "Output",
-      mcp_tool_uses: [
-        %{
-          name: "mcp__destila__session",
-          input: %{action: "export", key: "result", value: "plain text"}
-        }
-      ]
-    }
-  })
+      assert [%{key: "doc", value: "# Title", type: "markdown"}] =
+               ResponseProcessor.extract_export_actions(result)
+    end
 
-  all_metadata = Workflows.get_all_metadata(ws.id)
-  exported = Enum.find(all_metadata, &(&1.key == "result"))
-  assert exported.value == %{"text" => "plain text"}
-end
+    test "type is nil when omitted" do
+      result = %{
+        mcp_tool_uses: [
+          %{
+            name: "mcp__destila__session",
+            input: %{action: "export", key: "doc", value: "plain text"}
+          }
+        ]
+      }
 
-test "skips export with invalid type" do
-  ws = create_session_with_ai(%{pe_status: :processing})
+      assert [%{key: "doc", value: "plain text", type: nil}] =
+               ResponseProcessor.extract_export_actions(result)
+    end
 
-  Engine.phase_update(ws.id, 1, %{
-    ai_result: %{
-      text: "Output",
-      result: "Output",
-      mcp_tool_uses: [
-        %{
-          name: "mcp__destila__session",
-          input: %{action: "export", key: "bad", value: "v", type: "html"}
-        }
-      ]
-    }
-  })
+    test "extracts multiple exports with different types" do
+      result = %{
+        mcp_tool_uses: [
+          %{
+            name: "mcp__destila__session",
+            input: %{action: "export", key: "summary", value: "text", type: "text"}
+          },
+          %{
+            name: "mcp__destila__session",
+            input: %{action: "export", key: "doc", value: "# MD", type: "markdown"}
+          }
+        ]
+      }
 
-  all_metadata = Workflows.get_all_metadata(ws.id)
-  assert all_metadata == []
+      exports = ResponseProcessor.extract_export_actions(result)
+      assert length(exports) == 2
+      assert Enum.at(exports, 0).type == "text"
+      assert Enum.at(exports, 1).type == "markdown"
+    end
+
+    test "ignores non-export session actions" do
+      result = %{
+        mcp_tool_uses: [
+          %{
+            name: "mcp__destila__session",
+            input: %{action: "phase_complete", message: "done"}
+          }
+        ]
+      }
+
+      assert [] = ResponseProcessor.extract_export_actions(result)
+    end
+  end
 end
 ```
 
-### Step 9: Run `mix precommit`
+**Note on integration tests**: There is no existing `engine_test.exs` — the `handle_ai_result/2` function is called from `SessionProcess` (a `gen_statem`) and is not directly tested in isolation. The typed export behavior is fully covered by:
+- Unit tests on `ResponseProcessor.extract_export_actions/1` (type extraction)
+- Unit tests on `Workflows.upsert_metadata/5` (type validation)
+- Unit tests on `Workflows.list_sessions_with_exported_metadata/1` (type-aware value extraction)
+
+The `for` comprehension logic in `conversation.ex` (defaulting nil → "text", filtering invalid types) is thin glue. If desired, a `Conversation` test can be added later, but it would require setting up an AI session and workflow session — heavyweight for testing three lines of `for` logic.
+
+### Step 10: Run `mix precommit`
 
 Verify compilation, formatting, and tests pass.
 
@@ -442,6 +486,7 @@ Verify compilation, formatting, and tests pass.
 - **Existing data**: All existing `%{"text" => value}` entries are automatically backward-compatible — `"text"` is a valid type.
 - **Creation metadata**: `create_workflow_session/1` (line 119) stores `%{"text" => input_text}` — this is the `text` type, already valid.
 - **Internal metadata**: Non-exported metadata like `%{"id" => session_id}` and `%{"status" => "done"}` are not validated (only exported metadata is type-checked).
+- **Workflow prompt reads**: `get_in(metadata, ["idea", "text"])`, `get_in(metadata, ["prompt", "text"])`, and `get_in(metadata, ["user_prompt", "text"])` all read non-exported creation metadata which is always `%{"text" => value}`. These do not change.
 - **Gherkin feature files**: No scenario changes. This is internal plumbing.
 - **Rendering**: All four types render as plain text for now. Specialized rendering components will be built separately.
 - **`metadata_value_block/1`**: The function component structure stays the same — it calls `format_metadata_value/1` which now handles all four types.
@@ -450,35 +495,38 @@ Verify compilation, formatting, and tests pass.
 
 1. Step 1 (tool definition) — add `type` field to `:session` tool
 2. Step 2 (ResponseProcessor) — extract `type` from export actions
-3. Steps 3-4 (Conversation + Workflows) — build typed value maps and validate
-4. Step 5 (Workflows) — update `list_sessions_with_exported_metadata`
-5. Step 6 (LiveView) — expand `format_metadata_value` for all types
-6. Step 7 (tool instructions) — document the `type` parameter
-7. Step 8 (tests) — verify type extraction, validation, persistence, and display
-8. Step 9 (precommit) — validate
+3. Steps 3-4 (Workflows) — add valid types list, validate in `upsert_metadata`
+4. Step 5 (Conversation) — build typed value maps using `Workflows.valid_metadata_types()`
+5. Step 6 (Workflows) — update `list_sessions_with_exported_metadata`
+6. Step 7 (LiveView) — expand `format_metadata_value` for all types
+7. Step 8 (tool instructions) — document `type` in all three workflows
+8. Step 9 (tests) — verify type extraction, validation, persistence, and display
+9. Step 10 (precommit) — validate
 
 ## Files modified
 
 - `lib/destila/ai/tools.ex` — add `type` field to `:session` tool
 - `lib/destila/ai/response_processor.ex` — extract `type` in `do_extract_export_actions`
-- `lib/destila/ai/conversation.ex` — build `%{type => value}` map, validate type
-- `lib/destila/workflows.ex` — validate exported metadata type, update `list_sessions_with_exported_metadata`, add `extract_metadata_text` helper
+- `lib/destila/workflows.ex` — add `@valid_metadata_types`, `valid_metadata_types/0`, `valid_exported_value?/1`, `extract_metadata_text/1`; validate in `upsert_metadata`; update `list_sessions_with_exported_metadata`
+- `lib/destila/ai/conversation.ex` — build `%{type => value}` map, filter invalid types
 - `lib/destila_web/live/workflow_runner_live.ex` — expand `format_metadata_value` for all four types
 - `lib/destila/workflows/brainstorm_idea_workflow.ex` — update `@tool_instructions`
 - `lib/destila/workflows/implement_general_prompt_workflow.ex` — update `@non_interactive_tool_instructions`
-- `test/destila/workflows_metadata_test.exs` — type validation tests
-- `test/destila/executions/engine_test.exs` — typed export integration tests
-- `test/destila/ai/response_processor_test.exs` — type extraction tests
+- `lib/destila/workflows/code_chat_workflow.ex` — update inline export instructions
+- `test/destila/workflows_metadata_test.exs` — type validation and typed listing tests
+- `test/destila/ai/response_processor_test.exs` — **new file**, type extraction tests
 
 ## Done when
 
 - The `:session` tool accepts an optional `type` field for export actions
 - `extract_export_actions/1` returns `%{key: ..., value: ..., type: ...}` maps
+- `Workflows.valid_metadata_types/0` is the single source of truth for allowed types
 - `conversation.ex` builds `%{type => value}` instead of hardcoded `%{"text" => value}`
-- Unknown types are rejected in both the export path and `upsert_metadata` (for exported metadata)
+- Unknown types are filtered in the export path and rejected in `upsert_metadata` (for exported metadata)
 - `list_sessions_with_exported_metadata/1` extracts values from any valid type key
 - `format_metadata_value/1` pattern-matches on all four type keys
 - Type defaults to `"text"` when omitted by the LLM
+- All three workflow tool instructions document the `type` parameter
 - Existing `%{"text" => value}` data is fully backward-compatible
 - No database migration needed
 - All tests pass, `mix precommit` passes

--- a/lib/destila/ai/conversation.ex
+++ b/lib/destila/ai/conversation.ex
@@ -84,12 +84,17 @@ defmodule Destila.AI.Conversation do
       phase_name =
         Workflows.phase_name(ws.workflow_type, phase_number) || "Phase #{phase_number}"
 
-      for %{key: key, value: value} <- export_actions, key != nil do
+      valid_types = Workflows.valid_metadata_types()
+
+      for %{key: key, value: value, type: type} <- export_actions,
+          key != nil,
+          type = type || "text",
+          type in valid_types do
         Workflows.upsert_metadata(
           ws.id,
           phase_name,
           key,
-          %{"text" => value},
+          %{type => value},
           exported: true
         )
       end

--- a/lib/destila/ai/response_processor.ex
+++ b/lib/destila/ai/response_processor.ex
@@ -114,7 +114,7 @@ defmodule Destila.AI.ResponseProcessor do
   @doc """
   Extracts all export actions from an AI result's MCP tool uses.
 
-  Returns a list of `%{key: key, value: value}` maps.
+  Returns a list of `%{key: key, value: value, type: type}` maps. Type is `nil` when omitted.
   """
   def extract_export_actions(%{mcp_tool_uses: tool_uses}) when is_list(tool_uses) do
     do_extract_export_actions(tool_uses)
@@ -160,7 +160,7 @@ defmodule Destila.AI.ResponseProcessor do
         input = access(tool, :input) || %{}
 
         if access(input, :action) == "export" do
-          [%{key: access(input, :key), value: access(input, :value)}]
+          [%{key: access(input, :key), value: access(input, :value), type: access(input, :type)}]
         else
           []
         end

--- a/lib/destila/ai/tools.ex
+++ b/lib/destila/ai/tools.ex
@@ -64,6 +64,12 @@ defmodule Destila.AI.Tools do
       description: "Metadata value for the export action. Required for export."
     )
 
+    field(:type, :string,
+      description:
+        "Type of the exported value. One of: text (default), text_file, markdown, video_file. " <>
+          "Determines how the value is interpreted and rendered."
+    )
+
     def execute(_params) do
       {:ok, "Action recorded."}
     end

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -9,6 +9,13 @@ defmodule Destila.Workflows do
   alias Destila.Repo
   alias Destila.Workflows.{Session, SessionMetadata}
 
+  @valid_metadata_types ~w(text text_file markdown video_file)
+
+  @doc """
+  Returns the list of valid metadata types for exported metadata values.
+  """
+  def valid_metadata_types, do: @valid_metadata_types
+
   @workflow_modules %{
     brainstorm_idea: Destila.Workflows.BrainstormIdeaWorkflow,
     implement_general_prompt: Destila.Workflows.ImplementGeneralPromptWorkflow,
@@ -180,9 +187,15 @@ defmodule Destila.Workflows do
       select: {ws, m.value}
     )
     |> Repo.all()
-    |> Enum.map(fn {ws, value} -> {ws, value["text"]} end)
+    |> Enum.map(fn {ws, value} -> {ws, extract_metadata_text(value)} end)
     |> Enum.reject(fn {_ws, text} -> is_nil(text) || text == "" end)
   end
+
+  defp extract_metadata_text(value) when is_map(value) do
+    Enum.find_value(@valid_metadata_types, fn type -> value[type] end)
+  end
+
+  defp extract_metadata_text(_), do: nil
 
   def count_by_project(project_id) do
     Repo.aggregate(
@@ -227,32 +240,48 @@ defmodule Destila.Workflows do
 
   # --- Metadata ---
 
-  def upsert_metadata(workflow_session_id, phase_name, key, value, opts \\ []) do
+  def upsert_metadata(workflow_session_id, phase_name, key, value, opts \\ [])
+
+  def upsert_metadata(workflow_session_id, phase_name, key, value, opts) do
     exported = Keyword.get(opts, :exported, false)
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-    %SessionMetadata{}
-    |> SessionMetadata.changeset(%{
-      workflow_session_id: workflow_session_id,
-      phase_name: phase_name,
-      key: key,
-      value: value,
-      exported: exported
-    })
-    |> Repo.insert(
-      on_conflict: {:replace, [:value, :exported, :updated_at]},
-      conflict_target: [:workflow_session_id, :phase_name, :key],
-      set: [updated_at: now]
-    )
-    |> case do
-      {:ok, metadata} ->
-        Destila.PubSubHelper.broadcast_event(:metadata_updated, workflow_session_id)
-        {:ok, metadata}
+    if exported and not valid_exported_value?(value) do
+      {:error, :invalid_metadata_type}
+    else
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-      {:error, changeset} ->
-        {:error, changeset}
+      %SessionMetadata{}
+      |> SessionMetadata.changeset(%{
+        workflow_session_id: workflow_session_id,
+        phase_name: phase_name,
+        key: key,
+        value: value,
+        exported: exported
+      })
+      |> Repo.insert(
+        on_conflict: {:replace, [:value, :exported, :updated_at]},
+        conflict_target: [:workflow_session_id, :phase_name, :key],
+        set: [updated_at: now]
+      )
+      |> case do
+        {:ok, metadata} ->
+          Destila.PubSubHelper.broadcast_event(:metadata_updated, workflow_session_id)
+          {:ok, metadata}
+
+        {:error, changeset} ->
+          {:error, changeset}
+      end
     end
   end
+
+  defp valid_exported_value?(value) when is_map(value) do
+    case Map.keys(value) do
+      [type] -> type in @valid_metadata_types
+      _ -> false
+    end
+  end
+
+  defp valid_exported_value?(_), do: false
 
   def get_metadata(workflow_session_id) do
     workflow_session_id

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -191,11 +191,9 @@ defmodule Destila.Workflows do
     |> Enum.reject(fn {_ws, text} -> is_nil(text) || text == "" end)
   end
 
-  defp extract_metadata_text(value) when is_map(value) do
+  defp extract_metadata_text(value) do
     Enum.find_value(@valid_metadata_types, fn type -> value[type] end)
   end
-
-  defp extract_metadata_text(_), do: nil
 
   def count_by_project(project_id) do
     Repo.aggregate(
@@ -274,14 +272,12 @@ defmodule Destila.Workflows do
     end
   end
 
-  defp valid_exported_value?(value) when is_map(value) do
+  defp valid_exported_value?(value) do
     case Map.keys(value) do
       [type] -> type in @valid_metadata_types
       _ -> false
     end
   end
-
-  defp valid_exported_value?(_), do: false
 
   def get_metadata(workflow_session_id) do
     workflow_session_id

--- a/lib/destila/workflows/brainstorm_idea_workflow.ex
+++ b/lib/destila/workflows/brainstorm_idea_workflow.ex
@@ -208,7 +208,8 @@ defmodule Destila.Workflows.BrainstormIdeaWorkflow do
     or "Let me know if you'd like changes." Just the prompt content, nothing else.
 
     After outputting the prompt, call `mcp__destila__session` with `action: "export"`, \
-    `key: "prompt_generated"`, and `value` set to the full prompt text you just generated.
+    `key: "prompt_generated"`, `type: "markdown"`, and `value` set to the full prompt text \
+    you just generated.
 
     The user may ask you to refine it. Each time you output a revised prompt, export it again \
     with the same key to update the stored value.

--- a/lib/destila/workflows/brainstorm_idea_workflow.ex
+++ b/lib/destila/workflows/brainstorm_idea_workflow.ex
@@ -207,12 +207,13 @@ defmodule Destila.Workflows.BrainstormIdeaWorkflow do
     or commentary around it. Do not wrap it in a code block. Do not say "Here is the prompt:" \
     or "Let me know if you'd like changes." Just the prompt content, nothing else.
 
-    After outputting the prompt, call `mcp__destila__session` with `action: "export"`, \
-    `key: "prompt_generated"`, `type: "markdown"`, and `value` set to the full prompt text \
-    you just generated.
+    After outputting the prompt, export it by calling `mcp__destila__session` with these \
+    exact parameters: `action: "export"`, `key: "prompt_generated"`, `type: "markdown"`, \
+    and `value` set to the full prompt text. You MUST set `type` to `"markdown"` — never \
+    use `"text"`.
 
-    The user may ask you to refine it. Each time you output a revised prompt, export it again \
-    with the same key to update the stored value.
+    The user may ask you to refine it. Each time you output a revised prompt, export it \
+    again with the same key and `type: "markdown"` to update the stored value.
 
     Do NOT call the `mcp__destila__session` tool with `suggest_phase_complete` or \
     `phase_complete` — the user will mark this phase as done manually.

--- a/lib/destila/workflows/brainstorm_idea_workflow.ex
+++ b/lib/destila/workflows/brainstorm_idea_workflow.ex
@@ -79,6 +79,10 @@ defmodule Destila.Workflows.BrainstormIdeaWorkflow do
   To store a key-value pair as session metadata, call `mcp__destila__session` with \
   `action: "export"`, a `key` string, and a `value` string. You may call export \
   multiple times in a single response and may combine it with a phase transition action.
+
+  You can optionally specify a `type` string to indicate how the value should be \
+  interpreted: `text` (default), `text_file` (absolute path to a text file), \
+  `markdown` (markdown content), or `video_file` (absolute path to a video file).
   """
 
   defp task_description_prompt(workflow_session) do

--- a/lib/destila/workflows/code_chat_workflow.ex
+++ b/lib/destila/workflows/code_chat_workflow.ex
@@ -80,7 +80,8 @@ defmodule Destila.Workflows.CodeChatWorkflow do
     For open-ended questions without clear options, just ask in plain text.
 
     To store a key-value pair as session metadata, call `mcp__destila__session` with \
-    `action: "export"`, a `key` string, and a `value` string.
+    `action: "export"`, a `key` string, and a `value` string. You can optionally \
+    specify a `type` string: `text` (default), `text_file`, `markdown`, or `video_file`.
 
     IMPORTANT: Never call `mcp__destila__session` with `suggest_phase_complete` or \
     `phase_complete`. The user controls when this session ends via the UI.

--- a/lib/destila/workflows/implement_general_prompt_workflow.ex
+++ b/lib/destila/workflows/implement_general_prompt_workflow.ex
@@ -48,6 +48,10 @@ defmodule Destila.Workflows.ImplementGeneralPromptWorkflow do
   To store a key-value pair as session metadata, call `mcp__destila__session` with \
   `action: "export"`, a `key` string, and a `value` string. You may call export \
   multiple times in a single response and may combine it with a phase transition action.
+
+  You can optionally specify a `type` string to indicate how the value should be \
+  interpreted: `text` (default), `text_file` (absolute path to a text file), \
+  `markdown` (markdown content), or `video_file` (absolute path to a video file).
   """
 
   def phases do

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -761,6 +761,9 @@ defmodule DestilaWeb.WorkflowRunnerLive do
   end
 
   defp format_metadata_value(%{"text" => text}) when is_binary(text), do: text
+  defp format_metadata_value(%{"markdown" => md}) when is_binary(md), do: md
+  defp format_metadata_value(%{"text_file" => path}) when is_binary(path), do: path
+  defp format_metadata_value(%{"video_file" => path}) when is_binary(path), do: path
   defp format_metadata_value(value) when is_map(value), do: Jason.encode!(value, pretty: true)
   defp format_metadata_value(value), do: inspect(value)
 

--- a/test/destila/ai/response_processor_test.exs
+++ b/test/destila/ai/response_processor_test.exs
@@ -1,0 +1,87 @@
+defmodule Destila.AI.ResponseProcessorTest do
+  use ExUnit.Case, async: true
+
+  alias Destila.AI.ResponseProcessor
+
+  describe "extract_export_actions/1" do
+    test "extracts type from export actions (atom keys)" do
+      result = %{
+        mcp_tool_uses: [
+          %{
+            name: "mcp__destila__session",
+            input: %{action: "export", key: "doc", value: "# Title", type: "markdown"}
+          }
+        ]
+      }
+
+      assert [%{key: "doc", value: "# Title", type: "markdown"}] =
+               ResponseProcessor.extract_export_actions(result)
+    end
+
+    test "extracts type from export actions (string keys)" do
+      result = %{
+        "mcp_tool_uses" => [
+          %{
+            "name" => "mcp__destila__session",
+            "input" => %{
+              "action" => "export",
+              "key" => "doc",
+              "value" => "# Title",
+              "type" => "markdown"
+            }
+          }
+        ]
+      }
+
+      assert [%{key: "doc", value: "# Title", type: "markdown"}] =
+               ResponseProcessor.extract_export_actions(result)
+    end
+
+    test "type is nil when omitted" do
+      result = %{
+        mcp_tool_uses: [
+          %{
+            name: "mcp__destila__session",
+            input: %{action: "export", key: "doc", value: "plain text"}
+          }
+        ]
+      }
+
+      assert [%{key: "doc", value: "plain text", type: nil}] =
+               ResponseProcessor.extract_export_actions(result)
+    end
+
+    test "extracts multiple exports with different types" do
+      result = %{
+        mcp_tool_uses: [
+          %{
+            name: "mcp__destila__session",
+            input: %{action: "export", key: "summary", value: "text", type: "text"}
+          },
+          %{
+            name: "mcp__destila__session",
+            input: %{action: "export", key: "doc", value: "# MD", type: "markdown"}
+          }
+        ]
+      }
+
+      exports = ResponseProcessor.extract_export_actions(result)
+      assert length(exports) == 2
+      assert Enum.at(exports, 0).type == "text"
+      assert Enum.at(exports, 1).type == "markdown"
+    end
+
+    test "ignores non-export session actions" do
+      result = %{
+        mcp_tool_uses: [
+          %{
+            name: "mcp__destila__session",
+            input: %{action: "phase_complete", message: "done"}
+          }
+        ]
+      }
+
+      assert [] = ResponseProcessor.extract_export_actions(result)
+    end
+  end
+end

--- a/test/destila/workflows_metadata_test.exs
+++ b/test/destila/workflows_metadata_test.exs
@@ -170,18 +170,73 @@ defmodule Destila.WorkflowsMetadataTest do
       ws = create_session()
 
       {:ok, _} =
-        Workflows.upsert_metadata(ws.id, "z_phase", "alpha", %{"v" => "1"}, exported: true)
+        Workflows.upsert_metadata(ws.id, "z_phase", "alpha", %{"text" => "1"}, exported: true)
 
       {:ok, _} =
-        Workflows.upsert_metadata(ws.id, "a_phase", "beta", %{"v" => "2"}, exported: true)
+        Workflows.upsert_metadata(ws.id, "a_phase", "beta", %{"text" => "2"}, exported: true)
 
       {:ok, _} =
-        Workflows.upsert_metadata(ws.id, "a_phase", "alpha", %{"v" => "3"}, exported: true)
+        Workflows.upsert_metadata(ws.id, "a_phase", "alpha", %{"text" => "3"}, exported: true)
 
       exported = Workflows.get_exported_metadata(ws.id)
       assert length(exported) == 3
       assert Enum.map(exported, & &1.phase_name) == ["a_phase", "a_phase", "z_phase"]
       assert Enum.map(exported, & &1.key) == ["alpha", "beta", "alpha"]
+    end
+  end
+
+  describe "upsert_metadata/5 type validation for exported metadata" do
+    test "accepts all valid metadata types" do
+      ws = create_session()
+
+      for type <- ~w(text text_file markdown video_file) do
+        assert {:ok, _} =
+                 Workflows.upsert_metadata(
+                   ws.id,
+                   "phase",
+                   "key_#{type}",
+                   %{type => "value"},
+                   exported: true
+                 )
+      end
+    end
+
+    test "rejects invalid type for exported metadata" do
+      ws = create_session()
+
+      assert {:error, :invalid_metadata_type} =
+               Workflows.upsert_metadata(
+                 ws.id,
+                 "phase",
+                 "key",
+                 %{"html" => "<p>bad</p>"},
+                 exported: true
+               )
+    end
+
+    test "rejects multi-key value maps for exported metadata" do
+      ws = create_session()
+
+      assert {:error, :invalid_metadata_type} =
+               Workflows.upsert_metadata(
+                 ws.id,
+                 "phase",
+                 "key",
+                 %{"text" => "a", "extra" => "b"},
+                 exported: true
+               )
+    end
+
+    test "allows arbitrary value maps for non-exported metadata" do
+      ws = create_session()
+
+      assert {:ok, _} =
+               Workflows.upsert_metadata(
+                 ws.id,
+                 "creation",
+                 "source_session",
+                 %{"id" => "some-uuid"}
+               )
     end
   end
 
@@ -276,6 +331,24 @@ defmodule Destila.WorkflowsMetadataTest do
 
       assert Workflows.list_sessions_with_exported_metadata("prompt_generated") != []
       assert Workflows.list_sessions_with_exported_metadata("other_key") == []
+    end
+
+    test "returns value for non-text metadata types" do
+      ws = create_session()
+      {:ok, _} = Workflows.update_workflow_session(ws, %{done_at: DateTime.utc_now()})
+
+      Workflows.upsert_metadata(
+        ws.id,
+        "phase",
+        "my_doc",
+        %{"markdown" => "# Hello"},
+        exported: true
+      )
+
+      result = Workflows.list_sessions_with_exported_metadata("my_doc")
+      assert [{session, text}] = result
+      assert session.id == ws.id
+      assert text == "# Hello"
     end
   end
 


### PR DESCRIPTION
## Summary

- Added optional `type` field to the `:session` MCP tool's `export` action, supporting four types: `text` (default), `text_file`, `markdown`, and `video_file`
- Type is encoded as the key of the value map (e.g., `%{"markdown" => "# Title"}`) — no database migration needed
- `Workflows.valid_metadata_types/0` is the single source of truth for allowed types
- Invalid types are silently filtered in the export path and rejected with `{:error, :invalid_metadata_type}` in `upsert_metadata/5`
- `list_sessions_with_exported_metadata/1` now extracts values from any valid type key, not just `"text"`
- All three workflow tool instructions updated to document the `type` parameter
- All four types render as plain text pass-through for now — specialized rendering (markdown, file preview, video player) will be added separately

## Test plan

- [x] ResponseProcessor: type extraction with atom keys, string keys, nil type, multiple exports, non-export filtering (5 tests)
- [x] Workflows: accepts valid types, rejects invalid types, rejects multi-key maps, allows arbitrary non-exported metadata (4 tests)
- [x] Workflows: `list_sessions_with_exported_metadata` returns values for non-text types (1 test)
- [x] Pre-existing metadata tests continue to pass (20 tests)
- [x] Full suite: 232 tests, 2 pre-existing failures unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)