### PR TITLE
Change primary color from purple-blue to magenta

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -54,8 +54,8 @@
   --color-base-200: oklch(15% 0.008 260);
   --color-base-300: oklch(30% 0.015 260);
   --color-base-content: oklch(93% 0.005 260);
-  --color-primary: oklch(55% 0.2 265);
-  --color-primary-content: oklch(98% 0.01 265);
+  --color-primary: oklch(55% 0.2 330);
+  --color-primary-content: oklch(98% 0.01 330);
   --color-secondary: oklch(60% 0.15 290);
   --color-secondary-content: oklch(98% 0.01 290);
   --color-accent: oklch(70% 0.17 250);
@@ -90,8 +90,8 @@
   --color-base-200: oklch(97% 0.003 260);
   --color-base-300: oklch(93% 0.005 260);
   --color-base-content: oklch(25% 0.01 260);
-  --color-primary: oklch(55% 0.2 265);
-  --color-primary-content: oklch(98% 0.01 265);
+  --color-primary: oklch(55% 0.2 330);
+  --color-primary-content: oklch(98% 0.01 330);
   --color-secondary: oklch(55% 0.15 290);
   --color-secondary-content: oklch(98% 0.01 290);
   --color-accent: oklch(25% 0.01 260);
@@ -212,7 +212,7 @@ a, button, .card, .btn, input {
   border-color: oklch(0% 0 0 / 0.1);
 }
 .prose a {
-  color: oklch(55% 0.2 265);
+  color: oklch(55% 0.2 330);
   text-decoration: underline;
 }
 

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,35 @@
+# Plan: Change primary color from purple-blue to magenta
+
+## Summary
+
+Update the OKLCH hue value from `265` (purple-blue) to `330` (magenta) in three locations within `assets/css/app.css`. Lightness and chroma values remain unchanged.
+
+## File: `assets/css/app.css`
+
+### Step 1: Update dark theme primary color (lines 57-58)
+
+Change the `--color-primary` and `--color-primary-content` custom properties inside the dark theme daisyUI plugin block:
+
+- Line 57: `--color-primary: oklch(55% 0.2 265);` → `--color-primary: oklch(55% 0.2 330);`
+- Line 58: `--color-primary-content: oklch(98% 0.01 265);` → `--color-primary-content: oklch(98% 0.01 330);`
+
+### Step 2: Update light theme primary color (lines 93-94)
+
+Change the `--color-primary` and `--color-primary-content` custom properties inside the light theme daisyUI plugin block:
+
+- Line 93: `--color-primary: oklch(55% 0.2 265);` → `--color-primary: oklch(55% 0.2 330);`
+- Line 94: `--color-primary-content: oklch(98% 0.01 265);` → `--color-primary-content: oklch(98% 0.01 330);`
+
+### Step 3: Update prose link color (line 215)
+
+Change the hardcoded color on `.prose a`:
+
+- Line 215: `color: oklch(55% 0.2 265);` → `color: oklch(55% 0.2 330);`
+
+## Constraints
+
+- Only `assets/css/app.css` is modified
+- No Gherkin scenarios are affected (visual-only change)
+- Both light and dark themes are updated consistently
+- No other color properties (secondary, accent, neutral, etc.) change
+- The secondary color (hue 290) remains unchanged despite being adjacent in the color wheel


### PR DESCRIPTION
## Summary

- Update the OKLCH hue value from `265` (purple-blue) to `330` (magenta) for the primary color across dark theme, light theme, and prose link styles in `assets/css/app.css`
- Both themes updated consistently; no other color properties changed

## Changes

5 OKLCH hue values updated in `assets/css/app.css`:
- Dark theme `--color-primary` and `--color-primary-content` (lines 57-58)
- Light theme `--color-primary` and `--color-primary-content` (lines 93-94)
- `.prose a` link color (line 215)

🤖 Generated with [Claude Code](https://claude.com/claude-code)