### PR TITLE
feat: Add project service management with MCP tool

### DIFF
--- a/docs/plans/2026-04-14-001-feat-project-service-management-plan.md
+++ b/docs/plans/2026-04-14-001-feat-project-service-management-plan.md
@@ -1,0 +1,433 @@
+---
+title: "feat: Add project service management with MCP tool"
+type: feat
+status: completed
+date: 2026-04-14
+deepened: 2026-04-14
+---
+
+# feat: Add project service management with MCP tool
+
+## Overview
+
+Add the ability for projects to define a run command and port environment variables. During workflow sessions, the AI agent manages the service lifecycle (start/stop/restart/status) via a new `service` MCP tool. The service runs inside the workflow's existing tmux session, with dynamically assigned ports exposed as environment variables.
+
+## Problem Frame
+
+Workflow sessions operate on projects that often need a running development server (e.g., `mix phx.server`, `npm run dev`). Currently, the AI agent has no way to start, stop, or check the status of a project's service. Users must manually manage this outside of the workflow, which breaks the autonomous workflow loop. Adding service management as a first-class MCP tool lets the AI agent control the project's dev server lifecycle within the tmux session that already exists for terminal access.
+
+## Requirements Trace
+
+- R1. Projects can optionally define a run command (shell string) and port definitions (list of env var names)
+- R2. Project management UI (dedicated page + inline wizard form) supports creating/editing run command and port definitions with dynamic add/remove
+- R3. A `service` MCP tool with `start`, `stop`, `restart`, `status` actions manages the service lifecycle
+- R4. Service state (status, PID, port mappings) is persisted in a `service_state` JSON column on `workflow_sessions`
+- R5. Service state and port assignments are included in the AI's session context (system prompt)
+- R6. Ports are dynamically assigned from available OS ports at start time
+- R7. Service runs in a tmux window named "service" inside the session's tmux session
+- R8. Session archival stops the service and cleans up the tmux window
+- R9. Port definition env var names are validated: must start with an uppercase letter (A-Z) and contain only uppercase letters, digits (0-9), and underscores
+- R10. Gherkin scenarios for project_management.feature and project_inline_creation.feature are updated
+
+## Scope Boundaries
+
+- No service management Gherkin feature file (AI-agent behavior, not user-facing)
+- No cleanup when a session is merely marked as done (only on archive)
+- No default port values; all ports are dynamically assigned at runtime
+- No UI for service management; it is entirely AI-driven via the MCP tool
+- No persistent port reservation; ports are reserved only on `start`
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `lib/destila/projects/project.ex` -- Project schema with `name`, `git_repo_url`, `local_folder` fields, `changeset/2` with custom validators
+- `lib/destila/projects.ex` -- Project context with CRUD + PubSub broadcasting on `"store:updates"`
+- `lib/destila/ai/tools.ex` -- MCP tool definitions using `tool :name, "desc" do ... end` macro, `@tool_details` module attrs for prompt injection, `@tool_descriptions` map
+- `lib/destila/ai/claude_session.ex:11` -- `@default_allowed_tools` list that controls available tools
+- `lib/destila/ai/conversation.ex:20-65` -- `phase_start/1` assembles system prompt from tool descriptions + skills + phase prompt
+- `lib/destila/ai/response_processor.ex` -- Extracts session actions and export actions from MCP tool uses; pattern to follow for extracting service actions
+- `lib/destila/workflows/session.ex` -- Session schema; target for `service_state` column
+- `lib/destila/workflows.ex:206-213` -- `archive_workflow_session/1` stops ClaudeSession; needs service cleanup
+- `lib/destila/terminal/server.ex` -- Tmux session creation pattern with `build_tmux_command/1`, uses `ExPTY` and `escape_shell/1`
+- `lib/destila_web/live/projects_live.ex` -- Projects page with inline create/edit forms, `validate_project_params/1` manual validation, streams
+- `lib/destila_web/components/project_components.ex` -- `project_selector/1` component for inline creation in wizard
+- `features/project_management.feature` -- Current Gherkin scenarios
+- `features/project_inline_creation.feature` -- Current inline creation scenarios
+- `test/destila_web/live/projects_live_test.exs` -- Test file with `@tag feature:, scenario:` pattern
+- `test/destila_web/live/project_inline_creation_live_test.exs` -- Inline creation tests
+
+### Institutional Learnings
+
+- The DB is SQLite and can be freely reset; no backward compatibility needed for migrations
+- All schemas use `binary_id` primary keys with `@foreign_key_type :binary_id`
+- Race condition avoidance: the metadata table pattern uses composite unique keys + upsert; `service_state` on the session itself avoids this since only one tool call writes at a time
+- `DynamicSupervisor` + `Registry` naming pattern is established for per-session processes
+- PubSub + `Process.monitor/1` is the established health-checking pattern (no polling)
+- Tool execution in `tools.ex` returns `{:ok, "..."}` immediately; actual side effects happen in `ResponseProcessor`/worker after the tool use is extracted from the AI response
+
+## Key Technical Decisions
+
+- **`service_state` as a JSON column on `workflow_sessions`**: Simpler than a separate table since there's exactly one service state per session. No concurrent write risk since only one AI tool call processes at a time per session. Rationale: follows the principle of least complexity for a 1:1 relationship.
+
+- **`port_definitions` as a `{:array, :string}` on `projects`**: A simple list of env var name strings stored as a JSON array in SQLite. No need for a join table since these are just string labels with no additional attributes.
+
+- **Service tool processes actions in the worker, not in `execute/1`**: The existing MCP tools (`session`, `ask_user_question`) return immediately from `execute/1` with a confirmation string. The actual side effects are processed by `ResponseProcessor` and the worker. However, the `service` tool is different: it needs to perform real side effects (port reservation, tmux commands, process management) and return actual results (port mappings, PID, status). The service tool's `execute/1` will need access to the workflow session context. This means the tool execution needs to be intercepted in the response processing pipeline, similar to how `session` actions are extracted. The `ResponseProcessor` will extract `service` tool calls, and the worker will execute the service actions and include the results in the response.
+
+  **Revised approach**: The service tool's actions must execute *before* the AI sees the tool result, so port mappings and status are returned in the same conversational turn. The `AiQueryWorker` already collects the streaming response and extracts MCP tool uses. After collecting the response but before passing it to `SessionProcess`, the worker should detect `service` tool calls, execute them via `ServiceManager`, and inject the real result into the tool result text that Claude sees. This way the AI gets `{"status": "running", "ports": {"PORT": 54321}}` instead of a placeholder. A new `Destila.Services.ServiceManager` module handles port reservation, tmux commands, and state persistence.
+
+- **Port reservation via `:gen_tcp.listen/2` with port 0**: Erlang's `:gen_tcp.listen(0, ...)` asks the OS for an available port, then immediately close the socket to release it. This is the standard Erlang idiom. There's a small TOCTOU window, but it's acceptable for dev tooling.
+
+- **Tmux window management**: Create a tmux window named "service" inside the session's existing tmux session. The tmux session name must be derived using the same logic as `Terminal.Server` (which uses a configurable `session_name` opt, not `ws.title` directly). If the tmux session doesn't exist yet (terminal hasn't been opened), create it with a "shell" window first (matching the terminal convention), then add the "service" window. Use `tmux send-keys` to run the command with env vars set inline. Service lifecycle is managed via tmux window commands (`tmux kill-window`, `tmux send-keys C-c`) rather than raw PID tracking, to avoid PID reuse risks.
+
+- **PID liveness checking**: Use `System.cmd("kill", ["-0", to_string(pid)])` to check process liveness (macOS does not have `/proc`). The `status` action always checks PID liveness and corrects stale "running" state.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where does service_state context go in the AI prompt?**: Injected by the workflow's `system_prompt` function, which already receives the full `ws` struct. Each workflow's prompt function can read `ws.service_state` and include port/status info when non-nil.
+
+- **Which phases get the service tool?**: All phases that have `system_prompt` (AI-driven phases). The `service` tool is added to `@default_allowed_tools` in `claude_session.ex` so it's available in every AI session, just like `session` and `ask_user_question`. Its description is always injected.
+
+- **How to handle the service tool's response data**: The `service` tool needs to return actual port mappings and status to the AI. Since `execute/1` runs without session context, the tool's result text will be a placeholder. The actual service action is processed after response collection (like `session` actions), and the result is stored in `service_state`. The AI reads service state from the next prompt's context, or the tool result can be enriched in the worker before being sent back.
+
+  **Resolution**: The `AiQueryWorker` intercepts `service` tool calls after collecting the AI response but before passing it to `SessionProcess`. It calls `ServiceManager` to execute the action, then replaces the placeholder tool result text with the actual result (port mappings, status, or error). The results are also persisted to `ws.service_state`. This way the AI receives real service data in the same conversational turn.
+
+### Deferred to Implementation
+
+- Exact `tmux send-keys` command syntax for setting env vars inline with the run command
+- How to derive the tmux session name for a given workflow session -- must match `Terminal.Server`'s naming to target the correct session
+- Whether to use `tmux send-keys C-c` (graceful) or `tmux kill-window` (force) for service stop, or a combination (try graceful first, force after timeout)
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant AI as AI Agent
+    participant MCP as MCP Tool Server
+    participant W as AiQueryWorker
+    participant SM as ServiceManager
+    participant DB as Database
+    participant Tmux as Tmux Session
+
+    AI->>MCP: service(action: "start")
+    MCP-->>AI: placeholder response
+    Note over W: Collect streaming response
+    W->>W: Detect service tool call
+    W->>SM: execute(ws, "start", worktree_path)
+    SM->>SM: load project via ws.project_id
+    SM->>SM: reserve_ports(port_definitions)
+    SM->>Tmux: create window "service"
+    SM->>Tmux: send-keys with env vars + run command
+    SM->>DB: update ws.service_state
+    SM-->>W: {:ok, %{status: "running", ports: ...}}
+    W->>W: Replace placeholder with real result
+    W-->>AI: Real service result in tool_result
+```
+
+## Implementation Units
+
+```mermaid
+graph TB
+    U1[Unit 1: Schema + Migration] --> U2[Unit 2: Project UI]
+    U1 --> U3[Unit 3: Service MCP Tool + ServiceManager]
+    U3 --> U4[Unit 4: Service Context in Prompts]
+    U3 --> U5[Unit 5: Archive Cleanup]
+    U1 --> U6[Unit 6: Gherkin + Tests]
+    U2 --> U6
+```
+
+- [ ] **Unit 1: Project schema + session migration**
+
+**Goal:** Add `run_command` and `port_definitions` fields to Project schema, add `service_state` column to workflow_sessions.
+
+**Requirements:** R1, R4, R9
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `lib/destila/projects/project.ex`
+- Modify: `lib/destila/workflows/session.ex`
+- Create: `priv/repo/migrations/TIMESTAMP_add_service_fields.exs`
+
+**Approach:**
+- Add `run_command` (`:string`, optional) and `port_definitions` (`{:array, :string}`, default `[]`) to the Project schema
+- Add both to `cast/3` fields list; add validation for port_definitions (each entry must be non-empty, match `~r/^[A-Z][A-Z0-9_]*$/`). Add a denylist rejecting critical system env var names (`PATH`, `HOME`, `SHELL`, `USER`, `TERM`, `LANG`, `LD_PRELOAD`, `LD_LIBRARY_PATH`) to prevent environment variable collision when launching the service
+- Add `service_state` (`:map`, optional) to Session schema and its `cast/3` list
+- Single migration adds all three columns
+
+**Patterns to follow:**
+- `lib/destila/projects/project.ex` changeset structure with custom validators (`validate_at_least_one_location`, `validate_git_repo_url`)
+- Existing migration in `priv/repo/migrations/20260324111938_create_projects_workflow_sessions_messages.exs`
+
+**Test scenarios:**
+- Happy path: Project changeset accepts valid `run_command` and `port_definitions` (e.g., `["PORT", "API_PORT"]`)
+- Happy path: Project changeset accepts nil/empty `run_command` and `port_definitions` (both optional)
+- Happy path: Session changeset accepts a `service_state` map
+- Edge case: Port definition with empty string is rejected
+- Edge case: Port definition with lowercase or special chars (e.g., `"my-port"`, `"123"`) is rejected
+- Edge case: Port definition with valid underscore names (e.g., `"DB_PORT"`, `"PORT_3000"`) is accepted
+- Happy path: Existing project and session validations still pass unchanged
+
+**Verification:**
+- `mix test test/destila/projects/project_test.exs` passes (create this test file)
+- Migration runs cleanly with `mix ecto.migrate`
+
+- [ ] **Unit 2: Project management UI updates**
+
+**Goal:** Add run command and port definitions fields to both the dedicated projects page form and the inline creation form in the workflow wizard.
+
+**Requirements:** R2
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `lib/destila_web/live/projects_live.ex`
+- Modify: `lib/destila_web/components/project_components.ex`
+- Modify: `lib/destila_web/live/create_session_live.ex`
+
+**Approach:**
+- Extend `project_form/1` in `ProjectsLive` with:
+  - A text input for `run_command` (optional, labeled "Run command", placeholder e.g. `mix setup && mix phx.server`)
+  - A dynamic list section for port definitions: each entry is a text input for the env var name with a remove button, plus an "Add port" button
+- Use hidden inputs with indexed names (e.g., `port_definitions[0]`, `port_definitions[1]`) for the port list
+- Handle `add_port` and `remove_port` events in the LiveView to manipulate a `@port_definitions` assign (list of strings)
+- Extend `validate_project_params/1` to include `run_command` and `port_definitions` validation
+- Extend `new_form/0` to include `run_command` and `port_definitions` defaults
+- Extend `edit_project` handler to populate form with existing `run_command` and `port_definitions`
+- Mirror the same fields in `project_selector/1` component's `:create` step
+- Show run command and port count in the project display card (similar to how git URL and local folder are shown)
+
+**Patterns to follow:**
+- Existing `project_form/1` component in `ProjectsLive` with fieldset structure, error display, class list pattern
+- Existing inline form in `project_components.ex` with `phx-target={@target}` pattern
+- Manual `validate_project_params/1` approach (not changeset-based) for LiveView validation
+
+**Test scenarios:**
+- Happy path: Create a project with run command and port definitions -- form submits, project appears in list with run command displayed
+- Happy path: Edit a project's run configuration -- existing values pre-fill, update saves
+- Happy path: Add multiple port definitions dynamically -- clicking "Add port" adds input rows
+- Happy path: Remove a port definition -- clicking remove button removes the row
+- Edge case: Empty port definition env var name shows validation error
+- Edge case: Create project without run command or ports (optional fields) -- succeeds as before
+- Integration: Port definitions with invalid format rejected on form submit
+
+**Verification:**
+- Project form renders with run command and port definition fields
+- Dynamic add/remove of port definition entries works
+- Validation errors display for empty/invalid port names
+- Existing project CRUD behavior unchanged
+
+- [ ] **Unit 3: Service MCP tool + ServiceManager**
+
+**Goal:** Add the `service` MCP tool definition and a `Destila.Services.ServiceManager` module that handles port reservation, tmux commands, PID tracking, and service_state persistence.
+
+**Requirements:** R3, R4, R6, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `lib/destila/ai/tools.ex`
+- Modify: `lib/destila/ai/claude_session.ex`
+- Modify: `lib/destila/ai/response_processor.ex`
+- Modify: `lib/destila/workers/ai_query_worker.ex`
+- Modify: `lib/destila/workflows/implement_general_prompt_workflow.ex` (add to `@implementation_tools`)
+- Modify: `lib/destila/workflows/code_chat_workflow.ex` (add to `@chat_tools`)
+- Create: `lib/destila/services/service_manager.ex`
+
+**Approach:**
+
+**Tool definition** (`tools.ex`):
+- Add `tool :service` with a single `:action` string field (required, description lists start/stop/restart/status)
+- Add `@service_details` markdown describing the tool's behavior, when to use each action, and that port mappings are returned in the tool result. Include guidance that the AI should not combine a service start with immediate port-dependent actions in the same response
+- Add `"mcp__destila__service"` to `@tool_descriptions`
+- `execute/1` returns `{:ok, "Service action will be processed."}`
+
+**Tool registration** (`claude_session.ex`):
+- Add `"mcp__destila__service"` to `@default_allowed_tools`
+
+**Per-workflow tool lists**:
+- Add `"mcp__destila__service"` to `@implementation_tools` in `implement_general_prompt_workflow.ex`
+- Add `"mcp__destila__service"` to `@chat_tools` in `code_chat_workflow.ex`
+- Do NOT add to `brainstorm_idea_workflow.ex` (brainstorm phases are conversational, no service management needed)
+
+**Response processing** (`response_processor.ex`):
+- Add `@service_tool_names ["service", "mcp__destila__service"]`
+- Add `extract_service_action/1` that finds the first service tool call and returns `%{action: action}` or `nil`
+
+**Worker integration** (`ai_query_worker.ex`):
+- After collecting the streaming response but before passing the result to `SessionProcess`, detect service tool calls via `ResponseProcessor.extract_service_action(result)`
+- If a service action is found, call `ServiceManager.execute(ws, action, worktree_path: worktree_path)` where `worktree_path` comes from the AI session (already available in the worker context)
+- Replace the placeholder tool result text in the response with the actual ServiceManager result (JSON-encoded port mappings, status, or error message)
+- Service actions must be processed BEFORE session actions (phase transitions) to ensure service state is persisted before any phase advance
+
+**ServiceManager** (`lib/destila/services/service_manager.ex`):
+- `execute(ws, action, opts)` dispatches to `do_start/2`, `do_stop/1`, `do_restart/2`, `do_status/1`
+- `do_start/2`:
+  1. Load the project via `Destila.Projects.get_project(ws.project_id)` (NOT via ws.project which is not preloaded)
+  2. Return error if project is nil or `run_command` is nil
+  3. Reserve ports via `:gen_tcp.listen(0, ...)` + `:inet.port/1` for each port definition
+  4. Get worktree_path from opts
+  5. Derive the tmux session name using the same logic as `Terminal.Server` (escape_shell on the session name). If the tmux session doesn't exist, create it with a "shell" window first (matching terminal convention), then add the "service" window
+  6. Create a tmux window named "service" with env vars and run command via `tmux send-keys`
+  7. Update `ws.service_state` with `%{"status" => "running", "ports" => port_map}`. Validate that `pid` (if tracked) is always a positive integer before storing
+  8. Return the service state
+- `do_stop/1`: Use `tmux send-keys -t session:service C-c` to send SIGINT, or `tmux kill-window -t session:service` to force-stop. Update `service_state` to `%{"status" => "stopped", ...}`, keep port info for reference. Prefer tmux-level control over raw PID kill to avoid PID reuse risks
+- `do_restart/2`: Call `do_stop/1` then `do_start/2`. On restart, reuse previously assigned ports from `service_state` rather than reserving new ones, to avoid breaking port references
+- `do_status/1`: Check if the tmux "service" window exists and if the process is alive, correct stale state, return current `service_state`
+
+**Patterns to follow:**
+- `ResponseProcessor.extract_session_action/1` pattern for extracting tool calls
+- `Terminal.Server.build_tmux_command/1` and `escape_shell/1` for tmux command construction
+- `Workflows.update_workflow_session/2` for persisting state changes
+
+**Test scenarios:**
+- Happy path: `ServiceManager.execute(ws, "start")` with valid project run_command reserves ports, returns running state with port mappings
+- Happy path: `ServiceManager.execute(ws, "stop")` on a running service updates state to stopped
+- Happy path: `ServiceManager.execute(ws, "restart")` stops then starts with new ports
+- Happy path: `ServiceManager.execute(ws, "status")` on running service returns current state
+- Error path: `start` on a project with no run_command returns an error tuple
+- Error path: `stop` when no service is running returns appropriate error/message
+- Edge case: `status` when PID is no longer alive corrects state to "stopped"
+- Edge case: `start` when tmux session doesn't exist yet creates it first
+- Integration: `ResponseProcessor.extract_service_action/1` correctly extracts service tool calls from MCP tool uses
+- Integration: Port reservation finds actually available ports (`:gen_tcp` approach)
+
+**Verification:**
+- Service MCP tool appears in tool descriptions
+- `ServiceManager` correctly manages tmux windows and tracks PIDs
+- Port reservation produces valid, available ports
+- Service state is persisted to the database after each action
+
+- [ ] **Unit 4: Service state in AI session context**
+
+**Goal:** Include service state and port assignments in the AI's system prompt so the AI always knows current service status.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `lib/destila/ai/conversation.ex`
+
+**Approach:**
+- Inject service state context centrally in `conversation.ex`'s `phase_start/1`, alongside the existing `tool_section` and `skill_section` assembly. This avoids modifying individual workflow modules (many of whose prompt functions ignore the `ws` argument with `_workflow_session`)
+- Add a `service_section` that reads `ws.service_state` and formats it as a prompt section when non-nil
+- Format: `## Service Status\n\nThe project service is currently {status}.\nPorts: PORT=54321, API_PORT=54322`
+- When `service_state` is nil, omit the section entirely
+- The `ws` struct is loaded via `Workflows.get_workflow_session!/1` which does NOT preload `:project`. Service state is already on the `ws` struct directly (the `:map` column), so no preload is needed for this unit
+- Append the service section to the `sections` list in `phase_start/1` so it appears in every phase prompt automatically
+
+**Patterns to follow:**
+- Existing `tool_section` and `skill_section` assembly pattern in `conversation.ex:42-61`
+- `Destila.Workflows.Skills.assemble_skills/1` pattern for composing prompt sections
+
+**Test scenarios:**
+- Happy path: When `ws.service_state` is `%{"status" => "running", "ports" => %{"PORT" => 54321}}`, assembled prompt includes service status and port mappings
+- Happy path: When `ws.service_state` is nil, assembled prompt has no service section
+- Edge case: When service state is `%{"status" => "stopped"}`, prompt indicates service is stopped
+
+**Verification:**
+- AI system prompts include service context when service is running
+- AI system prompts omit service context when no service has been started
+
+- [ ] **Unit 5: Archive cleanup**
+
+**Goal:** Stop the service and clean up the tmux service window when a workflow session is archived.
+
+**Requirements:** R8
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `lib/destila/workflows.ex`
+
+**Approach:**
+- In `archive_workflow_session/1`, before the existing `ClaudeSession.stop_for_workflow_session`, call `ServiceManager.cleanup(ws)` if `ws.service_state` is non-nil
+- `ServiceManager.cleanup/1` kills the tmux "service" window (which terminates the service process) and updates `service_state` to nil
+- In `unarchive_workflow_session/1`, clear `service_state` to nil so the AI starts fresh rather than seeing stale port/PID data from before archival
+
+**Patterns to follow:**
+- Existing `archive_workflow_session/1` which already calls `ClaudeSession.stop_for_workflow_session/1`
+- Existing `unarchive_workflow_session/1` which resets phase execution status
+
+**Test scenarios:**
+- Happy path: Archiving a session with a running service stops the process and cleans up tmux window
+- Happy path: Archiving a session with no service (nil service_state) proceeds without error
+- Edge case: Archiving a session where the service process already died still cleans up tmux window
+- Happy path: Unarchiving a session clears stale service_state to nil
+- Integration: After archive, service_state is nil
+
+**Verification:**
+- Archive stops service process when running
+- Archive cleans up tmux "service" window
+- Archive of session without service still works
+
+- [ ] **Unit 6: Gherkin scenarios and tests**
+
+**Goal:** Update Gherkin feature files and add/update LiveView tests for the new project fields.
+
+**Requirements:** R10
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `features/project_management.feature`
+- Modify: `features/project_inline_creation.feature`
+- Modify: `test/destila_web/live/projects_live_test.exs`
+- Modify: `test/destila_web/live/project_inline_creation_live_test.exs`
+
+**Approach:**
+- Update `project_management.feature` description to mention run command and port definitions
+- Add three new scenarios as specified in the prompt: create with run config, edit run config, port definitions require env var name
+- Update `project_inline_creation.feature` description to mention optional run command and port definitions
+- Add corresponding `@tag feature: @feature, scenario: "..."` tests in the test files
+- Tests should use `has_element?/2` and `element/2` to verify form fields and validation errors
+
+**Patterns to follow:**
+- Existing `@tag feature: @feature, scenario: "..."` pattern in test files
+- Existing test structure using `Phoenix.LiveViewTest` functions
+- Existing Gherkin scenario writing style in feature files
+
+**Test scenarios:**
+- Happy path: "Create a project with run command and port definitions" -- fill form, submit, verify project created with fields
+- Happy path: "Edit a project's run configuration" -- edit existing project, verify pre-fill, update, verify saved
+- Error path: "Port definitions require an environment variable name" -- add empty port def, submit, verify error
+- Integration: Existing scenarios still pass unchanged
+
+**Verification:**
+- `mix test test/destila_web/live/projects_live_test.exs` passes with new scenarios
+- `mix test test/destila_web/live/project_inline_creation_live_test.exs` passes
+- Gherkin files accurately describe current behavior
+
+## System-Wide Impact
+
+- **Interaction graph:** The `service` tool's actions are extracted by `ResponseProcessor` in `AiQueryWorker` after collecting the AI response. `ServiceManager` executes the action and writes to `workflow_sessions`. The result is injected back into the tool result before passing to `SessionProcess`. The archive path in `Workflows.archive_workflow_session/1` gains a new cleanup step. `update_workflow_session/2` broadcasts `:workflow_session_updated` after each service state write, which triggers UI refreshes in connected LiveViews -- this is acceptable since service actions are infrequent.
+- **Error propagation:** Service action failures (port unavailable, tmux command failure, project has no run_command) should be returned as error messages in the tool result text, and also stored in `service_state`. The AI sees the error in the tool result and can react in the same turn. Service failures do not affect the session state machine return value (`:awaiting_input`, `:phase_complete`, etc.).
+- **State lifecycle risks:** The `service_state` JSON column is written by `ServiceManager` via `Workflows.update_workflow_session/2`. Since only one AI tool call processes at a time per session (sequential Oban worker), there's no concurrent write risk. Stale "running" state is corrected on `status` checks via tmux window existence.
+- **API surface parity:** No external API affected. The MCP tool is internal to the AI agent loop.
+- **Integration coverage:** The critical cross-layer path is: AI calls service tool -> ResponseProcessor extracts it -> Conversation calls ServiceManager -> ServiceManager runs tmux commands + writes DB -> next prompt reads service_state. This end-to-end flow should have at least one integration test.
+- **Unchanged invariants:** Existing project CRUD, session lifecycle, terminal opening, and all other MCP tools remain unchanged. The `session` and `ask_user_question` tools are not affected.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| TOCTOU window in port reservation (port freed then grabbed by another process) | Acceptable for dev tooling; document the limitation. On restart, reuse previously assigned ports to minimize exposure. |
+| Tmux session might not exist when service start is called | ServiceManager checks for tmux session existence and creates it (with "shell" window first) if needed, matching `Terminal.Server` convention. |
+| Tmux session name must match between Terminal.Server and ServiceManager | Both derive the session name from the same source. ServiceManager must use the same naming/escaping logic as `Terminal.Server.build_tmux_command/1`. |
+| Service process crash between status checks leaves stale state | `status` action checks if the tmux "service" window still exists and corrects state. AI prompt context shows last-known state. |
+| SQLite JSON column handling for service_state and {:array, :string} | Ecto's `:map` type and `{:array, :string}` with `ecto_sqlite3` store as JSON text; verify roundtrip behavior during implementation. |
+| Environment variable collision in port definitions | Denylist validation rejects critical system env var names (PATH, HOME, etc.) to prevent accidental override. |
+| run_command enables arbitrary shell execution | Intentional for dev tooling. Trust boundary: only the user sets this via project UI. The AI agent does not have write access to `run_command` via any MCP tool. |
+
+## Sources & References
+
+- Related code: `lib/destila/ai/tools.ex` (MCP tool pattern)
+- Related code: `lib/destila/terminal/server.ex` (tmux integration)
+- Related code: `lib/destila/ai/response_processor.ex` (tool action extraction)
+- Related code: `lib/destila/workflows.ex:206-213` (archive cleanup)
+- Related code: `lib/destila_web/live/projects_live.ex` (project form UI)

--- a/features/project_inline_creation.feature
+++ b/features/project_inline_creation.feature
@@ -1,7 +1,7 @@
 Feature: Project Inline Creation
   Users can create a new project inline from the workflow wizard phase.
   A project requires a name and at least one of a git repository URL or
-  a local folder path.
+  a local folder path. Optionally, a run command can be configured.
 
   Background:
     Given I am on the workflow wizard page

--- a/features/project_management.feature
+++ b/features/project_management.feature
@@ -1,8 +1,9 @@
 Feature: Project Management
   Users can manage projects independently from sessions. A project has a name,
-  an optional git repository URL, and an optional local folder path. At least
-  one of git repository URL or local folder must be provided. Projects can be
-  shared across multiple sessions.
+  an optional git repository URL, an optional local folder path, an optional
+  run command, and optional port definitions. At least one of git repository
+  URL or local folder must be provided. Projects can be shared across multiple
+  sessions.
 
   Scenario: View list of projects
     Given there are existing projects
@@ -75,3 +76,28 @@ Feature: Project Management
     When I navigate to the projects page
     And I click delete on the project
     Then I should see a message indicating the project cannot be deleted while linked to sessions
+
+  Scenario: Create a project with run command and port definitions
+    When I navigate to the projects page
+    And I click "New Project"
+    When I fill in the name, a git repository URL, a run command, and port definitions
+    And I click "Create"
+    Then the project should be created
+    And I should see the run command displayed in the project card
+
+  Scenario: Edit a project's run configuration
+    Given there is an existing project with a run command
+    When I navigate to the projects page
+    And I click edit on the project
+    Then I should see the run command pre-filled
+    When I update the run command
+    And I click "Save"
+    Then the project should be updated with the new run command
+
+  Scenario: Port definitions require a valid environment variable name
+    When I navigate to the projects page
+    And I click "New Project"
+    When I fill in the name and a git repository URL
+    And I add a port definition with an invalid name
+    And I click "Create"
+    Then I should see a validation error for the port definition

--- a/lib/destila/ai/claude_session.ex
+++ b/lib/destila/ai/claude_session.ex
@@ -17,7 +17,8 @@ defmodule Destila.AI.ClaudeSession do
     "Bash(git log:*)",
     "Bash(git show:*)",
     "mcp__destila__ask_user_question",
-    "mcp__destila__session"
+    "mcp__destila__session",
+    "mcp__destila__service"
   ]
 
   # Client API
@@ -147,7 +148,12 @@ defmodule Destila.AI.ClaudeSession do
     claude_opts = Keyword.put_new(claude_opts, :allowed_tools, @default_allowed_tools)
 
     claude_opts =
-      Keyword.put_new(claude_opts, :mcp_servers, %{"destila" => Destila.AI.Tools})
+      Keyword.put_new(claude_opts, :mcp_servers, %{
+        "destila" => %{
+          module: Destila.AI.Tools,
+          assigns: %{workflow_session_id: workflow_session_id}
+        }
+      })
 
     claude_opts = Keyword.put_new(claude_opts, :setting_sources, ["user", "project"])
 

--- a/lib/destila/ai/conversation.ex
+++ b/lib/destila/ai/conversation.ex
@@ -51,10 +51,13 @@ defmodule Destila.AI.Conversation do
 
     skill_section = Skills.assemble_skills(all_skills)
 
+    service_section = build_service_section(ws)
+
     sections =
       [
         if(tool_section != "", do: "# Tools\n\n#{tool_section}"),
         if(skill_section != "", do: "# Skills\n\n#{skill_section}"),
+        service_section,
         "# Prompt\n\n#{phase_prompt}"
       ]
 
@@ -248,6 +251,22 @@ defmodule Destila.AI.Conversation do
   end
 
   # --- Private ---
+
+  defp build_service_section(%{service_state: nil}), do: nil
+
+  defp build_service_section(%{service_state: state}) do
+    status = state["status"]
+    ports = state["ports"] || %{}
+
+    port_lines =
+      ports
+      |> Enum.map(fn {name, port} -> "#{name}=#{port}" end)
+      |> Enum.join(", ")
+
+    port_info = if port_lines != "", do: "\nPorts: #{port_lines}", else: ""
+
+    "# Service Status\n\nThe project service is currently #{status}.#{port_info}"
+  end
 
   defp get_phase(ws, phase_number) do
     Enum.at(Workflows.phases(ws.workflow_type), phase_number - 1)

--- a/lib/destila/ai/tools.ex
+++ b/lib/destila/ai/tools.ex
@@ -117,9 +117,53 @@ defmodule Destila.AI.Tools do
   `markdown` (markdown content), or `video_file` (absolute path to a video file).
   """
 
+  tool :service,
+       "Manage the project's development service lifecycle. " <>
+         "Use this to start, stop, restart, or check the status of the project's service." do
+    field(:action, :string,
+      required: true,
+      description:
+        "One of: start (start the service), stop (stop the service), " <>
+          "restart (restart the service), status (check current service status)"
+    )
+
+    def execute(%{action: action}, frame) do
+      try do
+        workflow_session_id = frame.assigns[:workflow_session_id]
+        ws = Destila.Workflows.get_workflow_session!(workflow_session_id)
+        ai_session = Destila.AI.get_ai_session_for_workflow(ws.id)
+        worktree_path = ai_session && ai_session.worktree_path
+
+        case Destila.Services.ServiceManager.execute(ws, action, worktree_path: worktree_path) do
+          {:ok, state} -> {:ok, Jason.encode!(state)}
+          {:error, reason} -> {:ok, "Service error: #{reason}"}
+        end
+      rescue
+        e -> {:ok, "Service error: #{Exception.message(e)}"}
+      end
+    end
+  end
+
+  @service_details """
+  ## Service Management
+
+  Use the `mcp__destila__service` tool to manage the project's development server. \
+  The tool accepts an `action` parameter:
+
+  - `start` — Start the service using the project's configured run command. \
+  Returns the assigned port mappings (e.g., `{"PORT": 54321}`).
+  - `stop` — Stop the running service gracefully.
+  - `restart` — Stop and restart the service with fresh port assignments.
+  - `status` — Check the current service status and port mappings.
+
+  The tool result contains the service state as JSON, including status and \
+  port mappings. Use these ports when configuring or accessing the service.
+  """
+
   @tool_descriptions %{
     "mcp__destila__ask_user_question" => @ask_user_question_details,
-    "mcp__destila__session" => @session_details
+    "mcp__destila__session" => @session_details,
+    "mcp__destila__service" => @service_details
   }
 
   @doc """

--- a/lib/destila/projects/project.ex
+++ b/lib/destila/projects/project.ex
@@ -8,6 +8,8 @@ defmodule Destila.Projects.Project do
     field(:name, :string)
     field(:git_repo_url, :string)
     field(:local_folder, :string)
+    field(:run_command, :string)
+    field(:port_definitions, {:array, :string}, default: [])
 
     has_many(:workflow_sessions, Destila.Workflows.Session)
 
@@ -16,10 +18,11 @@ defmodule Destila.Projects.Project do
 
   def changeset(project, attrs) do
     project
-    |> cast(attrs, [:name, :git_repo_url, :local_folder])
+    |> cast(attrs, [:name, :git_repo_url, :local_folder, :run_command, :port_definitions])
     |> validate_required([:name])
     |> validate_at_least_one_location()
     |> validate_git_repo_url()
+    |> validate_port_definitions()
   end
 
   defp validate_at_least_one_location(changeset) do
@@ -61,6 +64,44 @@ defmodule Destila.Projects.Project do
           true ->
             changeset
         end
+    end
+  end
+
+  @denied_env_vars ~w(PATH HOME SHELL USER TERM LANG LD_PRELOAD LD_LIBRARY_PATH)
+  @port_definition_pattern ~r/^[A-Z][A-Z0-9_]*$/
+
+  defp validate_port_definitions(changeset) do
+    definitions = get_field(changeset, :port_definitions)
+
+    if definitions in [nil, []] do
+      changeset
+    else
+      invalid =
+        Enum.find(definitions, fn d ->
+          d == "" or not Regex.match?(@port_definition_pattern, d) or d in @denied_env_vars
+        end)
+
+      case invalid do
+        nil ->
+          changeset
+
+        "" ->
+          add_error(changeset, :port_definitions, "port definition cannot be empty")
+
+        name when name in @denied_env_vars ->
+          add_error(
+            changeset,
+            :port_definitions,
+            "#{name} is a reserved system environment variable"
+          )
+
+        name ->
+          add_error(
+            changeset,
+            :port_definitions,
+            "#{name} must start with A-Z and contain only uppercase letters, digits, and underscores"
+          )
+      end
     end
   end
 

--- a/lib/destila/services/service_manager.ex
+++ b/lib/destila/services/service_manager.ex
@@ -1,0 +1,140 @@
+defmodule Destila.Services.ServiceManager do
+  @moduledoc """
+  Manages the lifecycle of a project's development service within a
+  workflow session's tmux session.
+
+  Handles port reservation, tmux window creation, process management,
+  and service state persistence. The service always runs in tmux window
+  index 9 of the session.
+  """
+
+  alias Destila.{Projects, Workflows}
+  alias Destila.Terminal.Tmux
+
+  @service_window 9
+
+  @doc """
+  Executes a service action for the given workflow session.
+
+  Returns `{:ok, service_state_map}` or `{:error, reason}`.
+  """
+  def execute(ws, action, opts \\ []) do
+    case action do
+      "start" -> do_start(ws, opts)
+      "stop" -> do_stop(ws)
+      "restart" -> do_restart(ws, opts)
+      "status" -> do_status(ws)
+      _ -> {:error, "Unknown service action: #{action}"}
+    end
+  end
+
+  @doc """
+  Cleans up the service tmux window and clears service state.
+  Called during session archival.
+  """
+  def cleanup(ws) do
+    Tmux.kill_window(service_target(ws))
+    Workflows.update_workflow_session(ws, %{service_state: nil})
+    :ok
+  end
+
+  # --- Private ---
+
+  defp do_start(ws, opts) do
+    project = Projects.get_project(ws.project_id)
+
+    cond do
+      is_nil(project) ->
+        {:error, "No project linked to this session"}
+
+      is_nil(project.run_command) or project.run_command == "" ->
+        {:error, "Project has no run command configured"}
+
+      true ->
+        ports = reserve_ports(project.port_definitions)
+        worktree_path = Keyword.get(opts, :worktree_path)
+        session = Tmux.session_name(ws)
+        target = service_target(ws)
+
+        Tmux.ensure_session(session, worktree_path)
+        Tmux.kill_window(target)
+        Tmux.new_window(target, cwd: worktree_path)
+        Tmux.send_keys(target, build_service_command(project.run_command, ports))
+
+        service_state = %{
+          "status" => "running",
+          "ports" => ports,
+          "run_command" => project.run_command
+        }
+
+        Workflows.update_workflow_session(ws, %{service_state: service_state})
+
+        {:ok, service_state}
+    end
+  end
+
+  defp do_stop(ws) do
+    target = service_target(ws)
+    Tmux.term_panes(target)
+    Tmux.kill_window(target)
+
+    service_state = %{
+      "status" => "stopped",
+      "ports" => (ws.service_state || %{})["ports"]
+    }
+
+    Workflows.update_workflow_session(ws, %{service_state: service_state})
+
+    {:ok, service_state}
+  end
+
+  defp do_restart(ws, opts) do
+    do_stop(ws)
+    ws = Workflows.get_workflow_session!(ws.id)
+    do_start(ws, opts)
+  end
+
+  defp do_status(ws) do
+    current_state = ws.service_state || %{"status" => "stopped"}
+
+    service_state =
+      if current_state["status"] == "running" and
+           not Tmux.window_exists?(service_target(ws)) do
+        %{current_state | "status" => "stopped"}
+      else
+        current_state
+      end
+
+    if service_state != current_state do
+      Workflows.update_workflow_session(ws, %{service_state: service_state})
+    end
+
+    {:ok, service_state}
+  end
+
+  # --- Helpers ---
+
+  defp service_target(ws), do: "#{Tmux.session_name(ws)}:#{@service_window}"
+
+  defp build_service_command(run_command, ports) do
+    env_exports =
+      ports
+      |> Enum.map(fn {name, port} -> "export #{name}=#{port}" end)
+      |> Enum.join(" && ")
+
+    if env_exports != "" do
+      "#{env_exports} && #{run_command}"
+    else
+      run_command
+    end
+  end
+
+  defp reserve_ports(port_definitions) do
+    Map.new(port_definitions, fn name ->
+      {:ok, socket} = :gen_tcp.listen(0, reuseaddr: true)
+      {:ok, port} = :inet.port(socket)
+      :gen_tcp.close(socket)
+      {name, port}
+    end)
+  end
+end

--- a/lib/destila/terminal/server.ex
+++ b/lib/destila/terminal/server.ex
@@ -1,6 +1,8 @@
 defmodule Destila.Terminal.Server do
   use GenServer
 
+  alias Destila.Terminal.Tmux
+
   defstruct [:pty, :topic, :cols, :rows]
 
   def start_link(opts) do
@@ -10,41 +12,32 @@ defmodule Destila.Terminal.Server do
   def write(server, data), do: GenServer.cast(server, {:write, data})
   def resize(server, cols, rows), do: GenServer.cast(server, {:resize, cols, rows})
 
-  require Logger
-
   @impl true
   def init(opts) do
     Process.flag(:trap_exit, true)
 
     cwd = Keyword.fetch!(opts, :cwd)
     topic = Keyword.fetch!(opts, :topic)
+    session_name = Keyword.get(opts, :session_name, "destila")
+    claude_session_id = Keyword.get(opts, :claude_session_id)
     cols = Keyword.get(opts, :cols, 80)
     rows = Keyword.get(opts, :rows, 24)
 
-    script = build_tmux_command(opts)
+    Tmux.ensure_session(session_name, cwd)
+    setup_claude_window(session_name, cwd, claude_session_id)
 
-    Logger.info(
-      "Terminal starting: /usr/bin/env TERM=xterm-256color COLORTERM=truecolor /bin/sh -c #{inspect(script)}"
-    )
+    attach_cmd = "tmux attach -t #{Tmux.escape_shell(session_name)}"
 
     {:ok, pty} =
       ExPTY.spawn(
         "/usr/bin/env",
-        [
-          "TERM=xterm-256color",
-          "COLORTERM=truecolor",
-          "/bin/sh",
-          "-c",
-          script
-        ],
+        ["TERM=xterm-256color", "COLORTERM=truecolor", "/bin/sh", "-c", attach_cmd],
         cwd: cwd,
         cols: cols,
         rows: rows,
         closeFDs: true
       )
 
-    # ExPTY uses GenServer.start (not start_link), so link manually to ensure
-    # the PTY process is cleaned up if Terminal.Server is killed without terminate/2
     Process.link(pty)
 
     ExPTY.on_data(pty, fn _pty, _pid, data ->
@@ -84,32 +77,23 @@ defmodule Destila.Terminal.Server do
     :ok
   end
 
-  defp build_tmux_command(opts) do
-    session_name = Keyword.get(opts, :session_name, "destila")
-    cwd = Keyword.fetch!(opts, :cwd)
-    claude_session_id = Keyword.get(opts, :claude_session_id)
+  defp setup_claude_window(_session_name, _cwd, nil), do: :ok
 
-    session = escape_shell(session_name)
-    dir = escape_shell(cwd)
+  defp setup_claude_window(session_name, cwd, claude_session_id) do
+    window = "#{session_name}:claude-code"
 
-    attach = "tmux attach -t #{session}"
+    unless Tmux.window_exists?(window) do
+      claude_cmd = build_claude_resume_cmd(claude_session_id)
 
-    create =
-      if claude_session_id do
-        claude_cmd = build_claude_resume_cmd(claude_session_id)
+      cmd =
+        "clear && echo '# run the following command to resume the claude code session:' && " <>
+          "echo '# #{claude_cmd}' && exec $SHELL"
 
-        claude_window_cmd =
-          "clear && echo '# run the following command to resume the claude code session:' && " <>
-            "echo '# #{claude_cmd}' && exec $SHELL"
+      Tmux.new_window(session_name, name: "claude-code", cwd: cwd)
+      Tmux.send_keys(window, cmd)
 
-        "tmux new-session -s #{session} -n shell -c #{dir} \\; " <>
-          "new-window -n 'claude code' -c #{dir} #{escape_shell(claude_window_cmd)} \\; " <>
-          "select-window -t 1"
-      else
-        "tmux new-session -s #{session} -n shell -c #{dir}"
-      end
-
-    "tmux has-session -t #{session} 2>/dev/null && #{attach} || #{create}"
+      System.cmd("tmux", ["select-window", "-t", "#{session_name}:1"], stderr_to_stdout: true)
+    end
   end
 
   defp build_claude_resume_cmd(session_id) do
@@ -132,6 +116,4 @@ defmodule Destila.Terminal.Server do
 
     Enum.join(parts, " ")
   end
-
-  defp escape_shell(str), do: "'" <> String.replace(str, "'", "'\\''") <> "'"
 end

--- a/lib/destila/terminal/tmux.ex
+++ b/lib/destila/terminal/tmux.ex
@@ -1,0 +1,107 @@
+defmodule Destila.Terminal.Tmux do
+  @moduledoc """
+  Low-level tmux operations shared by Terminal.Server and ServiceManager.
+  """
+
+  @doc """
+  Returns the tmux session name for a workflow session, derived from its title.
+  Strips everything except alphanumerics, hyphens, and underscores.
+  """
+  def session_name(ws) do
+    ws.title
+    |> String.replace(~r/[^0-9a-zA-Z_-]/, "-")
+  end
+
+  @doc """
+  Checks whether a tmux session exists.
+  """
+  def has_session?(name) do
+    match?({_, 0}, System.cmd("tmux", ["has-session", "-t", name], stderr_to_stdout: true))
+  end
+
+  @doc """
+  Creates a tmux session if it doesn't already exist.
+  Sets renumber-windows off to preserve fixed window indices.
+  """
+  def ensure_session(name, cwd) do
+    unless has_session?(name) do
+      dir = cwd || System.tmp_dir!()
+
+      System.cmd("tmux", [
+        "new-session",
+        "-d",
+        "-s",
+        name,
+        "-n",
+        "shell",
+        "-c",
+        dir
+      ])
+
+      System.cmd("tmux", ["set-option", "-t", name, "renumber-windows", "off"])
+    end
+
+    :ok
+  end
+
+  @doc """
+  Creates a new window at the given target (e.g. "session" or "session:9").
+  Options: `:cwd`, `:name`.
+  """
+  def new_window(target, opts \\ []) do
+    name_args = if opts[:name], do: ["-n", opts[:name]], else: []
+    cwd_args = if opts[:cwd], do: ["-c", opts[:cwd]], else: []
+
+    System.cmd(
+      "tmux",
+      ["new-window", "-t", target] ++ name_args ++ cwd_args,
+      stderr_to_stdout: true
+    )
+  end
+
+  @doc """
+  Sends a command string to a tmux target followed by Enter.
+  """
+  def send_keys(target, command) do
+    System.cmd("tmux", ["send-keys", "-t", target, command, "Enter"], stderr_to_stdout: true)
+  end
+
+  @doc """
+  Kills the window at the given target.
+  """
+  def kill_window(target) do
+    System.cmd("tmux", ["kill-window", "-t", target], stderr_to_stdout: true)
+  end
+
+  @doc """
+  Checks whether a window exists at the given target.
+  """
+  def window_exists?(target) do
+    match?({_, 0}, System.cmd("tmux", ["list-panes", "-t", target], stderr_to_stdout: true))
+  end
+
+  @doc """
+  Sends SIGTERM to the process group of each pane in the target window.
+  """
+  def term_panes(target) do
+    case System.cmd("tmux", ["list-panes", "-t", target, "-F", ~S"#{pane_pid}"],
+           stderr_to_stdout: true
+         ) do
+      {output, 0} ->
+        output
+        |> String.trim()
+        |> String.split("\n", trim: true)
+        |> Enum.each(fn pid_str ->
+          System.cmd("kill", ["-TERM", "--", "-#{pid_str}"], stderr_to_stdout: true)
+        end)
+
+      _ ->
+        :ok
+    end
+  end
+
+  @doc """
+  Escapes a string for safe use in shell commands.
+  """
+  def escape_shell(str), do: "'" <> String.replace(str, "'", "'\\''") <> "'"
+end

--- a/lib/destila/workflows.ex
+++ b/lib/destila/workflows.ex
@@ -204,6 +204,10 @@ defmodule Destila.Workflows do
   end
 
   def archive_workflow_session(%Session{} = ws) do
+    if ws.service_state do
+      Destila.Services.ServiceManager.cleanup(ws)
+    end
+
     Destila.AI.ClaudeSession.stop_for_workflow_session(ws.id)
 
     ws
@@ -221,7 +225,7 @@ defmodule Destila.Workflows do
     end
 
     ws
-    |> Session.changeset(%{archived_at: nil})
+    |> Session.changeset(%{archived_at: nil, service_state: nil})
     |> Repo.update()
     |> broadcast(:workflow_session_updated)
   end

--- a/lib/destila/workflows/code_chat_workflow.ex
+++ b/lib/destila/workflows/code_chat_workflow.ex
@@ -21,7 +21,8 @@ defmodule Destila.Workflows.CodeChatWorkflow do
     "WebFetch",
     "Skill",
     "mcp__destila__ask_user_question",
-    "mcp__destila__session"
+    "mcp__destila__session",
+    "mcp__destila__service"
   ]
 
   def phases do

--- a/lib/destila/workflows/implement_general_prompt_workflow.ex
+++ b/lib/destila/workflows/implement_general_prompt_workflow.ex
@@ -26,7 +26,8 @@ defmodule Destila.Workflows.ImplementGeneralPromptWorkflow do
     "Grep",
     "WebFetch",
     "Skill",
-    "mcp__destila__session"
+    "mcp__destila__session",
+    "mcp__destila__service"
   ]
 
   use Destila.Workflows.Workflow

--- a/lib/destila/workflows/session.ex
+++ b/lib/destila/workflows/session.ex
@@ -31,6 +31,8 @@ defmodule Destila.Workflows.Session do
 
     has_many(:metadata, Destila.Workflows.SessionMetadata, foreign_key: :workflow_session_id)
 
+    field(:service_state, :map)
+
     timestamps(type: :utc_datetime)
   end
 
@@ -47,7 +49,8 @@ defmodule Destila.Workflows.Session do
       :position,
       :archived_at,
       :user_prompt,
-      :source_session_id
+      :source_session_id,
+      :service_state
     ])
     |> validate_required([:title, :workflow_type])
   end

--- a/lib/destila_web/components/project_components.ex
+++ b/lib/destila_web/components/project_components.ex
@@ -12,6 +12,7 @@ defmodule DestilaWeb.ProjectComponents do
   attr :step, :atom, default: :select
   attr :form, :map, default: nil
   attr :errors, :map, default: %{}
+  attr :port_definitions, :list, default: []
   attr :target, :any, required: true
 
   def project_selector(assigns) do
@@ -191,6 +192,58 @@ defmodule DestilaWeb.ProjectComponents do
               class="input input-bordered w-full"
             />
           </fieldset>
+
+          <div>
+            <div class="flex items-center justify-between mb-2">
+              <label class="text-xs font-medium text-base-content/70">Port definitions</label>
+              <button
+                type="button"
+                phx-click="add_port"
+                phx-target={@target}
+                class="btn btn-ghost btn-xs"
+                id="inline-add-port-btn"
+              >
+                <.icon name="hero-plus-micro" class="size-3" /> Add port
+              </button>
+            </div>
+
+            <div :if={@port_definitions != []} class="space-y-2">
+              <div
+                :for={{pd, idx} <- Enum.with_index(@port_definitions)}
+                class="flex items-center gap-2"
+                id={"inline-port-def-#{idx}"}
+              >
+                <input
+                  type="text"
+                  name={"port_def_#{idx}"}
+                  value={pd}
+                  placeholder="PORT"
+                  phx-blur="update_port"
+                  phx-target={@target}
+                  phx-value-index={idx}
+                  class={[
+                    "input input-bordered w-full font-mono uppercase",
+                    @errors[:port_definitions] && "input-error"
+                  ]}
+                  id={"inline-port-input-#{idx}"}
+                />
+                <button
+                  type="button"
+                  phx-click="remove_port"
+                  phx-target={@target}
+                  phx-value-index={idx}
+                  class="btn btn-ghost btn-xs text-error/60 hover:text-error"
+                  id={"inline-remove-port-#{idx}"}
+                >
+                  <.icon name="hero-x-mark-micro" class="size-4" />
+                </button>
+              </div>
+            </div>
+
+            <p :if={@errors[:port_definitions]} class="text-xs text-error mt-1">
+              {@errors[:port_definitions]}
+            </p>
+          </div>
         </div>
 
         <button type="submit" class="btn btn-primary w-full" id="create-and-select-btn">

--- a/lib/destila_web/components/project_components.ex
+++ b/lib/destila_web/components/project_components.ex
@@ -172,6 +172,27 @@ defmodule DestilaWeb.ProjectComponents do
           </p>
         </div>
 
+        <div class="rounded-lg p-3 space-y-3 bg-base-200/50">
+          <div class="flex items-center gap-2">
+            <span class="text-xs font-medium text-base-content/50">Service</span>
+            <span class="text-xs text-base-content/30">optional</span>
+          </div>
+
+          <fieldset class="fieldset">
+            <label class="fieldset-label text-xs font-medium" for="project-run-command">
+              Run command
+            </label>
+            <input
+              type="text"
+              id="project-run-command"
+              name="run_command"
+              value={@form["run_command"] && @form["run_command"].value}
+              placeholder="mix setup && mix phx.server"
+              class="input input-bordered w-full"
+            />
+          </fieldset>
+        </div>
+
         <button type="submit" class="btn btn-primary w-full" id="create-and-select-btn">
           <.icon name="hero-plus-micro" class="size-4" /> Create & Select
         </button>

--- a/lib/destila_web/components/project_components.ex
+++ b/lib/destila_web/components/project_components.ex
@@ -88,6 +88,7 @@ defmodule DestilaWeb.ProjectComponents do
 
       <form
         phx-submit="create_and_select_project"
+        phx-change="validate_project_form"
         phx-target={@target}
         class="space-y-4"
         id="inline-project-form"

--- a/lib/destila_web/live/create_session_live.ex
+++ b/lib/destila_web/live/create_session_live.ex
@@ -44,7 +44,7 @@ defmodule DestilaWeb.CreateSessionLive do
      |> assign(:project_step, :select)
      |> assign(
        :project_form,
-       to_form(%{"name" => "", "git_repo_url" => "", "local_folder" => ""})
+       to_form(%{"name" => "", "git_repo_url" => "", "local_folder" => "", "run_command" => ""})
      )
      |> assign(:errors, %{})
      |> assign(:page_title, Workflows.default_title(workflow_type))}
@@ -112,6 +112,7 @@ defmodule DestilaWeb.CreateSessionLive do
     name = String.trim(params["name"] || "")
     git_repo_url = non_blank(params["git_repo_url"])
     local_folder = non_blank(params["local_folder"])
+    run_command = non_blank(params["run_command"])
 
     errors = %{}
     errors = if name == "", do: Map.put(errors, :name, "Name is required"), else: errors
@@ -128,7 +129,8 @@ defmodule DestilaWeb.CreateSessionLive do
         Destila.Projects.create_project(%{
           name: name,
           git_repo_url: git_repo_url,
-          local_folder: local_folder
+          local_folder: local_folder,
+          run_command: run_command
         })
 
       {:noreply,

--- a/lib/destila_web/live/create_session_live.ex
+++ b/lib/destila_web/live/create_session_live.ex
@@ -109,6 +109,22 @@ defmodule DestilaWeb.CreateSessionLive do
     {:noreply, assign(socket, :project_step, :select)}
   end
 
+  def handle_event("validate_project_form", params, socket) do
+    port_definitions =
+      params
+      |> Enum.filter(fn {k, _} -> String.starts_with?(k, "port_def_") end)
+      |> Enum.sort_by(fn {k, _} -> k end)
+      |> Enum.map(fn {_, v} -> v end)
+
+    port_definitions =
+      if port_definitions == [], do: socket.assigns.port_definitions, else: port_definitions
+
+    {:noreply,
+     socket
+     |> assign(:project_form, to_form(params))
+     |> assign(:port_definitions, port_definitions)}
+  end
+
   def handle_event("add_port", _params, socket) do
     {:noreply, assign(socket, :port_definitions, socket.assigns.port_definitions ++ [""])}
   end

--- a/lib/destila_web/live/create_session_live.ex
+++ b/lib/destila_web/live/create_session_live.ex
@@ -47,6 +47,7 @@ defmodule DestilaWeb.CreateSessionLive do
        to_form(%{"name" => "", "git_repo_url" => "", "local_folder" => "", "run_command" => ""})
      )
      |> assign(:errors, %{})
+     |> assign(:port_definitions, [])
      |> assign(:page_title, Workflows.default_title(workflow_type))}
   end
 
@@ -108,11 +109,35 @@ defmodule DestilaWeb.CreateSessionLive do
     {:noreply, assign(socket, :project_step, :select)}
   end
 
+  def handle_event("add_port", _params, socket) do
+    {:noreply, assign(socket, :port_definitions, socket.assigns.port_definitions ++ [""])}
+  end
+
+  def handle_event("remove_port", %{"index" => index}, socket) do
+    index = String.to_integer(index)
+
+    {:noreply,
+     assign(socket, :port_definitions, List.delete_at(socket.assigns.port_definitions, index))}
+  end
+
+  def handle_event("update_port", params, socket) do
+    index = String.to_integer(params["index"])
+    value = params["value"] || ""
+
+    {:noreply,
+     assign(
+       socket,
+       :port_definitions,
+       List.replace_at(socket.assigns.port_definitions, index, value)
+     )}
+  end
+
   def handle_event("create_and_select_project", params, socket) do
     name = String.trim(params["name"] || "")
     git_repo_url = non_blank(params["git_repo_url"])
     local_folder = non_blank(params["local_folder"])
     run_command = non_blank(params["run_command"])
+    port_defs = Enum.reject(socket.assigns.port_definitions, &(&1 == ""))
 
     errors = %{}
     errors = if name == "", do: Map.put(errors, :name, "Name is required"), else: errors
@@ -130,7 +155,8 @@ defmodule DestilaWeb.CreateSessionLive do
           name: name,
           git_repo_url: git_repo_url,
           local_folder: local_folder,
-          run_command: run_command
+          run_command: run_command,
+          port_definitions: port_defs
         })
 
       {:noreply,
@@ -138,6 +164,7 @@ defmodule DestilaWeb.CreateSessionLive do
        |> assign(:project_id, project.id)
        |> assign(:projects, Destila.Projects.list_projects())
        |> assign(:project_step, :select)
+       |> assign(:port_definitions, [])
        |> assign(:errors, %{})}
     else
       {:noreply,
@@ -328,6 +355,7 @@ defmodule DestilaWeb.CreateSessionLive do
               step={@project_step}
               form={@project_form}
               errors={@errors}
+              port_definitions={@port_definitions}
               target={nil}
             />
           </div>

--- a/lib/destila_web/live/projects_live.ex
+++ b/lib/destila_web/live/projects_live.ex
@@ -18,6 +18,7 @@ defmodule DestilaWeb.ProjectsLive do
      |> assign(:editing_project_id, nil)
      |> assign(:form, new_form())
      |> assign(:errors, %{})
+     |> assign(:port_definitions, [])
      |> assign(:delete_confirming_id, nil)}
   end
 
@@ -27,7 +28,8 @@ defmodule DestilaWeb.ProjectsLive do
      |> assign(:creating, true)
      |> assign(:editing_project_id, nil)
      |> assign(:form, new_form())
-     |> assign(:errors, %{})}
+     |> assign(:errors, %{})
+     |> assign(:port_definitions, [])}
   end
 
   def handle_event("cancel", _params, socket) do
@@ -40,12 +42,13 @@ defmodule DestilaWeb.ProjectsLive do
       |> assign(:editing_project_id, nil)
       |> assign(:delete_confirming_id, nil)
       |> assign(:errors, %{})
+      |> assign(:port_definitions, [])
 
     {:noreply, socket}
   end
 
   def handle_event("create_project", params, socket) do
-    case validate_project_params(params) do
+    case validate_project_params(params, socket.assigns.port_definitions) do
       {:ok, attrs} ->
         {:ok, _project} = Destila.Projects.create_project(attrs)
 
@@ -53,7 +56,8 @@ defmodule DestilaWeb.ProjectsLive do
          socket
          |> assign(:creating, false)
          |> assign(:form, new_form())
-         |> assign(:errors, %{})}
+         |> assign(:errors, %{})
+         |> assign(:port_definitions, [])}
 
       {:error, errors} ->
         {:noreply,
@@ -71,7 +75,8 @@ defmodule DestilaWeb.ProjectsLive do
         to_form(%{
           "name" => project.name,
           "git_repo_url" => project.git_repo_url || "",
-          "local_folder" => project.local_folder || ""
+          "local_folder" => project.local_folder || "",
+          "run_command" => project.run_command || ""
         })
 
       {:noreply,
@@ -80,7 +85,8 @@ defmodule DestilaWeb.ProjectsLive do
        |> assign(:editing_project_id, id)
        |> assign(:creating, false)
        |> assign(:form, form)
-       |> assign(:errors, %{})}
+       |> assign(:errors, %{})
+       |> assign(:port_definitions, project.port_definitions)}
     else
       {:noreply, socket}
     end
@@ -89,7 +95,7 @@ defmodule DestilaWeb.ProjectsLive do
   def handle_event("update_project", params, socket) do
     id = socket.assigns.editing_project_id
 
-    case validate_project_params(params) do
+    case validate_project_params(params, socket.assigns.port_definitions) do
       {:ok, attrs} ->
         project = Destila.Projects.get_project!(id)
         {:ok, _project} = Destila.Projects.update_project(project, attrs)
@@ -98,7 +104,8 @@ defmodule DestilaWeb.ProjectsLive do
          socket
          |> assign(:editing_project_id, nil)
          |> assign(:form, new_form())
-         |> assign(:errors, %{})}
+         |> assign(:errors, %{})
+         |> assign(:port_definitions, [])}
 
       {:error, errors} ->
         project = Destila.Projects.get_project(id)
@@ -109,6 +116,39 @@ defmodule DestilaWeb.ProjectsLive do
          |> assign(:form, to_form(params))
          |> assign(:errors, errors)}
     end
+  end
+
+  def handle_event("validate_form", params, socket) do
+    port_definitions =
+      params
+      |> Enum.filter(fn {k, _} -> String.starts_with?(k, "port_def_") end)
+      |> Enum.sort_by(fn {k, _} -> k end)
+      |> Enum.map(fn {_, v} -> v end)
+
+    port_definitions =
+      if port_definitions == [], do: socket.assigns.port_definitions, else: port_definitions
+
+    {:noreply,
+     socket
+     |> assign(:form, to_form(params))
+     |> assign(:port_definitions, port_definitions)}
+  end
+
+  def handle_event("add_port", _params, socket) do
+    {:noreply, assign(socket, :port_definitions, socket.assigns.port_definitions ++ [""])}
+  end
+
+  def handle_event("remove_port", %{"index" => index}, socket) do
+    index = String.to_integer(index)
+    port_definitions = List.delete_at(socket.assigns.port_definitions, index)
+    {:noreply, assign(socket, :port_definitions, port_definitions)}
+  end
+
+  def handle_event("update_port", params, socket) do
+    index = String.to_integer(params["index"])
+    value = params["value"] || ""
+    port_definitions = List.replace_at(socket.assigns.port_definitions, index, value)
+    {:noreply, assign(socket, :port_definitions, port_definitions)}
   end
 
   def handle_event("confirm_delete", %{"id" => id}, socket) do
@@ -190,29 +230,54 @@ defmodule DestilaWeb.ProjectsLive do
   end
 
   defp new_form do
-    to_form(%{"name" => "", "git_repo_url" => "", "local_folder" => ""})
+    to_form(%{"name" => "", "git_repo_url" => "", "local_folder" => "", "run_command" => ""})
   end
 
-  defp validate_project_params(params) do
+  defp validate_project_params(params, port_definitions) do
     name = String.trim(params["name"] || "")
     git_repo_url = params["git_repo_url"]
     git_repo_url = if git_repo_url && git_repo_url != "", do: git_repo_url, else: nil
     local_folder = params["local_folder"]
     local_folder = if local_folder && local_folder != "", do: local_folder, else: nil
+    run_command = params["run_command"]
+    run_command = if run_command && run_command != "", do: run_command, else: nil
+
+    # Filter empty port definitions
+    port_defs = Enum.reject(port_definitions, &(&1 == ""))
 
     errors = %{}
     errors = if name == "", do: Map.put(errors, :name, "Name is required"), else: errors
 
     errors =
       if git_repo_url == nil && local_folder == nil do
-        errors
-        |> Map.put(:location, "Provide at least one")
+        Map.put(errors, :location, "Provide at least one")
       else
         errors
       end
 
+    # Validate port definitions format
+    errors =
+      Enum.reduce(port_defs, errors, fn pd, acc ->
+        if Regex.match?(~r/^[A-Z][A-Z0-9_]*$/, pd) do
+          acc
+        else
+          Map.put(
+            acc,
+            :port_definitions,
+            "#{pd} is not a valid env var name (use uppercase, e.g. PORT)"
+          )
+        end
+      end)
+
     if errors == %{} do
-      {:ok, %{name: name, git_repo_url: git_repo_url, local_folder: local_folder}}
+      {:ok,
+       %{
+         name: name,
+         git_repo_url: git_repo_url,
+         local_folder: local_folder,
+         run_command: run_command,
+         port_definitions: port_defs
+       }}
     else
       {:error, errors}
     end
@@ -255,6 +320,7 @@ defmodule DestilaWeb.ProjectsLive do
               errors={@errors}
               submit_event="create_project"
               submit_label="Create"
+              port_definitions={@port_definitions}
             >
               <button phx-click="cancel" type="button" class="btn btn-ghost btn-sm flex-1">
                 Cancel
@@ -291,6 +357,7 @@ defmodule DestilaWeb.ProjectsLive do
                 errors={@errors}
                 submit_event="update_project"
                 submit_label="Save"
+                port_definitions={@port_definitions}
               >
                 <button phx-click="cancel" type="button" class="btn btn-ghost btn-sm flex-1">
                   Cancel
@@ -314,6 +381,13 @@ defmodule DestilaWeb.ProjectsLive do
                     <span :if={project.local_folder} class="text-xs text-base-content/40 truncate">
                       <.icon name="hero-folder-micro" class="size-3.5 inline" />
                       {project.local_folder}
+                    </span>
+                    <span
+                      :if={project.run_command}
+                      class="text-xs text-base-content/40 truncate"
+                    >
+                      <.icon name="hero-play-micro" class="size-3.5 inline" />
+                      {project.run_command}
                     </span>
                   </div>
                 </div>
@@ -368,12 +442,14 @@ defmodule DestilaWeb.ProjectsLive do
   attr :errors, :map, required: true
   attr :submit_event, :string, required: true
   attr :submit_label, :string, required: true
+  attr :port_definitions, :list, required: true
   slot :inner_block
 
   defp project_form(assigns) do
     ~H"""
     <form
       phx-submit={@submit_event}
+      phx-change="validate_form"
       class="space-y-3"
       id={"project-form-#{@submit_event}"}
       phx-hook="FocusFirstError"
@@ -450,6 +526,76 @@ defmodule DestilaWeb.ProjectsLive do
         </fieldset>
 
         <p :if={@errors[:location]} class="text-xs text-error">{@errors[:location]}</p>
+      </div>
+
+      <div class="rounded-lg p-3 space-y-3 bg-base-200/50">
+        <div class="flex items-center gap-2">
+          <span class="text-xs font-medium text-base-content/50">Service</span>
+          <span class="text-xs text-base-content/30">optional</span>
+        </div>
+
+        <fieldset class="fieldset">
+          <label class="fieldset-label text-xs font-medium" for="project-run-command">
+            Run command
+          </label>
+          <input
+            type="text"
+            id="project-run-command"
+            name="run_command"
+            value={@form["run_command"].value}
+            placeholder="mix setup && mix phx.server"
+            class="input input-bordered w-full input-sm"
+          />
+        </fieldset>
+
+        <div>
+          <div class="flex items-center justify-between mb-2">
+            <label class="text-xs font-medium text-base-content/70">Port definitions</label>
+            <button
+              type="button"
+              phx-click="add_port"
+              class="btn btn-ghost btn-xs"
+              id="add-port-btn"
+            >
+              <.icon name="hero-plus-micro" class="size-3" /> Add port
+            </button>
+          </div>
+
+          <div :if={@port_definitions != []} class="space-y-2">
+            <div
+              :for={{pd, idx} <- Enum.with_index(@port_definitions)}
+              class="flex items-center gap-2"
+              id={"port-def-#{idx}"}
+            >
+              <input
+                type="text"
+                name={"port_def_#{idx}"}
+                value={pd}
+                placeholder="PORT"
+                phx-blur="update_port"
+                phx-value-index={idx}
+                class={[
+                  "input input-bordered w-full input-sm font-mono uppercase",
+                  @errors[:port_definitions] && "input-error"
+                ]}
+                id={"port-input-#{idx}"}
+              />
+              <button
+                type="button"
+                phx-click="remove_port"
+                phx-value-index={idx}
+                class="btn btn-ghost btn-xs text-error/60 hover:text-error"
+                id={"remove-port-#{idx}"}
+              >
+                <.icon name="hero-x-mark-micro" class="size-4" />
+              </button>
+            </div>
+          </div>
+
+          <p :if={@errors[:port_definitions]} class="text-xs text-error mt-1">
+            {@errors[:port_definitions]}
+          </p>
+        </div>
       </div>
 
       <div class="flex gap-2">

--- a/lib/destila_web/live/terminal_live.ex
+++ b/lib/destila_web/live/terminal_live.ex
@@ -46,7 +46,7 @@ defmodule DestilaWeb.TerminalLive do
       TerminalServer.start_link(
         cwd: ai_session.worktree_path,
         topic: "terminal:#{ws.id}",
-        session_name: ws.title,
+        session_name: Destila.Terminal.Tmux.session_name(ws),
         claude_session_id: ai_session.claude_session_id
       )
 

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -685,7 +685,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
                         />
                       </span>
                       <span class="text-sm text-base-content/60 truncate flex-1">
-                        Source Code
+                        Terminal
                       </span>
                       <.icon
                         name="hero-arrow-top-right-on-square-micro"

--- a/priv/repo/migrations/20260414000000_add_service_fields.exs
+++ b/priv/repo/migrations/20260414000000_add_service_fields.exs
@@ -1,0 +1,14 @@
+defmodule Destila.Repo.Migrations.AddServiceFields do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      add :run_command, :string
+      add :port_definitions, :string, default: "[]"
+    end
+
+    alter table(:workflow_sessions) do
+      add :service_state, :map
+    end
+  end
+end

--- a/test/destila/projects/project_test.exs
+++ b/test/destila/projects/project_test.exs
@@ -1,0 +1,99 @@
+defmodule Destila.Projects.ProjectTest do
+  use DestilaWeb.ConnCase, async: false
+
+  alias Destila.Projects.Project
+
+  @valid_attrs %{name: "Test Project", git_repo_url: "https://github.com/test/repo"}
+
+  describe "changeset/2 with run_command and port_definitions" do
+    test "accepts valid run_command and port_definitions" do
+      changeset =
+        Project.changeset(
+          %Project{},
+          Map.merge(@valid_attrs, %{
+            run_command: "mix phx.server",
+            port_definitions: ["PORT", "API_PORT"]
+          })
+        )
+
+      assert changeset.valid?
+    end
+
+    test "accepts nil run_command and empty port_definitions" do
+      changeset = Project.changeset(%Project{}, @valid_attrs)
+      assert changeset.valid?
+    end
+
+    test "rejects port definition with lowercase letters" do
+      changeset =
+        Project.changeset(
+          %Project{},
+          Map.merge(@valid_attrs, %{
+            port_definitions: ["my_port"]
+          })
+        )
+
+      refute changeset.valid?
+
+      assert {"my_port must start with A-Z and contain only uppercase letters, digits, and underscores",
+              _} = changeset.errors[:port_definitions]
+    end
+
+    test "rejects port definition starting with digit" do
+      changeset =
+        Project.changeset(
+          %Project{},
+          Map.merge(@valid_attrs, %{
+            port_definitions: ["123"]
+          })
+        )
+
+      refute changeset.valid?
+    end
+
+    test "rejects port definition with special characters" do
+      changeset =
+        Project.changeset(
+          %Project{},
+          Map.merge(@valid_attrs, %{
+            port_definitions: ["MY-PORT"]
+          })
+        )
+
+      refute changeset.valid?
+    end
+
+    test "accepts valid underscore names" do
+      changeset =
+        Project.changeset(
+          %Project{},
+          Map.merge(@valid_attrs, %{
+            port_definitions: ["DB_PORT", "PORT_3000", "A"]
+          })
+        )
+
+      assert changeset.valid?
+    end
+
+    test "rejects reserved system env var names" do
+      changeset =
+        Project.changeset(
+          %Project{},
+          Map.merge(@valid_attrs, %{
+            port_definitions: ["PATH"]
+          })
+        )
+
+      refute changeset.valid?
+
+      assert {"PATH is a reserved system environment variable", _} =
+               changeset.errors[:port_definitions]
+    end
+
+    test "existing validations still pass unchanged" do
+      changeset = Project.changeset(%Project{}, %{name: "Test"})
+      refute changeset.valid?
+      assert changeset.errors[:git_repo_url]
+    end
+  end
+end

--- a/test/destila_web/live/projects_live_test.exs
+++ b/test/destila_web/live/projects_live_test.exs
@@ -165,6 +165,81 @@ defmodule DestilaWeb.ProjectsLiveTest do
     end
   end
 
+  describe "run configuration" do
+    @tag feature: @feature, scenario: "Create a project with run command and port definitions"
+    test "creates a project with run command and port definitions", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      view |> element("#new-project-btn") |> render_click()
+
+      # Add a port definition
+      view |> element("#add-port-btn") |> render_click()
+      assert has_element?(view, "#port-input-0")
+
+      view
+      |> form("#project-form-create_project", %{
+        "name" => "Service Project",
+        "git_repo_url" => "https://github.com/test/service",
+        "run_command" => "mix phx.server"
+      })
+      |> render_submit()
+
+      html = render(view)
+      assert html =~ "Service Project"
+      assert html =~ "mix phx.server"
+    end
+
+    @tag feature: @feature, scenario: "Edit a project's run configuration"
+    test "edits a project's run configuration", %{conn: conn} do
+      {:ok, project} =
+        Destila.Projects.create_project(%{
+          name: "Run Config Project",
+          git_repo_url: "https://github.com/test/repo",
+          run_command: "npm start"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      view |> element("#edit-project-#{project.id}") |> render_click()
+
+      # Verify run command is pre-filled
+      assert has_element?(view, "#project-run-command")
+
+      view
+      |> form("#project-form-update_project", %{
+        "run_command" => "mix phx.server"
+      })
+      |> render_submit()
+
+      html = render(view)
+      assert html =~ "mix phx.server"
+    end
+
+    @tag feature: @feature,
+         scenario: "Port definitions require a valid environment variable name"
+    test "shows error for invalid port definition name", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      view |> element("#new-project-btn") |> render_click()
+
+      # Add a port and set an invalid value
+      view |> element("#add-port-btn") |> render_click()
+
+      view
+      |> element("#port-input-0")
+      |> render_blur(%{"index" => "0", "value" => "invalid-port"})
+
+      view
+      |> form("#project-form-create_project", %{
+        "name" => "Bad Port Project",
+        "git_repo_url" => "https://github.com/test/repo"
+      })
+      |> render_submit()
+
+      assert render(view) =~ "not a valid env var name"
+    end
+  end
+
   describe "delete project" do
     @tag feature: @feature, scenario: "Delete a project not linked to any sessions"
     test "deletes a project not linked to sessions", %{conn: conn} do


### PR DESCRIPTION
## Summary

- Projects can now define a **run command** and **port definitions** (environment variable names for dynamically assigned ports)
- New `service` MCP tool lets the AI agent **start, stop, restart, and check status** of the project's development server
- The tool executes directly via `execute/2` with frame context — returns real port mappings and status in the tool result, no placeholder replacement
- Service runs in tmux window index 9, with SIGTERM-based process termination
- Shared `Terminal.Tmux` module provides tmux primitives used by both `Terminal.Server` and `ServiceManager`
- Project management UI (dedicated page + inline wizard) updated with run command and port definition fields
- Session archival stops the service and cleans up the tmux window

## Architecture

```
AI Agent calls service tool
  → execute/2 reads workflow_session_id from frame.assigns
  → ServiceManager.execute/3
    → reserves ports via :gen_tcp
    → manages tmux window 9 via Terminal.Tmux
    → persists state to workflow_session.service_state
  → returns JSON with port mappings to AI immediately
```

## Test plan

- [x] 27 tests pass (project schema, projects LiveView, inline creation)
- [x] Compilation passes with `--warnings-as-errors`
- [x] Manual verification of service start/stop via tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)