### PR TITLE
feat: set claude-opus-4-6 model on AI session creation

### DIFF
--- a/lib/destila/ai/claude_session.ex
+++ b/lib/destila/ai/claude_session.ex
@@ -186,6 +186,7 @@ defmodule Destila.AI.ClaudeSession do
 
       case ClaudeCode.start_link(claude_opts) do
         {:ok, claude_session} ->
+          ClaudeCode.Session.set_model(claude_session, "claude-opus-4-6")
           timer_ref = schedule_timeout(timeout_ms)
 
           if workflow_session_id do


### PR DESCRIPTION
Ensures every new Claude session uses `claude-opus-4-6` by calling `ClaudeCode.Session.set_model/2` immediately after `ClaudeCode.start_link/1` succeeds in `ClaudeSession.init/1`.

---

[![Compound Engineering v2.60.0](https://img.shields.io/badge/Compound_Engineering-v2.60.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Sonnet 4.6 (200K context) via [Claude Code](https://claude.com/claude-code)