### PR TITLE
feat: Add service status item to workflow session sidebar

### DIFF
--- a/docs/plans/2026-04-14-003-feat-service-status-sidebar-plan.md
+++ b/docs/plans/2026-04-14-003-feat-service-status-sidebar-plan.md
@@ -1,0 +1,201 @@
+---
+title: "feat: Add service status item to workflow session sidebar"
+type: feat
+status: active
+date: 2026-04-14
+---
+
+# feat: Add service status item to workflow session sidebar
+
+## Overview
+
+Add a "Service" item to the right sidebar's "Workflow Session" section in `WorkflowRunnerLive`, alongside the existing "User Prompt" and "Terminal" items. The item reflects whether the project's development service is running or stopped, with conditional link behavior that opens the service in a new browser tab when running.
+
+## Problem Frame
+
+After the project service management feature shipped (plan 001), there is no UI indicator for the service's current state. Users have no way to know whether the service is running or to quickly open it in a browser. Adding a sidebar item makes service state visible and actionable.
+
+## Requirements Trace
+
+- R1. Show a "Service" item in the sidebar when the project has a `run_command` configured
+- R2. Show a disabled/grayed-out "Service" item when no `run_command` is configured, indicating the feature exists but isn't set up
+- R3. Icon color reflects service status: green when running, muted/gray when stopped or nil
+- R4. When running and port is available, render as an `<a target="_blank">` link to `http://localhost:<port>` using the first port from `project.port_definitions` resolved against `service_state["ports"]`
+- R5. When stopped (or no port available), render as a static non-clickable element
+- R6. Real-time updates happen automatically via existing `handle_info({:workflow_session_updated, ws}, ...)`
+- R7. Handle edge cases: nil `service_state`, empty `port_definitions`, port not yet assigned
+
+## Scope Boundaries
+
+- No changes to `ServiceManager`, schemas, or PubSub plumbing — all data flows already exist
+- No new assigns needed — `@project` and `@workflow_session` are already available in the template
+- No new `handle_event` clauses — the link is a plain `<a>` tag, not a LiveView event
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Sidebar location**: `lib/destila_web/live/workflow_runner_live.ex` lines 647-696, inside `#user-prompt-section > div.space-y-0.5`
+- **User Prompt item** (lines 652-673): `<button>` with `phx-click`, eye icon trailing — always rendered
+- **Terminal item** (lines 674-694): `<.link>` with `navigate`, arrow icon trailing — conditionally rendered via `:if={@worktree_path}`
+- **Project schema** (`lib/destila/projects/project.ex`): `run_command` (string, nullable), `port_definitions` (`{:array, :string}`, default `[]`)
+- **Session schema** (`lib/destila/workflows/session.ex`): `service_state` (map, nullable) — values: `nil`, `%{"status" => "running", "ports" => %{...}}`, `%{"status" => "stopped", ...}`
+- **Mount** (`workflow_runner_live.ex` lines 48-50): `@project` is loaded from `workflow_session.project_id`
+- **Real-time flow**: `ServiceManager` → `Workflows.update_workflow_session/2` → PubSub broadcast → `handle_info` re-fetches session → template re-renders
+
+### Institutional Learnings
+
+- All sidebar items follow a consistent visual pattern: full-width row, leading icon in `span.size-5`, label in `span.text-sm`, trailing action icon
+- Test files for sidebar items (`user_prompt_sidebar_live_test.exs`, `open_terminal_live_test.exs`) use dedicated test modules per feature with `has_element?` assertions on DOM IDs
+- Conditional sidebar items use `:if={}` on the element itself
+
+## Key Technical Decisions
+
+- **Always render the item, conditionally style it**: Show the Service item regardless of `run_command` presence. When no `run_command` exists, render a disabled/muted static element. This teaches users the feature exists.
+- **Conditional element type based on status**: When running with a resolvable port, render as `<a href="..." target="_blank">`. When stopped or no port, render as a `<div>`. Use `<%= if ... %>` to switch between the two elements.
+- **Port resolution via helper function**: Extract a private `service_url/2` function that takes `project` and `service_state`, finds the first entry from `project.port_definitions` in `service_state["ports"]`, and returns either a URL string (`http://localhost:<port>`) or nil. This keeps the template clean.
+- **Icon**: Use `hero-server-micro` — semantically fits "service/server" and is available in the Heroicons micro set.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Which icon?**: `hero-server-micro` — conveys "service" clearly and matches the micro icon style used by other sidebar items.
+- **Where to put the helper?**: Inline in the LiveView module as a private function, following the pattern of existing helpers like `assign_worktree_path/2`.
+
+### Deferred to Implementation
+
+- None — all planning-time questions resolved.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add Gherkin feature file**
+
+**Goal:** Create the feature file documenting service status sidebar scenarios.
+
+**Requirements:** All (R1-R7)
+
+**Dependencies:** None
+
+**Files:**
+- Create: `features/service_status_sidebar.feature`
+
+**Approach:**
+- Write the 7 Gherkin scenarios from the user prompt verbatim
+
+**Patterns to follow:**
+- Existing feature files in `features/` (e.g., `features/exported_metadata.feature`)
+
+**Test expectation:** none — this is a documentation artifact
+
+**Verification:**
+- Feature file exists and covers all 7 scenarios
+
+---
+
+- [ ] **Unit 2: Add service status item to sidebar template**
+
+**Goal:** Render the Service item in the sidebar with correct conditional behavior for all states.
+
+**Requirements:** R1, R2, R3, R4, R5, R7
+
+**Dependencies:** None (data already flows)
+
+**Files:**
+- Modify: `lib/destila_web/live/workflow_runner_live.ex`
+
+**Approach:**
+- Add a private `service_url/2` function that takes `project` and `service_state`, returns `"http://localhost:<port>"` or nil. Resolves port by finding the first entry from `project.port_definitions` in `service_state["ports"]`.
+- Insert the Service item after the Terminal link (after line 694), before `</div>` closing the `space-y-0.5` container.
+- Use `<%= if @project do %>` to gate rendering entirely (no project = no service item), then nest `<%= if @project.run_command do %>` to split between configured and unconfigured states.
+- When configured, derive `service_running?` from `@workflow_session.service_state["status"] == "running"` and `url` from `service_url(@project, @workflow_session.service_state)`.
+- When running + URL available: render `<a id="service-status-link" href={url} target="_blank" ...>` with green icon and arrow trailing icon.
+- When running + no URL (empty port_definitions): render `<div id="service-status-item" ...>` with green icon but not clickable.
+- When stopped/nil: render `<div id="service-status-item" ...>` with muted icon.
+- When no `run_command`: render `<div id="service-status-item" ...>` with fully muted styling and a tooltip indicating no run command is configured.
+- Icon color: `text-green-500` when running, `text-base-content/30` when stopped/nil, `text-base-content/20` when no run command.
+- Follow the exact class pattern from User Prompt and Terminal items.
+
+**Patterns to follow:**
+- Terminal link conditional rendering (`:if={@worktree_path}`)
+- Sidebar item CSS classes: `w-full flex items-center gap-2.5 px-2 py-1.5 rounded-md ...`
+- Leading icon: `span.size-5.rounded.flex.items-center.justify-center.shrink-0` with `<.icon name="hero-server-micro" class="size-3.5 ...">`
+
+**Test scenarios:**
+- Happy path: project with `run_command` and running service with ports → renders as clickable link with green icon and correct href
+- Happy path: project with `run_command` and stopped service → renders as static div with muted icon
+- Edge case: project with `run_command` but `service_state` is nil → renders as static div with muted icon
+- Edge case: project with `run_command`, running service, but empty `port_definitions` → renders as static div (not link) with green icon
+- Edge case: project with `run_command`, running service, port_definitions has entries but ports map doesn't contain first key → renders as static div with green icon
+- Edge case: no project (nil) → service item not rendered at all
+- Happy path: project without `run_command` → renders disabled item with muted styling
+
+**Verification:**
+- Service item appears in the sidebar in all expected states
+- Link href is correct when service is running with ports
+- Item is not clickable when stopped
+- Disabled state visible when no run command
+
+---
+
+- [ ] **Unit 3: Write LiveView tests**
+
+**Goal:** Test all service status sidebar states.
+
+**Requirements:** R1-R7
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Create: `test/destila_web/live/service_status_sidebar_live_test.exs`
+
+**Approach:**
+- Follow the pattern from `user_prompt_sidebar_live_test.exs` and `open_terminal_live_test.exs`.
+- Create helper functions to build projects with/without `run_command` and `port_definitions`, and sessions with/without `service_state`.
+- Set `service_state` directly on the workflow session via `Destila.Workflows.update_workflow_session/2` — no need for ServiceManager.
+- Test element presence/absence using `has_element?` with DOM IDs.
+- Test link href using selector `#service-status-link[href="..."]`.
+- Test icon classes using selectors.
+- Test real-time update by broadcasting a PubSub message and asserting the DOM changes.
+
+**Patterns to follow:**
+- `test/destila_web/live/user_prompt_sidebar_live_test.exs` — module structure, setup, helpers, assertions
+- `test/destila_web/live/open_terminal_live_test.exs` — testing link href with selector
+
+**Test scenarios:**
+- Happy path: Service item visible when project has run_command → `has_element?(view, "#service-status-item")` or `has_element?(view, "#service-status-link")`
+- Happy path: Service item disabled when project has no run_command → `has_element?(view, "#service-status-item")` with disabled indicator, `refute has_element?(view, "#service-status-link")`
+- Happy path: Service icon muted when stopped → icon element has muted class
+- Happy path: Service icon green when running → icon element has green class
+- Happy path: Running service link href points to correct port → `has_element?(view, ~s|#service-status-link[href="http://localhost:4000"]|)`
+- Edge case: Service item not clickable when stopped → `refute has_element?(view, "#service-status-link")`
+- Edge case: nil service_state treated as stopped → same assertions as stopped
+- Edge case: empty port_definitions, running service → no link element, has green icon
+- Integration: Real-time update changes icon color → update session service_state via PubSub broadcast, assert DOM changes
+
+**Verification:**
+- All tests pass
+- Tests cover all 7 Gherkin scenarios with `@tag feature:` and `@tag scenario:` annotations
+
+## System-Wide Impact
+
+- **Interaction graph:** Only the `WorkflowRunnerLive` template changes. No callbacks, middleware, or entry points affected.
+- **Error propagation:** No new error paths — all data access is on already-loaded assigns.
+- **State lifecycle risks:** None — `service_state` is read-only in this context, written by `ServiceManager` through an existing flow.
+- **API surface parity:** No other interfaces need this change.
+- **Integration coverage:** The real-time update test covers the PubSub → LiveView → template re-render flow.
+- **Unchanged invariants:** `ServiceManager`, project/session schemas, PubSub broadcasting all remain unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `@project` could be nil if session has no project | Guard with `@project && @project.run_command` before rendering the configured state |
+| `service_state["ports"]` map key ordering | Always use `project.port_definitions` (ordered list) to determine first port |
+| `hero-server-micro` icon may not exist in current Heroicon set | Verify during implementation; fall back to `hero-server-stack-micro` if needed |
+
+## Sources & References
+
+- Related plan: `docs/plans/2026-04-14-001-feat-project-service-management-plan.md`
+- Sidebar pattern: `docs/plans/2026-04-09-feat-user-prompt-sidebar-plan.md`
+- Terminal item pattern: `docs/plans/2026-04-09-feat-open-terminal-button-plan.md`

--- a/docs/plans/2026-04-14-003-feat-service-status-sidebar-plan.md
+++ b/docs/plans/2026-04-14-003-feat-service-status-sidebar-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Add service status item to workflow session sidebar"
 type: feat
-status: active
+status: completed
 date: 2026-04-14
 ---
 

--- a/features/service_status_sidebar.feature
+++ b/features/service_status_sidebar.feature
@@ -1,0 +1,43 @@
+Feature: Service Status Sidebar
+  The workflow session sidebar displays a "Service" item that reflects whether
+  the project's development service is running or stopped, with conditional
+  link behavior that opens the service in a new browser tab when running.
+
+  Scenario: Service item visible when project has run_command
+    Given I am on a session detail page
+    And the session's project has a run_command configured
+    Then I should see a "Service" item in the sidebar
+
+  Scenario: Service item disabled when no run_command configured
+    Given I am on a session detail page
+    And the session's project has no run_command configured
+    Then I should see a disabled "Service" item in the sidebar
+    And the item should indicate the feature is not set up
+
+  Scenario: Service icon is green when service is running
+    Given I am on a session detail page
+    And the session's service_state status is "running"
+    Then the service icon should be green
+
+  Scenario: Service icon is muted when service is stopped
+    Given I am on a session detail page
+    And the session's service_state status is "stopped"
+    Then the service icon should be muted/gray
+
+  Scenario: Running service with port is a clickable link
+    Given I am on a session detail page
+    And the session's service_state status is "running"
+    And the project has port_definitions and ports are assigned
+    Then the service item should be a link to http://localhost:<port>
+    And the link should open in a new browser tab
+
+  Scenario: Stopped service is not clickable
+    Given I am on a session detail page
+    And the session's service_state status is "stopped"
+    Then the service item should not be a clickable link
+
+  Scenario: Nil service_state treated as stopped
+    Given I am on a session detail page
+    And the session's service_state is nil
+    Then the service item should not be a clickable link
+    And the service icon should be muted/gray

--- a/features/service_status_sidebar.feature
+++ b/features/service_status_sidebar.feature
@@ -41,3 +41,21 @@ Feature: Service Status Sidebar
     And the session's service_state is nil
     Then the service item should not be a clickable link
     And the service icon should be muted/gray
+
+  Scenario: Service item hidden when session has no project
+    Given I am on a session detail page
+    And the session has no project assigned
+    Then no service item should appear in the sidebar
+
+  Scenario: Running service without available port shows green icon
+    Given I am on a session detail page
+    And the session's service_state status is "running"
+    And the project has empty port_definitions or the port is not yet assigned
+    Then the service item should not be a clickable link
+    But the service icon should still be green
+
+  Scenario: Service status updates in real-time
+    Given I am on a session detail page
+    And the session's service_state changes from stopped to running
+    Then the service item should update to reflect the new state
+    And the service link should become clickable with the correct port

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -692,6 +692,74 @@ defmodule DestilaWeb.WorkflowRunnerLive do
                         class="size-3.5 text-base-content/30 group-hover:text-primary transition-colors"
                       />
                     </.link>
+                    <%= if @project do %>
+                      <% service_running? = @workflow_session.service_state["status"] == "running" %>
+                      <% url = service_url(@project, @workflow_session.service_state) %>
+                      <%= if @project.run_command do %>
+                        <%= if url do %>
+                          <a
+                            id="service-status-link"
+                            href={url}
+                            target="_blank"
+                            class="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-md hover:bg-base-200/60 transition-colors duration-150 group"
+                            aria-label="Open service"
+                          >
+                            <span class="size-5 rounded flex items-center justify-center shrink-0">
+                              <.icon
+                                name="hero-server-micro"
+                                class="size-3.5 text-green-500"
+                              />
+                            </span>
+                            <span class="text-sm text-base-content/60 truncate flex-1 text-left">
+                              Service
+                            </span>
+                            <.icon
+                              name="hero-arrow-top-right-on-square-micro"
+                              class="size-3.5 text-base-content/30 group-hover:text-primary transition-colors"
+                            />
+                          </a>
+                        <% else %>
+                          <div
+                            id="service-status-item"
+                            class="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-md"
+                            aria-label="Service status"
+                          >
+                            <span class="size-5 rounded flex items-center justify-center shrink-0">
+                              <.icon
+                                name="hero-server-micro"
+                                class={[
+                                  "size-3.5",
+                                  if(service_running?,
+                                    do: "text-green-500",
+                                    else: "text-base-content/30"
+                                  )
+                                ]}
+                              />
+                            </span>
+                            <span class="text-sm text-base-content/60 truncate flex-1 text-left">
+                              Service
+                            </span>
+                          </div>
+                        <% end %>
+                      <% else %>
+                        <div
+                          id="service-status-item"
+                          class="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-md opacity-40"
+                          aria-label="Service not configured"
+                          title="No run command configured"
+                        >
+                          <span class="size-5 rounded flex items-center justify-center shrink-0">
+                            <.icon
+                              name="hero-server-micro"
+                              class="size-3.5 text-base-content/20"
+                            />
+                          </span>
+                          <span class="text-sm text-base-content/60 truncate flex-1 text-left">
+                            Service
+                          </span>
+                        </div>
+                      <% end %>
+                    <% end %>
                   </div>
                 </div>
 
@@ -999,6 +1067,19 @@ defmodule DestilaWeb.WorkflowRunnerLive do
     |> assign(:metadata, Enum.reduce(all, %{}, fn m, acc -> Map.put(acc, m.key, m.value) end))
     |> assign(:exported_metadata, Enum.filter(all, & &1.exported))
   end
+
+  defp service_url(%{port_definitions: [first_port | _]}, %{
+         "status" => "running",
+         "ports" => ports
+       })
+       when is_map(ports) do
+    case Map.get(ports, first_port) do
+      nil -> nil
+      port -> "http://localhost:#{port}"
+    end
+  end
+
+  defp service_url(_project, _service_state), do: nil
 
   defp assign_worktree_path(socket, ws_id) do
     ai_session = AI.get_ai_session_for_workflow(ws_id)

--- a/test/destila_web/live/service_status_sidebar_live_test.exs
+++ b/test/destila_web/live/service_status_sidebar_live_test.exs
@@ -72,8 +72,11 @@ defmodule DestilaWeb.ServiceStatusSidebarLiveTest do
 
       assert has_element?(view, "#service-status-item")
       refute has_element?(view, "#service-status-link")
+      assert has_element?(view, "#service-status-item .text-base-content\\/20")
     end
 
+    @tag feature: "service_status_sidebar",
+         scenario: "Service item hidden when session has no project"
     test "does not show service item when session has no project", %{conn: conn} do
       ws = create_session(%{project_id: nil})
       {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
@@ -162,6 +165,8 @@ defmodule DestilaWeb.ServiceStatusSidebarLiveTest do
       refute has_element?(view, "#service-status-link")
     end
 
+    @tag feature: "service_status_sidebar",
+         scenario: "Running service without available port shows green icon"
     test "renders static element when running but port_definitions is empty", %{conn: conn} do
       project = create_project(%{run_command: "mix phx.server", port_definitions: []})
 
@@ -175,8 +180,11 @@ defmodule DestilaWeb.ServiceStatusSidebarLiveTest do
 
       assert has_element?(view, "#service-status-item")
       refute has_element?(view, "#service-status-link")
+      assert has_element?(view, "#service-status-item .text-green-500")
     end
 
+    @tag feature: "service_status_sidebar",
+         scenario: "Running service without available port shows green icon"
     test "renders static element when running but first port not in ports map", %{conn: conn} do
       project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
 
@@ -190,12 +198,13 @@ defmodule DestilaWeb.ServiceStatusSidebarLiveTest do
 
       assert has_element?(view, "#service-status-item")
       refute has_element?(view, "#service-status-link")
+      assert has_element?(view, "#service-status-item .text-green-500")
     end
   end
 
   describe "real-time updates" do
     @tag feature: "service_status_sidebar",
-         scenario: "Service icon is green when service is running"
+         scenario: "Service status updates in real-time"
     test "updates when service state changes via PubSub", %{conn: conn} do
       project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
       ws = create_session(%{project_id: project.id, service_state: nil})

--- a/test/destila_web/live/service_status_sidebar_live_test.exs
+++ b/test/destila_web/live/service_status_sidebar_live_test.exs
@@ -1,0 +1,217 @@
+defmodule DestilaWeb.ServiceStatusSidebarLiveTest do
+  @moduledoc """
+  LiveView tests for Service status item in sidebar.
+  Feature: features/service_status_sidebar.feature
+  """
+  use DestilaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  setup %{conn: conn} do
+    ClaudeCode.Test.set_mode_to_shared()
+
+    ClaudeCode.Test.stub(ClaudeCode, fn _query, _opts ->
+      [
+        ClaudeCode.Test.text("AI response"),
+        ClaudeCode.Test.result("AI response")
+      ]
+    end)
+
+    {:ok, conn: conn}
+  end
+
+  defp create_project(attrs) do
+    {:ok, project} =
+      Destila.Projects.create_project(
+        Map.merge(
+          %{name: "Test Project", local_folder: System.tmp_dir!()},
+          attrs
+        )
+      )
+
+    project
+  end
+
+  defp create_session(attrs) do
+    {:ok, ws} =
+      Destila.Workflows.insert_workflow_session(
+        Map.merge(
+          %{
+            title: "Test Session",
+            workflow_type: :brainstorm_idea,
+            project_id: nil,
+            done_at: DateTime.utc_now(),
+            current_phase: 4,
+            total_phases: 4
+          },
+          attrs
+        )
+      )
+
+    ws
+  end
+
+  describe "service item visibility" do
+    @tag feature: "service_status_sidebar",
+         scenario: "Service item visible when project has run_command"
+    test "shows service item when project has run_command", %{conn: conn} do
+      project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
+      ws = create_session(%{project_id: project.id})
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      assert has_element?(view, "#service-status-item") or
+               has_element?(view, "#service-status-link")
+    end
+
+    @tag feature: "service_status_sidebar",
+         scenario: "Service item disabled when no run_command configured"
+    test "shows disabled service item when project has no run_command", %{conn: conn} do
+      project = create_project(%{run_command: nil})
+      ws = create_session(%{project_id: project.id})
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      assert has_element?(view, "#service-status-item")
+      refute has_element?(view, "#service-status-link")
+    end
+
+    test "does not show service item when session has no project", %{conn: conn} do
+      ws = create_session(%{project_id: nil})
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      refute has_element?(view, "#service-status-item")
+      refute has_element?(view, "#service-status-link")
+    end
+  end
+
+  describe "service icon color" do
+    @tag feature: "service_status_sidebar",
+         scenario: "Service icon is green when service is running"
+    test "icon is green when service is running", %{conn: conn} do
+      project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
+
+      ws =
+        create_session(%{
+          project_id: project.id,
+          service_state: %{"status" => "running", "ports" => %{"PORT" => 4000}}
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      assert has_element?(view, "#service-status-link .text-green-500")
+    end
+
+    @tag feature: "service_status_sidebar",
+         scenario: "Service icon is muted when service is stopped"
+    test "icon is muted when service is stopped", %{conn: conn} do
+      project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
+
+      ws =
+        create_session(%{
+          project_id: project.id,
+          service_state: %{"status" => "stopped"}
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      assert has_element?(view, "#service-status-item .text-base-content\\/30")
+    end
+
+    @tag feature: "service_status_sidebar",
+         scenario: "Nil service_state treated as stopped"
+    test "icon is muted when service_state is nil", %{conn: conn} do
+      project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
+      ws = create_session(%{project_id: project.id, service_state: nil})
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      assert has_element?(view, "#service-status-item .text-base-content\\/30")
+    end
+  end
+
+  describe "service link behavior" do
+    @tag feature: "service_status_sidebar",
+         scenario: "Running service with port is a clickable link"
+    test "renders link with correct href when running with port", %{conn: conn} do
+      project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
+
+      ws =
+        create_session(%{
+          project_id: project.id,
+          service_state: %{"status" => "running", "ports" => %{"PORT" => 4000}}
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      assert has_element?(view, ~s|#service-status-link[href="http://localhost:4000"]|)
+      assert has_element?(view, ~s|#service-status-link[target="_blank"]|)
+    end
+
+    @tag feature: "service_status_sidebar",
+         scenario: "Stopped service is not clickable"
+    test "renders static element when stopped", %{conn: conn} do
+      project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
+
+      ws =
+        create_session(%{
+          project_id: project.id,
+          service_state: %{"status" => "stopped"}
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      assert has_element?(view, "#service-status-item")
+      refute has_element?(view, "#service-status-link")
+    end
+
+    test "renders static element when running but port_definitions is empty", %{conn: conn} do
+      project = create_project(%{run_command: "mix phx.server", port_definitions: []})
+
+      ws =
+        create_session(%{
+          project_id: project.id,
+          service_state: %{"status" => "running", "ports" => %{}}
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      assert has_element?(view, "#service-status-item")
+      refute has_element?(view, "#service-status-link")
+    end
+
+    test "renders static element when running but first port not in ports map", %{conn: conn} do
+      project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
+
+      ws =
+        create_session(%{
+          project_id: project.id,
+          service_state: %{"status" => "running", "ports" => %{"OTHER" => 5000}}
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      assert has_element?(view, "#service-status-item")
+      refute has_element?(view, "#service-status-link")
+    end
+  end
+
+  describe "real-time updates" do
+    @tag feature: "service_status_sidebar",
+         scenario: "Service icon is green when service is running"
+    test "updates when service state changes via PubSub", %{conn: conn} do
+      project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
+      ws = create_session(%{project_id: project.id, service_state: nil})
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      assert has_element?(view, "#service-status-item")
+      refute has_element?(view, "#service-status-link")
+
+      {:ok, updated_ws} =
+        Destila.Workflows.update_workflow_session(ws, %{
+          service_state: %{"status" => "running", "ports" => %{"PORT" => 4000}}
+        })
+
+      send(view.pid, {:workflow_session_updated, updated_ws})
+
+      assert has_element?(view, ~s|#service-status-link[href="http://localhost:4000"]|)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add a "Service" item to the right sidebar in `WorkflowRunnerLive`, reflecting whether the project's dev service is running or stopped
- When running with an assigned port, the item links to `http://localhost:<port>` in a new tab (green icon + arrow)
- When stopped or service_state is nil, renders as a static element with muted icon
- When the project has no `run_command`, shows a disabled/dimmed item indicating the feature exists but isn't configured
- When the session has no project, no service item is rendered
- Real-time updates work automatically via existing PubSub `handle_info`

## Changes

- `lib/destila_web/live/workflow_runner_live.ex` — Added `service_url/2` helper and sidebar template item with conditional rendering for all states
- `test/destila_web/live/service_status_sidebar_live_test.exs` — 11 LiveView tests covering visibility, icon color, link behavior, edge cases, and real-time PubSub updates
- `features/service_status_sidebar.feature` — 10 Gherkin scenarios documenting all behaviors

## Test plan

- [x] All 11 new tests pass (`mix test test/destila_web/live/service_status_sidebar_live_test.exs`)
- [x] Existing sidebar tests unaffected (17 total sidebar tests pass)
- [x] Code compiles with no warnings
- [x] Code review completed — fixed missing @tag annotations, icon color assertions, and feature file coverage