### PR TITLE
fix: Add max_turns limit and increase inactivity timeouts

### DIFF
--- a/lib/destila/ai/claude_session.ex
+++ b/lib/destila/ai/claude_session.ex
@@ -215,9 +215,14 @@ defmodule Destila.AI.ClaudeSession do
   def handle_call({:query_streaming, prompt, opts}, _from, state) do
     topic = Keyword.fetch!(opts, :stream_topic)
 
+    stream_opts =
+      opts
+      |> Keyword.delete(:stream_topic)
+      |> Keyword.put_new(:max_turns, 200)
+
     result =
       state.claude_session
-      |> ClaudeCode.stream(prompt, Keyword.delete(opts, :stream_topic))
+      |> ClaudeCode.stream(prompt, stream_opts)
       |> collect_with_mcp_and_broadcast(topic)
 
     state = reset_timer(state)

--- a/lib/destila/sessions/session_process.ex
+++ b/lib/destila/sessions/session_process.ex
@@ -13,7 +13,7 @@ defmodule Destila.Sessions.SessionProcess do
   alias Destila.{AI, Executions, Workflows}
   alias Destila.Workflows.Session
 
-  @inactivity_timeout :timer.minutes(30)
+  @inactivity_timeout :timer.hours(1)
 
   # --- Client API ---
 


### PR DESCRIPTION
## Summary
- Set default `max_turns: 200` on workflow AI streaming queries to prevent indefinite AI looping (the likely cause of cost-accumulating hangs during work phases)
- Increase `SessionProcess` inactivity timeout from 30 minutes to 1 hour

## Test plan
- [ ] Run a workflow session through a work phase and verify AI completes normally
- [ ] Verify the AI stops after 200 turns if it loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)