### PR TITLE
Add no-defensive-code guidance to workflow system prompts

### DIFF
--- a/lib/destila/workflows/brainstorm_idea_workflow.ex
+++ b/lib/destila/workflows/brainstorm_idea_workflow.ex
@@ -199,6 +199,12 @@ defmodule Destila.Workflows.BrainstormIdeaWorkflow do
     - File-by-file change lists
     - Time estimates
 
+    The prompt MUST include a code quality instruction telling the implementer: \
+    do not write unnecessary defensive code — no redundant nil checks, fallback \
+    values, error handling, or validation for scenarios that cannot happen. Trust \
+    internal code and framework guarantees. Only validate at system boundaries. \
+    Keep code simple and direct.
+
     IMPORTANT: Output ONLY the prompt itself — no introductory text, headers, footers, \
     or commentary around it. Do not wrap it in a code block. Do not say "Here is the prompt:" \
     or "Let me know if you'd like changes." Just the prompt content, nothing else.

--- a/lib/destila/workflows/code_chat_workflow.ex
+++ b/lib/destila/workflows/code_chat_workflow.ex
@@ -71,6 +71,11 @@ defmodule Destila.Workflows.CodeChatWorkflow do
     - Use tools proactively when they would help answer the user's question
     - When making changes, explain what you did and why
     - Ask clarifying questions when the request is ambiguous
+    - Write simple, direct code. Do NOT add unnecessary defensive code — no \
+    redundant nil checks, fallback values, error handling, or validation for \
+    scenarios that cannot happen. Trust internal code and framework guarantees. \
+    Only validate at system boundaries (user input, external APIs). Do not add \
+    features or "improvements" beyond what was asked
 
     When asking questions with clear, discrete options, use the \
     `mcp__destila__ask_user_question` tool to present structured choices. \

--- a/lib/destila/workflows/implement_general_prompt_workflow.ex
+++ b/lib/destila/workflows/implement_general_prompt_workflow.ex
@@ -177,6 +177,16 @@ defmodule Destila.Workflows.ImplementGeneralPromptWorkflow do
     3. Ensure the code compiles and basic tests pass
     4. Commit all changes: `git add . && git commit -m "Implement plan"`
     5. Push to the remote: `git push`
+
+    ## Code Quality
+
+    Write code that is simple, direct, and minimal. Do NOT write unnecessary \
+    defensive code — no redundant nil checks, fallback values, error handling, \
+    or validation for scenarios that cannot happen. Trust internal code and \
+    framework guarantees. Only validate at system boundaries (user input, \
+    external APIs). Three simple lines are better than a premature abstraction. \
+    Do not add features, configurability, or "improvements" beyond what the \
+    plan specifies.
     """ <> @non_interactive_tool_instructions
   end
 
@@ -188,7 +198,10 @@ defmodule Destila.Workflows.ImplementGeneralPromptWorkflow do
     Steps:
     1. Read the plan and understand the requirements
     2. Review all changed files for correctness, quality, and completeness
-    3. Identify P1 (critical) and P2 (important) issues
+    3. Identify P1 (critical) and P2 (important) issues — unnecessary defensive \
+    code counts as P2 (remove redundant nil checks, fallback values, error \
+    handling for impossible scenarios, and validation that duplicates framework \
+    guarantees)
     4. Fix all P1 and P2 items
     5. Commit fixes: `git add . && git commit -m "Fix review issues"`
     6. Push to the remote: `git push`
@@ -244,6 +257,11 @@ defmodule Destila.Workflows.ImplementGeneralPromptWorkflow do
     Then wait for the user. They may ask you to make changes to the code, \
     fix issues, or adjust the implementation. Apply any requested changes, \
     commit, and push. The PR will update automatically.
+
+    When writing or modifying code, keep it simple and direct. Do NOT add \
+    unnecessary defensive code — no redundant nil checks, fallback values, \
+    error handling, or validation for scenarios that cannot happen. Only \
+    validate at system boundaries.
 
     The user will mark this phase as done when they are satisfied.
 


### PR DESCRIPTION
## Summary
- Adds explicit instructions to code-generating workflow system prompts to avoid unnecessary defensive code (redundant nil checks, fallback values, error handling for impossible scenarios)
- Applied to **ImplementGeneralPromptWorkflow** (work, review, and adjustments phases), **CodeChatWorkflow** (chat prompt), and **BrainstormIdeaWorkflow** (prompt generation phase)
- The review phase now treats unnecessary defensive code as a P2 issue to be removed

## Test plan
- [ ] Run a Code Chat session and verify the LLM avoids defensive code patterns
- [ ] Run a Brainstorm Idea session through to Prompt Generation and verify the generated prompt includes the no-defensive-code instruction
- [ ] Run an Implement General Prompt session and verify the work phase produces clean, non-defensive code

🤖 Generated with [Claude Code](https://claude.com/claude-code)