### PR TITLE
feat: AI sessions sidebar + debug detail page

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -26,6 +26,9 @@ config :phoenix_live_view,
 # Use test adapter for ClaudeCode
 config :claude_code, adapter: {ClaudeCode.Test, ClaudeCode}
 
+# Stub the history reader in tests so we don't touch ~/.claude/projects.
+config :destila, :ai_history_module, Destila.AI.FakeHistory
+
 # Execute Oban jobs inline during tests for synchronous behavior
 config :destila, Oban, testing: :inline
 

--- a/docs/plans/2026-04-16-001-feat-ai-sessions-sidebar-and-debug-detail-plan.md
+++ b/docs/plans/2026-04-16-001-feat-ai-sessions-sidebar-and-debug-detail-plan.md
@@ -187,7 +187,7 @@ tool_index =
 
 ## Implementation Units
 
-- [ ] **Unit 1: Extend `AlivenessTracker` to dual-key (`workflow_session_id` + `ai_session_id`)**
+- [x] **Unit 1: Extend `AlivenessTracker` to dual-key (`workflow_session_id` + `ai_session_id`)**
 
 **Goal:** Track aliveness by both keys while preserving the existing `workflow_session_id` contract.
 
@@ -230,7 +230,7 @@ tool_index =
 
 ---
 
-- [ ] **Unit 2: Add `list_ai_sessions_for_workflow/1` to `Destila.AI`**
+- [x] **Unit 2: Add `list_ai_sessions_for_workflow/1` to `Destila.AI`**
 
 **Goal:** Provide a context function returning all AI sessions for a workflow session, ordered newest-first.
 
@@ -262,7 +262,7 @@ tool_index =
 
 ---
 
-- [ ] **Unit 3: Render "AI Sessions" section in the workflow runner right sidebar**
+- [x] **Unit 3: Render "AI Sessions" section in the workflow runner right sidebar**
 
 **Goal:** Show the AI sessions list between the "Workflow Session" and "Exported Metadata" sections, with live aliveness dots and navigation to the detail page.
 
@@ -306,7 +306,7 @@ tool_index =
 
 ---
 
-- [ ] **Unit 4: Add route + `DestilaWeb.AiSessionDetailLive` skeleton**
+- [x] **Unit 4: Add route + `DestilaWeb.AiSessionDetailLive` skeleton**
 
 **Goal:** Stand up the detail page with header, mount logic, subscription, empty states, and back-navigation — but without the content-block rendering (deferred to Unit 6).
 
@@ -357,7 +357,7 @@ tool_index =
 
 ---
 
-- [ ] **Unit 5: `Destila.AI.History` adapter for `ClaudeCode.History.get_messages/2`**
+- [x] **Unit 5: `Destila.AI.History` adapter for `ClaudeCode.History.get_messages/2`**
 
 **Goal:** Make the history read swappable in tests without stubbing a module we do not own.
 
@@ -394,7 +394,7 @@ tool_index =
 
 ---
 
-- [ ] **Unit 6: `DestilaWeb.AiSessionDebugComponents` + full renderer wired into the detail page**
+- [x] **Unit 6: `DestilaWeb.AiSessionDebugComponents` + full renderer wired into the detail page**
 
 **Goal:** Render every content block type, pair tool calls with tool results, gracefully handle unknown shapes.
 
@@ -459,7 +459,7 @@ tool_index =
 
 ---
 
-- [ ] **Unit 7: Gherkin features + test linkage**
+- [x] **Unit 7: Gherkin features + test linkage**
 
 **Goal:** Commit the two `.feature` files from the prompt and ensure every LiveView test carries the matching `@tag feature:/scenario:`.
 
@@ -492,7 +492,7 @@ tool_index =
 
 ---
 
-- [ ] **Unit 8: Precommit run and polish**
+- [x] **Unit 8: Precommit run and polish**
 
 **Goal:** Run `mix precommit`, fix any lint/type/test issues, and do one manual pass of the UI in the browser.
 

--- a/docs/plans/2026-04-16-001-feat-ai-sessions-sidebar-and-debug-detail-plan.md
+++ b/docs/plans/2026-04-16-001-feat-ai-sessions-sidebar-and-debug-detail-plan.md
@@ -3,6 +3,7 @@ title: Add AI Sessions List to Workflow Runner Right Sidebar + AI Session Debug 
 type: feat
 status: active
 date: 2026-04-16
+deepened: 2026-04-16
 ---
 
 # Add AI Sessions List to Workflow Runner Right Sidebar + AI Session Debug Detail Page
@@ -13,7 +14,7 @@ Add two debugging-oriented features to the Destila workflow runner:
 
 1. An **"AI Sessions" section** in the workflow runner right sidebar that lists every AI session belonging to the current workflow session. Each row shows the creation date and a live aliveness dot (green when the Claude Code GenServer is running, muted/gray when not). Clicking a row navigates to a new detail page.
 
-2. A new **AI Session Debug Detail page** at `/sessions/:workflow_session_id/ai/:ai_session_id`. This page is designed for debugging what happened inside a specific AI session: it shows the session's creation date and `claude_session_id` in a header, then renders the full conversation history read exclusively via `ClaudeCode.Session.get_messages/1`, rendering every content block type (text, thinking, tool calls, tool results, server tool usage, MCP tool usage, images, documents, redacted thinking, container uploads, compaction markers).
+2. A new **AI Session Debug Detail page** at `/sessions/:workflow_session_id/ai/:ai_session_id`. This page is designed for debugging what happened inside a specific AI session: it shows the session's creation date and `claude_session_id` in a header, then renders the full conversation history read exclusively via `ClaudeCode.History.get_messages/2` (the string-keyed variant — see "Verified History API" in Key Technical Decisions), rendering every content block type (text, thinking, tool calls, tool results, server tool usage, MCP tool usage, images, documents, redacted thinking, container uploads, compaction markers).
 
 ## Problem Frame
 
@@ -26,13 +27,13 @@ Today, the only way to inspect a past AI session's raw conversation is to open a
 - **R3.** Show an empty state in the sidebar when the workflow has no AI sessions.
 - **R4.** Add route `live "/sessions/:workflow_session_id/ai/:ai_session_id", AiSessionDetailLive` inside the existing `scope "/", DestilaWeb` block.
 - **R5.** The detail page header displays the session's creation date and `claude_session_id`.
-- **R6.** The detail page renders the full conversation history exclusively via `ClaudeCode.Session.get_messages(claude_session_id)`.
+- **R6.** The detail page renders the full conversation history exclusively via `ClaudeCode.History.get_messages(claude_session_id, opts \\ [])` (the string-session-id variant; `ClaudeCode.Session.get_messages/2` takes a live session PID and is **not** what we want here).
 - **R7.** The renderer handles every content block struct type listed in the prompt (`TextBlock`, `ThinkingBlock`, `RedactedThinkingBlock`, `ToolUseBlock`, `ToolResultBlock`, `ServerToolUseBlock`, `ServerToolResultBlock`, `MCPToolUseBlock`, `MCPToolResultBlock`, `ImageBlock`, `DocumentBlock`, `ContainerUploadBlock`, `CompactionBlock`).
 - **R8.** Tool calls are visually paired with their matching tool results via `tool_use_id`.
 - **R9.** Thinking blocks render collapsed by default and can be expanded.
 - **R10.** Tool input/output render as pretty JSON; tool-result blocks render with an error style when `:is_error` is `true`.
 - **R11.** Unknown/future content block types use a generic fallback (e.g. `inspect/2`) and never crash the page.
-- **R12.** The detail page renders an empty state when `claude_session_id` is nil or `get_messages/1` returns `{:error, _}` or `{:ok, []}`.
+- **R12.** The detail page renders an empty state when `claude_session_id` is nil or `History.get_messages/2` returns `{:error, _}` or `{:ok, []}`.
 - **R13.** Extending the aliveness tracker must not break the existing `workflow_session_id`-based aliveness used by the Crafting Board and the workflow runner header.
 - **R14.** The new sidebar section must render correctly whether the sidebar is expanded or collapsed (it lives inside `#metadata-sidebar-content`, which is hidden as a unit).
 - **R15.** Every Gherkin scenario in `features/ai_session_sidebar.feature` and `features/ai_session_detail.feature` has at least one linked LiveView test via `@tag feature:/scenario:`.
@@ -41,8 +42,8 @@ Today, the only way to inspect a past AI session's raw conversation is to open a
 
 - Not building an editing/rerun UI for past AI sessions. Detail page is read-only.
 - Not changing how AI sessions are created or associated with Claude Code processes.
-- Not persisting conversation history to our DB — reads stay on-disk via `ClaudeCode.Session.get_messages/1`.
-- Not adding pagination for large histories in the MVP. `ClaudeCode.Session.get_messages/2` accepts `limit:`/`offset:` and can be wired up later.
+- Not persisting conversation history to our DB — reads stay on-disk via `ClaudeCode.History.get_messages/2`.
+- Not adding pagination for large histories in the MVP. `ClaudeCode.History.get_messages/2` accepts `limit:`/`offset:` opts and can be wired up later.
 - Not adding the ability to resume/clone a past session from the detail page.
 - Not redesigning the existing header aliveness dot in `WorkflowRunnerLive` — it keeps its current per-workflow semantics.
 
@@ -55,6 +56,8 @@ Today, the only way to inspect a past AI session's raw conversation is to open a
 - **`lib/destila/ai/session.ex`** — AI session schema with `claude_session_id`, `worktree_path`, `workflow_session_id`, `inserted_at`. Primary key is `binary_id`.
 - **`lib/destila/ai/claude_session.ex`** — Wrapper around `ClaudeCode.start_link`. On init (line 192–198) it broadcasts `{:claude_session_started, workflow_session_id}` to `PubSubHelper.claude_session_topic()`. `workflow_session_id` is already in state; `ai_session_id` is not currently passed in.
 - **`lib/destila/ai/conversation.ex:117`** — `AI.update_ai_session(ai_session, %{claude_session_id: result[:session_id]})` is where the AI session record captures its `claude_session_id` after the first stream completes. This is the only place where the ai_session ↔ claude_session_id link is established.
+- **`lib/destila/workers/ai_query_worker.ex:25`** — **Verified call site for `ClaudeSession.for_workflow_session/2`.** The worker calls `AI.SessionConfig.session_opts_for_workflow(ws, phase)` to build the opts keyword list, then passes those opts through unchanged to `AI.ClaudeSession.for_workflow_session(workflow_session_id, session_opts)`. There is no direct `ClaudeSession.for_workflow_session/2` call in `Conversation.ex` — `Conversation.phase_start/*` calls `AI.get_or_create_ai_session/2` and enqueues the Oban worker, which in turn starts the ClaudeSession. **This is where `ai_session_id` must be injected.**
+- **`lib/destila/ai/session_config.ex:17-55`** — **Verified insertion point for `ai_session_id` opt.** `session_opts_for_workflow/3` already fetches `ai_session = Destila.AI.get_ai_session_for_workflow(workflow_session.id)` (line 26) and uses it to populate `:resume` (from `ai_session.claude_session_id`) and `:cwd` (from `ai_session.worktree_path`). The natural seam is one more `Keyword.put(opts, :ai_session_id, ai_session.id)` in the same block, guarded by the existing `ai_session != nil` branch. No change needed in `AiQueryWorker` — it forwards the full opts keyword list.
 - **`lib/destila_web/live/workflow_runner_live.ex`** — Right sidebar lives at lines 695–900+. Key anchor points: `<div id="user-prompt-section">` at ~line 724 (header "Workflow Session"), divider at ~line 863, Exported Metadata section at ~line 866 (header "Exported Metadata"). Mount already subscribes to `AlivenessTracker.topic()` and handles `{:aliveness_changed, ws_id, alive?}` at ~line 468. The `.MetadataSidebar` colocated JS hook at line 1079+ toggles the whole `#metadata-sidebar-content` div visibility — the new section nests inside this div and needs no extra hook logic.
 - **`lib/destila_web/components/board_components.ex:42`** — `aliveness_dot/1` is the existing visual primitive: green `bg-success`, muted `bg-base-content/20`, red pulsing `bg-error animate-pulse`. Reuse by passing `phase_status` explicitly so the muted-vs-red branching still works for historical sessions without a live workflow phase.
 - **`lib/destila_web/live/terminal_live.ex`** — Single-purpose detail LiveView pattern to mirror: mount validates by looking up the workflow session, redirects with `put_flash` on missing, renders a `Layouts.app` header with a back-link icon (`hero-arrow-left-micro`) pointing to `~p"/sessions/#{ws.id}"`, and uses `page_title` like `"Terminal — #{ws.title}"`.
@@ -69,14 +72,18 @@ No matching entries found in `docs/solutions/` for this specific work. The close
 
 ### External References
 
-- `ClaudeCode.Session.get_messages/1` reads `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` and returns `{:ok, [%ClaudeCode.History.SessionMessage{}]}`. See https://github.com/guess/claude_code/blob/main/docs/guides/sessions.md and https://github.com/guess/claude_code/blob/main/lib/claude_code/history/session_message.ex.
-- Content block structs live under `ClaudeCode.Content.*` — see https://github.com/guess/claude_code/tree/main/lib/claude_code/content/ for the canonical field names used below.
+- **Verified in `deps/claude_code/` (installed).** Two distinct `get_messages` functions exist in the installed version:
+  - `ClaudeCode.History.get_messages(session_id, opts \\ [])` — `@spec get_messages(session_id(), keyword()) :: {:ok, [SessionMessage.t()]} | {:error, term()}` (`deps/claude_code/lib/claude_code/history.ex:124`). **This is the one we want** — it takes the `claude_session_id` string and reads the JSONL file directly.
+  - `ClaudeCode.Session.get_messages(session, opts \\ [])` — `@spec get_messages(session(), keyword()) :: ...` (`deps/claude_code/lib/claude_code/session.ex:351`). Takes a **live session PID** and calls `GenServer.call(session, {:history_call, :get_messages, opts})`. Not applicable here — the detail page reads *past* sessions whose PIDs are gone.
+- `ClaudeCode.History.SessionMessage` struct fields (verified at `deps/claude_code/lib/claude_code/history/session_message.ex`): `:type` (`:user | :assistant`), `:uuid`, `:session_id`, `:message`, `:parent_tool_use_id`. For `:user` type, `:message` is a plain map `%{content: parsed_content, role: :user}`. For `:assistant`, `:message` is a parsed `%ClaudeCode.Message.AssistantMessage{}` when parsing succeeds, else a normalized raw map (fallback is built into `parse_inner_message/3`, so we inherit the tolerance for free).
+- Content block structs live under `ClaudeCode.Content.*` — see `deps/claude_code/lib/claude_code/content/` (already installed locally) and https://github.com/guess/claude_code/tree/main/lib/claude_code/content/ for the canonical field names used below.
 
 ## Key Technical Decisions
 
 - **Extend `AlivenessTracker` to store both keys, not replace the workflow_session_id key.** The existing header aliveness dot, the Crafting Board cards, and the WorkflowRunnerLive header already depend on `alive?(workflow_session_id)` and `{:aliveness_changed, workflow_session_id, alive?}`. We keep that contract, and add parallel storage/broadcast keyed by `ai_session_id`. The ETS table can either grow into a tagged key (`{:workflow, ws_id}` / `{:ai, ai_id}`) or we can split into two tables — we go with tagged keys in a single table to preserve atomic lookup patterns.
 - **Plumb `ai_session_id` through `ClaudeSession` init, not through a DB lookup inside the tracker.** The caller (`Destila.AI.Conversation`) already knows which ai_session is about to own this ClaudeSession; passing it through opts avoids a DB query in the hot path and a race where the ai_session row exists but has no `claude_session_id` yet. The broadcast message becomes `{:claude_session_started, workflow_session_id, ai_session_id}` (a 3-tuple), and the `AlivenessTracker` handles both the old 2-tuple and the new 3-tuple for compatibility during rollout. The tracker broadcasts two separate `{:aliveness_changed, ...}` messages — one for the workflow key, one for the ai key — so existing subscribers need no change.
-- **Introduce a thin `Destila.AI.History` adapter module** that delegates to `ClaudeCode.Session.get_messages/1`. The LiveView calls `History.get_messages/1`; tests override it via `Application.put_env` to return fixture messages. This avoids trying to stub a function we do not own and keeps `ClaudeCode.Test.stub` usage focused on live streaming.
+- **Verified History API.** Use `ClaudeCode.History.get_messages/2` (takes the `claude_session_id` string). The Session-module variant (`ClaudeCode.Session.get_messages/2`) takes a live GenServer PID and is the wrong surface — by the time the detail page loads, the originating ClaudeSession GenServer is usually gone. Confirmed by reading `deps/claude_code/lib/claude_code/history.ex` and `deps/claude_code/lib/claude_code/session.ex`.
+- **Introduce a thin `Destila.AI.History` adapter module** that delegates to `ClaudeCode.History.get_messages/2`. The LiveView calls `Destila.AI.History.get_messages/1` (or `/2`); tests override the delegate target via `Application.put_env(:destila, :ai_history_module, ...)` to return fixture messages. This avoids trying to stub a function we do not own and keeps `ClaudeCode.Test.stub` usage focused on live streaming.
 - **Render `SessionMessage`s with a dedicated function component module `DestilaWeb.AiSessionDebugComponents`**, not by reusing `ChatComponents`. The chat components expect our `%Destila.AI.Message{}` schema with `role`/`content`/`raw_response`; the history structs are a different shape (`%ClaudeCode.History.SessionMessage{}` wrapping `%ClaudeCode.Content.*{}` blocks). Mixing them would pollute chat components with debug-only branches.
 - **Build a `%{tool_use_id => tool_use_block}` index up-front** by walking all messages once before rendering, then use the index to find the originating tool-use struct when rendering a `ToolResultBlock`/`ServerToolResultBlock`/`MCPToolResultBlock`. This is cheaper than re-scanning the list for every result block and produces stable visual pairing even when the tool_use and tool_result span different messages.
 - **Fallback on `inspect/2` for unrecognized content blocks.** Future claude_code releases will add new block types; a catch-all `_ -> inspect(block, pretty: true, limit: :infinity)` inside a `<pre>` renders the raw struct without crashing the LiveView.
@@ -89,7 +96,7 @@ No matching entries found in `docs/solutions/` for this specific work. The close
 
 - **Does the tracker need to track ai_session_id independently of workflow_session_id, given there's only one ClaudeSession per workflow_session at a time?** Resolved: yes, because the user-facing surface is a list of historical AI sessions, and we want the *currently-bound* AI session to show green while older ones show muted. Binding `ai_session_id` at ClaudeSession init gives us that per-session granularity without changing the Registry key.
 - **Where to pass `ai_session_id` into `ClaudeSession`?** Resolved via opts in `init/1`, mirroring how `workflow_session_id` is already plumbed.
-- **How to test `ClaudeCode.Session.get_messages/1` without touching the real `~/.claude/projects` tree?** Resolved via a `Destila.AI.History` adapter configured through `Application.get_env`, defaulting to the real `ClaudeCode.Session`. See Unit 5.
+- **How to test `ClaudeCode.History.get_messages/2` without touching the real `~/.claude/projects` tree?** Resolved via a `Destila.AI.History` adapter configured through `Application.get_env`, defaulting to the real `ClaudeCode.History`. See Unit 5.
 - **Reuse `ChatComponents` for rendering?** Resolved: no — different input struct shape. See Key Technical Decisions.
 - **Route shape.** Resolved: `/sessions/:workflow_session_id/ai/:ai_session_id` maps to `DestilaWeb.AiSessionDetailLive` inside the existing `scope "/", DestilaWeb`.
 
@@ -191,16 +198,18 @@ tool_index =
 **Files:**
 - Modify: `lib/destila/ai/aliveness_tracker.ex`
 - Modify: `lib/destila/ai/claude_session.ex` (broadcast 3-tuple; accept `ai_session_id` opt)
-- Modify: `lib/destila/ai/conversation.ex` (pass `ai_session_id` into `ClaudeSession.for_workflow_session/2`)
+- Modify: `lib/destila/ai/session_config.ex` (**verified insertion point** — inject `ai_session_id: ai_session.id` into the opts keyword returned by `session_opts_for_workflow/3`, adjacent to the existing `:resume`/`:cwd` puts on the `ai_session != nil` branch)
 - Modify: `lib/destila/pub_sub_helper.ex` (optional: add a helper to form the 3-tuple if we want a named constructor)
 - Test: `test/destila/ai/aliveness_tracker_test.exs` (create if missing)
+
+**Not modified (verified via deps read):** `lib/destila/ai/conversation.ex` does *not* call `ClaudeSession.for_workflow_session/2` directly. `lib/destila/workers/ai_query_worker.ex` forwards `session_opts` unchanged to the ClaudeSession starter, so updating `SessionConfig` is sufficient and avoids threading `ai_session_id` through the worker's args.
 
 **Approach:**
 - Store ETS entries under tagged keys: `{{:workflow, ws_id}, true}` and `{{:ai, ai_id}, true}`. Update the existing `alive?/1` implementation to continue looking up `{:workflow, ws_id}` so external callers see no change.
 - Add `alive_ai?/1` (or `alive_ai_session?/1`) that looks up `{:ai, ai_id}`.
 - Track two independent monitor-ref maps or one map keyed by ref with a `{:workflow_and_ai, ws_id, ai_id}` value so that a single `:DOWN` cleans up both keys atomically.
 - In `ClaudeSession.init/1`, pop `:ai_session_id` from opts and include it in the `{:claude_session_started, ws_id, ai_id}` broadcast. Keep the old 2-tuple broadcast path alive as a fallback for safety (the tracker handles both) — or remove it cleanly since we control both producer and consumer. Decision: remove the 2-tuple on the producer side since both ends ship together; the tracker retains a `handle_info/2` clause for the 2-tuple with `ai_id: nil` only to avoid breakage from any in-flight messages during deploy.
-- In `Conversation.ensure_session/*` or wherever `ClaudeSession.for_workflow_session/2` is called, pass `ai_session_id: ai_session.id` via opts. Confirm the call site by following the code path from `Destila.AI.Conversation` during implementation.
+- In `lib/destila/ai/session_config.ex` `session_opts_for_workflow/3`, on the `ai_session != nil` branch (where `:resume` and `:cwd` are already injected from `ai_session`), add `Keyword.put(opts, :ai_session_id, ai_session.id)`. The `AiQueryWorker` passes the full opts keyword through to `ClaudeSession.for_workflow_session/2` unchanged, so `ClaudeSession.init/1` receives `ai_session_id` for free.
 - Scan on `init/1` is extended: `Registry.select` already yields `{ws_id, pid}`; to recover `ai_session_id` after a tracker restart, fall back to a DB lookup via `AI.get_ai_session_for_workflow/1` (best-effort). If no ai_session exists yet, skip the `{:ai, ai_id}` entry — the next claude_session_started broadcast will fill it in.
 
 **Patterns to follow:**
@@ -348,7 +357,7 @@ tool_index =
 
 ---
 
-- [ ] **Unit 5: `Destila.AI.History` adapter for `ClaudeCode.Session.get_messages/1`**
+- [ ] **Unit 5: `Destila.AI.History` adapter for `ClaudeCode.History.get_messages/2`**
 
 **Goal:** Make the history read swappable in tests without stubbing a module we do not own.
 
@@ -363,23 +372,24 @@ tool_index =
 - Create: `test/support/fake_history.ex` (test helper storing canned responses via `Application.put_env` or an `Agent`/ETS store)
 
 **Approach:**
-- `Destila.AI.History` exposes `get_messages/1` and (optionally) `get_messages/2`. Delegate to the real implementation by default:
-  - `Application.get_env(:destila, :ai_history_module, ClaudeCode.Session).get_messages(session_id)` (or keyword form for `/2`).
+- `Destila.AI.History` exposes `get_messages/1` and `get_messages/2`. Delegate to the real implementation by default:
+  - `Application.get_env(:destila, :ai_history_module, ClaudeCode.History).get_messages(session_id, opts)`. **Default target is `ClaudeCode.History`** — verified string-session-id API. Not `ClaudeCode.Session`, which expects a live PID.
+- Return contract: `{:ok, [%ClaudeCode.History.SessionMessage{}]} | {:error, term()}`, matching the upstream `@spec`.
 - The module doubles as a safety wrapper: it rescues any exception from the underlying call and returns `{:error, {:exception, ...}}` so the LiveView's `{:error, _}` branch covers unexpected shapes/crashes from disk/parse failures.
 - In `config/test.exs`, set `config :destila, :ai_history_module, Destila.AI.FakeHistory`.
 - The fake history module stores `{session_id => {:ok, messages} | {:error, reason}}` in an `Agent` (or process dictionary or ETS keyed by test pid via `nimble_ownership`-style if we want async). Tests call `FakeHistory.stub(session_id, {:ok, messages})` in their `setup`.
-- Build convenience fixtures: `Destila.AI.HistoryFixtures` with tiny builders like `text_message/1`, `thinking_message/1`, `tool_use_pair/3`, etc., so rendering tests stay readable.
+- Build convenience fixtures: `Destila.AI.HistoryFixtures` with tiny builders like `text_message/1`, `thinking_message/1`, `tool_use_pair/3`, etc., so rendering tests stay readable. Each builder returns a fully-formed `%ClaudeCode.History.SessionMessage{}` so the renderer tests exercise the real struct, not a loose map.
 
 **Patterns to follow:**
 - `ClaudeCode.Test.stub/2` in the existing tests as conceptual inspiration, but we own this adapter so we can expose whatever API reads cleanly.
 
 **Test scenarios:**
-- Happy path: delegates to the configured module; default config calls `ClaudeCode.Session.get_messages/1` (verified via a stand-in module that records the call).
+- Happy path: delegates to the configured module; default config calls `ClaudeCode.History.get_messages/2` (verified via a stand-in module that records the call).
 - Edge case: when the underlying call raises, the adapter returns `{:error, {:exception, ...}}` instead of propagating.
 - Integration: in test env, `Destila.AI.History.get_messages(id)` returns exactly what `FakeHistory.stub/2` provided.
 
 **Verification:**
-- The LiveView never imports `ClaudeCode.Session` directly; it only calls `History.get_messages/1`.
+- The LiveView never imports `ClaudeCode.History` or `ClaudeCode.Session` directly; it only calls `Destila.AI.History.get_messages/1`.
 - Tests can drive arbitrary history shapes (including `{:ok, []}`, `{:error, :enoent}`, and rich content-block fixtures) without touching disk.
 
 ---
@@ -517,6 +527,8 @@ tool_index =
 ## System-Wide Impact
 
 - **Interaction graph:** The AlivenessTracker is the hub. `ClaudeSession` broadcasts to it; it broadcasts to all LiveViews subscribed on `"session_aliveness"` (currently the workflow runner and the Crafting Board; now also the AI Session Detail page). Adding a second broadcast message type (`:aliveness_changed_ai`) on the same topic means every existing subscriber receives an extra message per AI state change — cost is trivial (a pattern match that falls through) but worth naming.
+- **Crafting Board compatibility verified.** `DestilaWeb.CraftingBoardLive` (`lib/destila_web/live/crafting_board_live.ex:77`) already has a `def handle_info(_msg, socket), do: {:noreply, socket}` catch-all after its existing `{:aliveness_changed, ws_id, alive?}` clause, so the new `:aliveness_changed_ai` broadcast is dropped silently there with no code change required. The existing `{:aliveness_changed, ws_id, alive?}` handler continues to update `:alive_sessions` as before.
+- **Workflow runner compatibility verified.** `DestilaWeb.WorkflowRunnerLive.handle_info({:aliveness_changed, ws_id, alive?}, socket)` (~line 468) matches only the 3-tuple workflow form. A new `{:aliveness_changed_ai, ai_id, alive?}` clause is added for the sidebar (Unit 3); neither handler disturbs the other.
 - **Error propagation:** `History.get_messages/1` is the only new disk-touching call. It is wrapped in a rescue at the adapter level, and the LiveView treats `{:error, _}` as the empty-state branch. No error path crashes the LiveView.
 - **State lifecycle risks:** The ETS table in `AlivenessTracker` grows by one entry per running AI session. Entries are removed on `:DOWN`, and because ClaudeSession processes have an inactivity timer (5 min default), stale `{:ai, id}` entries clear naturally. The only lingering concern is a restart of the tracker itself — its init now walks the Registry and (optionally) the DB to rehydrate `{:ai, id}` entries; if the DB lookup fails, `{:workflow, ws_id}` is still correct, preserving existing behavior.
 - **API surface parity:** `alive?/1` semantics are explicitly preserved for the Crafting Board and the workflow runner header. The new `alive_ai?/1` function is purely additive. No public function is renamed or removed.
@@ -527,7 +539,7 @@ tool_index =
 
 | Risk | Mitigation |
 |------|------------|
-| `ClaudeCode.Session.get_messages/1` path, signature, or return shape differs from what the prompt describes | Wrap the call in `Destila.AI.History` with a rescue. Verify the real signature during Unit 5 implementation by `iex -S mix` + a known session id before relying on the empirical shape. If the real API takes a PID instead of a session id string, the adapter absorbs that change — only the adapter's body needs fixing. |
+| claude_code history API shape drift on package upgrade | Verified at plan time against installed deps: use `ClaudeCode.History.get_messages/2` (`@spec get_messages(session_id(), keyword()) :: {:ok, [SessionMessage.t()]} | {:error, term()}`). Still wrap the call in `Destila.AI.History` with a rescue so future shape/parse changes fall into the `{:error, _}` empty-state branch. The `limit:`/`offset:` opts are already accepted upstream, so pagination is a future one-line change. |
 | Tracker dual-key rehydrate misses an ai_session_id after a crash/restart | The detail page and sidebar both call `alive_ai?/1`; worst case is a muted dot on a currently-running session until the next `{:claude_session_started, ...}` broadcast. Acceptable. Next broadcast (idle timer end or next user turn) will correct it. A `Logger.debug/1` line when rehydrate can't find an ai_session for a running ws_id makes this observable without noise. |
 | Large JSONL files (long conversations) block the LiveView mount | MVP reads the whole file synchronously. Acceptable for current session sizes. Add `limit:`/`offset:` via `get_messages/2` if users complain; the adapter already takes a keyword list. |
 | Broadcast storm when an AI session turns over quickly | Two broadcasts per state transition instead of one. At the current workload this is not a concern; noted for future scaling. |
@@ -550,11 +562,18 @@ tool_index =
   - `lib/destila/ai/session.ex`
   - `lib/destila/ai/claude_session.ex`
   - `lib/destila/ai/conversation.ex`
+  - `lib/destila/ai/session_config.ex` (verified insertion point for `ai_session_id` opt)
+  - `lib/destila/workers/ai_query_worker.ex` (verified `ClaudeSession.for_workflow_session/2` call site)
   - `lib/destila_web/live/workflow_runner_live.ex` (right sidebar at ~lines 695–900)
+  - `lib/destila_web/live/crafting_board_live.ex` (existing aliveness subscriber with catch-all `handle_info/2`)
   - `lib/destila_web/live/terminal_live.ex` (detail-page shape reference)
   - `lib/destila_web/router.ex`
   - `lib/destila_web/components/board_components.ex` (`aliveness_dot/1`)
   - `lib/destila_web/components/chat_components.ex` (componentization reference)
+- Installed deps (read directly):
+  - `deps/claude_code/lib/claude_code/history.ex` — `get_messages/2` spec and body
+  - `deps/claude_code/lib/claude_code/session.ex` — PID-based `get_messages/2` (not used here)
+  - `deps/claude_code/lib/claude_code/history/session_message.ex` — struct shape and parser fallback behavior
 - External docs:
   - `ClaudeCode.Session` and history: https://github.com/guess/claude_code/blob/main/docs/guides/sessions.md
   - `%ClaudeCode.History.SessionMessage{}`: https://github.com/guess/claude_code/blob/main/lib/claude_code/history/session_message.ex

--- a/docs/plans/2026-04-16-001-feat-ai-sessions-sidebar-and-debug-detail-plan.md
+++ b/docs/plans/2026-04-16-001-feat-ai-sessions-sidebar-and-debug-detail-plan.md
@@ -1,0 +1,561 @@
+---
+title: Add AI Sessions List to Workflow Runner Right Sidebar + AI Session Debug Detail Page
+type: feat
+status: active
+date: 2026-04-16
+---
+
+# Add AI Sessions List to Workflow Runner Right Sidebar + AI Session Debug Detail Page
+
+## Overview
+
+Add two debugging-oriented features to the Destila workflow runner:
+
+1. An **"AI Sessions" section** in the workflow runner right sidebar that lists every AI session belonging to the current workflow session. Each row shows the creation date and a live aliveness dot (green when the Claude Code GenServer is running, muted/gray when not). Clicking a row navigates to a new detail page.
+
+2. A new **AI Session Debug Detail page** at `/sessions/:workflow_session_id/ai/:ai_session_id`. This page is designed for debugging what happened inside a specific AI session: it shows the session's creation date and `claude_session_id` in a header, then renders the full conversation history read exclusively via `ClaudeCode.Session.get_messages/1`, rendering every content block type (text, thinking, tool calls, tool results, server tool usage, MCP tool usage, images, documents, redacted thinking, container uploads, compaction markers).
+
+## Problem Frame
+
+Today, the only way to inspect a past AI session's raw conversation is to open a terminal and `cat` the JSONL file under `~/.claude/projects/...`. There is also no visible list of historical AI sessions for a workflow — the sidebar shows workflow metadata but never the AI sessions themselves, and the workflow-level aliveness dot in the header tells you only whether *something* is running, not which AI session. This plan surfaces both: a sidebar index of all AI sessions for the workflow with per-session aliveness, and a dedicated page for reading the full conversation history of a specific AI session.
+
+## Requirements Trace
+
+- **R1.** Render an "AI Sessions" section in the `WorkflowRunnerLive` right sidebar, between the existing "Workflow Session" section and the "Exported Metadata" section.
+- **R2.** Each sidebar item shows the creation date and an aliveness dot that live-updates (green = alive, muted/gray = not running), and navigates to the detail page on click.
+- **R3.** Show an empty state in the sidebar when the workflow has no AI sessions.
+- **R4.** Add route `live "/sessions/:workflow_session_id/ai/:ai_session_id", AiSessionDetailLive` inside the existing `scope "/", DestilaWeb` block.
+- **R5.** The detail page header displays the session's creation date and `claude_session_id`.
+- **R6.** The detail page renders the full conversation history exclusively via `ClaudeCode.Session.get_messages(claude_session_id)`.
+- **R7.** The renderer handles every content block struct type listed in the prompt (`TextBlock`, `ThinkingBlock`, `RedactedThinkingBlock`, `ToolUseBlock`, `ToolResultBlock`, `ServerToolUseBlock`, `ServerToolResultBlock`, `MCPToolUseBlock`, `MCPToolResultBlock`, `ImageBlock`, `DocumentBlock`, `ContainerUploadBlock`, `CompactionBlock`).
+- **R8.** Tool calls are visually paired with their matching tool results via `tool_use_id`.
+- **R9.** Thinking blocks render collapsed by default and can be expanded.
+- **R10.** Tool input/output render as pretty JSON; tool-result blocks render with an error style when `:is_error` is `true`.
+- **R11.** Unknown/future content block types use a generic fallback (e.g. `inspect/2`) and never crash the page.
+- **R12.** The detail page renders an empty state when `claude_session_id` is nil or `get_messages/1` returns `{:error, _}` or `{:ok, []}`.
+- **R13.** Extending the aliveness tracker must not break the existing `workflow_session_id`-based aliveness used by the Crafting Board and the workflow runner header.
+- **R14.** The new sidebar section must render correctly whether the sidebar is expanded or collapsed (it lives inside `#metadata-sidebar-content`, which is hidden as a unit).
+- **R15.** Every Gherkin scenario in `features/ai_session_sidebar.feature` and `features/ai_session_detail.feature` has at least one linked LiveView test via `@tag feature:/scenario:`.
+
+## Scope Boundaries
+
+- Not building an editing/rerun UI for past AI sessions. Detail page is read-only.
+- Not changing how AI sessions are created or associated with Claude Code processes.
+- Not persisting conversation history to our DB — reads stay on-disk via `ClaudeCode.Session.get_messages/1`.
+- Not adding pagination for large histories in the MVP. `ClaudeCode.Session.get_messages/2` accepts `limit:`/`offset:` and can be wired up later.
+- Not adding the ability to resume/clone a past session from the detail page.
+- Not redesigning the existing header aliveness dot in `WorkflowRunnerLive` — it keeps its current per-workflow semantics.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **`lib/destila/ai/aliveness_tracker.ex`** — GenServer + ETS that currently tracks aliveness by `workflow_session_id` (Registry key). On `{:claude_session_started, workflow_session_id}` from `PubSubHelper.claude_session_topic()`, it monitors the pid and broadcasts `{:aliveness_changed, workflow_session_id, alive?}` on topic `"session_aliveness"`.
+- **`lib/destila/ai.ex`** — `get_ai_session_for_workflow/1` (returns the latest AI session, `order_by: [desc: :inserted_at], limit: 1`) is the canonical pattern to mirror when adding `list_ai_sessions_for_workflow/1` (same query, no `limit`).
+- **`lib/destila/ai/session.ex`** — AI session schema with `claude_session_id`, `worktree_path`, `workflow_session_id`, `inserted_at`. Primary key is `binary_id`.
+- **`lib/destila/ai/claude_session.ex`** — Wrapper around `ClaudeCode.start_link`. On init (line 192–198) it broadcasts `{:claude_session_started, workflow_session_id}` to `PubSubHelper.claude_session_topic()`. `workflow_session_id` is already in state; `ai_session_id` is not currently passed in.
+- **`lib/destila/ai/conversation.ex:117`** — `AI.update_ai_session(ai_session, %{claude_session_id: result[:session_id]})` is where the AI session record captures its `claude_session_id` after the first stream completes. This is the only place where the ai_session ↔ claude_session_id link is established.
+- **`lib/destila_web/live/workflow_runner_live.ex`** — Right sidebar lives at lines 695–900+. Key anchor points: `<div id="user-prompt-section">` at ~line 724 (header "Workflow Session"), divider at ~line 863, Exported Metadata section at ~line 866 (header "Exported Metadata"). Mount already subscribes to `AlivenessTracker.topic()` and handles `{:aliveness_changed, ws_id, alive?}` at ~line 468. The `.MetadataSidebar` colocated JS hook at line 1079+ toggles the whole `#metadata-sidebar-content` div visibility — the new section nests inside this div and needs no extra hook logic.
+- **`lib/destila_web/components/board_components.ex:42`** — `aliveness_dot/1` is the existing visual primitive: green `bg-success`, muted `bg-base-content/20`, red pulsing `bg-error animate-pulse`. Reuse by passing `phase_status` explicitly so the muted-vs-red branching still works for historical sessions without a live workflow phase.
+- **`lib/destila_web/live/terminal_live.ex`** — Single-purpose detail LiveView pattern to mirror: mount validates by looking up the workflow session, redirects with `put_flash` on missing, renders a `Layouts.app` header with a back-link icon (`hero-arrow-left-micro`) pointing to `~p"/sessions/#{ws.id}"`, and uses `page_title` like `"Terminal — #{ws.title}"`.
+- **`lib/destila_web/router.ex`** — Add the new route inside `scope "/", DestilaWeb` below the existing `/sessions/:id` routes. No `live_session` wrapper is used.
+- **`lib/destila/pub_sub_helper.ex`** — Provides `claude_session_topic/0` (used by both the AlivenessTracker and ClaudeSession). Extending it with a second tuple shape (`:claude_session_started, workflow_session_id, ai_session_id`) keeps the topic stable.
+- **`lib/destila_web/components/chat_components.ex`** — Already imports a Markdown rendering function (`markdown_viewer/1`) used for assistant text. The detail page should not try to reuse the full `chat_message/1` — it is overloaded with our own `%Destila.AI.Message{}` schema, not the `ClaudeCode.History.SessionMessage` struct we are rendering here. Keep the renderer separate.
+- **`test/destila_web/live/open_terminal_live_test.exs`** — Minimal pattern for a detail-page LiveView test; also shows how `ClaudeCode.Test.set_mode_to_shared/0` + `ClaudeCode.Test.stub/2` is used in tests. The `ClaudeCode.Test` helpers do not obviously cover `Session.get_messages/1`, so we add a thin adapter (see Unit 5) to make the call swappable in tests.
+
+### Institutional Learnings
+
+No matching entries found in `docs/solutions/` for this specific work. The closest adjacent patterns are the existing terminal-detail LiveView and the aliveness infrastructure added for the Crafting Board, both already in-tree.
+
+### External References
+
+- `ClaudeCode.Session.get_messages/1` reads `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` and returns `{:ok, [%ClaudeCode.History.SessionMessage{}]}`. See https://github.com/guess/claude_code/blob/main/docs/guides/sessions.md and https://github.com/guess/claude_code/blob/main/lib/claude_code/history/session_message.ex.
+- Content block structs live under `ClaudeCode.Content.*` — see https://github.com/guess/claude_code/tree/main/lib/claude_code/content/ for the canonical field names used below.
+
+## Key Technical Decisions
+
+- **Extend `AlivenessTracker` to store both keys, not replace the workflow_session_id key.** The existing header aliveness dot, the Crafting Board cards, and the WorkflowRunnerLive header already depend on `alive?(workflow_session_id)` and `{:aliveness_changed, workflow_session_id, alive?}`. We keep that contract, and add parallel storage/broadcast keyed by `ai_session_id`. The ETS table can either grow into a tagged key (`{:workflow, ws_id}` / `{:ai, ai_id}`) or we can split into two tables — we go with tagged keys in a single table to preserve atomic lookup patterns.
+- **Plumb `ai_session_id` through `ClaudeSession` init, not through a DB lookup inside the tracker.** The caller (`Destila.AI.Conversation`) already knows which ai_session is about to own this ClaudeSession; passing it through opts avoids a DB query in the hot path and a race where the ai_session row exists but has no `claude_session_id` yet. The broadcast message becomes `{:claude_session_started, workflow_session_id, ai_session_id}` (a 3-tuple), and the `AlivenessTracker` handles both the old 2-tuple and the new 3-tuple for compatibility during rollout. The tracker broadcasts two separate `{:aliveness_changed, ...}` messages — one for the workflow key, one for the ai key — so existing subscribers need no change.
+- **Introduce a thin `Destila.AI.History` adapter module** that delegates to `ClaudeCode.Session.get_messages/1`. The LiveView calls `History.get_messages/1`; tests override it via `Application.put_env` to return fixture messages. This avoids trying to stub a function we do not own and keeps `ClaudeCode.Test.stub` usage focused on live streaming.
+- **Render `SessionMessage`s with a dedicated function component module `DestilaWeb.AiSessionDebugComponents`**, not by reusing `ChatComponents`. The chat components expect our `%Destila.AI.Message{}` schema with `role`/`content`/`raw_response`; the history structs are a different shape (`%ClaudeCode.History.SessionMessage{}` wrapping `%ClaudeCode.Content.*{}` blocks). Mixing them would pollute chat components with debug-only branches.
+- **Build a `%{tool_use_id => tool_use_block}` index up-front** by walking all messages once before rendering, then use the index to find the originating tool-use struct when rendering a `ToolResultBlock`/`ServerToolResultBlock`/`MCPToolResultBlock`. This is cheaper than re-scanning the list for every result block and produces stable visual pairing even when the tool_use and tool_result span different messages.
+- **Fallback on `inspect/2` for unrecognized content blocks.** Future claude_code releases will add new block types; a catch-all `_ -> inspect(block, pretty: true, limit: :infinity)` inside a `<pre>` renders the raw struct without crashing the LiveView.
+- **Tolerate parser fallbacks.** `:message` may be a parsed struct map *or* a raw fallback map when the JSONL row failed to parse. The renderer treats `message` as an opaque map, using `Map.get/2` with both atom and string keys as needed, and wraps the content iteration so a non-list `:content` degrades to a single raw-map fallback rather than a crash.
+- **Empty-state triggers.** The detail page short-circuits to an empty state for any of: `ai_session.claude_session_id == nil`, `{:ok, []}`, or `{:error, _}` from `History.get_messages/1`. Logging happens at `Logger.warning` for `{:error, _}` only.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Does the tracker need to track ai_session_id independently of workflow_session_id, given there's only one ClaudeSession per workflow_session at a time?** Resolved: yes, because the user-facing surface is a list of historical AI sessions, and we want the *currently-bound* AI session to show green while older ones show muted. Binding `ai_session_id` at ClaudeSession init gives us that per-session granularity without changing the Registry key.
+- **Where to pass `ai_session_id` into `ClaudeSession`?** Resolved via opts in `init/1`, mirroring how `workflow_session_id` is already plumbed.
+- **How to test `ClaudeCode.Session.get_messages/1` without touching the real `~/.claude/projects` tree?** Resolved via a `Destila.AI.History` adapter configured through `Application.get_env`, defaulting to the real `ClaudeCode.Session`. See Unit 5.
+- **Reuse `ChatComponents` for rendering?** Resolved: no — different input struct shape. See Key Technical Decisions.
+- **Route shape.** Resolved: `/sessions/:workflow_session_id/ai/:ai_session_id` maps to `DestilaWeb.AiSessionDetailLive` inside the existing `scope "/", DestilaWeb`.
+
+### Deferred to Implementation
+
+- **Exact Tailwind classes for the AI Sessions sidebar rows.** Visual style to match existing `user-prompt-section` buttons: `w-full flex items-center gap-2.5 px-2 py-1.5 rounded-md hover:bg-base-200/60`. Exact wording, icon choice (`hero-chat-bubble-oval-left-micro` vs `hero-cpu-chip-micro`), and spacing will be finalized with the visual pass during implementation.
+- **Whether to show message count or timestamps alongside each row.** The prompt only requires creation date; we will add counts only if they fit cleanly without clutter.
+- **How to escape/render very long JSON blobs in tool inputs/outputs.** Truncation thresholds and CSS `max-h` with a "show full" toggle are decided at implementation time based on how they feel with real data.
+- **Accessibility semantics for the collapsible thinking block.** `<details>`/`<summary>` vs button-plus-aria-expanded is decided at implementation time.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+**Aliveness flow (dual-key):**
+
+```
+ClaudeSession.init(opts: [workflow_session_id, ai_session_id, ...])
+  ├─ starts ClaudeCode
+  └─ broadcasts {:claude_session_started, ws_id, ai_id} on "claude_sessions"
+
+AlivenessTracker
+  ├─ on init + on :claude_session_started:
+  │     monitor(pid)
+  │     ets.insert({:workflow, ws_id}, true)    ← preserves existing contract
+  │     ets.insert({:ai, ai_id}, true)          ← new
+  │     broadcast({:aliveness_changed, ws_id, true})
+  │     broadcast({:aliveness_changed_ai, ai_id, true})
+  └─ on :DOWN:
+        ets.delete({:workflow, ws_id})
+        ets.delete({:ai, ai_id})
+        broadcast both false
+
+Public API
+  ├─ alive?(ws_id)              ← unchanged
+  └─ alive_ai?(ai_id)            ← new
+```
+
+**Detail-page render pipeline:**
+
+```
+mount(%{"workflow_session_id" => ws_id, "ai_session_id" => ai_id})
+  ├─ load ai_session, validate ai_session.workflow_session_id == ws_id
+  ├─ if claude_session_id is nil → empty state
+  ├─ else Destila.AI.History.get_messages(claude_session_id)
+  │       { :ok, [] }        → empty state
+  │       { :error, _ }      → log + empty state
+  │       { :ok, messages }  → {messages, tool_index}
+  └─ render(messages, tool_index)
+
+render(messages, tool_index):
+  for each %SessionMessage{type, message}:
+    branch on type:
+      :assistant → iterate message[:content] blocks (see block table)
+      :user      → if binary → text bubble
+                   if list   → iterate content blocks
+
+  for each content block, branch on struct:
+    TextBlock            → markdown bubble
+    ThinkingBlock        → <details> collapsible
+    RedactedThinkingBlock→ placeholder
+    ToolUseBlock         → name + pretty JSON input; mark id in index
+    ToolResultBlock      → look up tool_use by tool_use_id; pair visually;
+                           is_error → error style
+    ServerToolUseBlock/ResultBlock → same shape, labelled "server tool"
+    MCPToolUseBlock/ResultBlock    → same shape + server_name
+    ImageBlock / DocumentBlock / ContainerUploadBlock → placeholder card
+    CompactionBlock      → "--- Conversation compacted ---" marker
+    _ (unknown)          → <pre>{inspect(block, pretty: true)}</pre>
+```
+
+**Tool-use index build pass (directional pseudo-code):**
+
+```
+tool_index =
+  Enum.reduce(messages, %{}, fn msg, acc ->
+    content = get_in(msg, [:message, :content]) || []
+    content
+    |> List.wrap()
+    |> Enum.reduce(acc, fn
+         %ToolUseBlock{id: id} = b, a      -> Map.put(a, id, b)
+         %ServerToolUseBlock{id: id} = b, a -> Map.put(a, id, b)
+         %MCPToolUseBlock{id: id} = b, a    -> Map.put(a, id, b)
+         _, a                               -> a
+       end)
+  end)
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Extend `AlivenessTracker` to dual-key (`workflow_session_id` + `ai_session_id`)**
+
+**Goal:** Track aliveness by both keys while preserving the existing `workflow_session_id` contract.
+
+**Requirements:** R13, and enables R2.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `lib/destila/ai/aliveness_tracker.ex`
+- Modify: `lib/destila/ai/claude_session.ex` (broadcast 3-tuple; accept `ai_session_id` opt)
+- Modify: `lib/destila/ai/conversation.ex` (pass `ai_session_id` into `ClaudeSession.for_workflow_session/2`)
+- Modify: `lib/destila/pub_sub_helper.ex` (optional: add a helper to form the 3-tuple if we want a named constructor)
+- Test: `test/destila/ai/aliveness_tracker_test.exs` (create if missing)
+
+**Approach:**
+- Store ETS entries under tagged keys: `{{:workflow, ws_id}, true}` and `{{:ai, ai_id}, true}`. Update the existing `alive?/1` implementation to continue looking up `{:workflow, ws_id}` so external callers see no change.
+- Add `alive_ai?/1` (or `alive_ai_session?/1`) that looks up `{:ai, ai_id}`.
+- Track two independent monitor-ref maps or one map keyed by ref with a `{:workflow_and_ai, ws_id, ai_id}` value so that a single `:DOWN` cleans up both keys atomically.
+- In `ClaudeSession.init/1`, pop `:ai_session_id` from opts and include it in the `{:claude_session_started, ws_id, ai_id}` broadcast. Keep the old 2-tuple broadcast path alive as a fallback for safety (the tracker handles both) — or remove it cleanly since we control both producer and consumer. Decision: remove the 2-tuple on the producer side since both ends ship together; the tracker retains a `handle_info/2` clause for the 2-tuple with `ai_id: nil` only to avoid breakage from any in-flight messages during deploy.
+- In `Conversation.ensure_session/*` or wherever `ClaudeSession.for_workflow_session/2` is called, pass `ai_session_id: ai_session.id` via opts. Confirm the call site by following the code path from `Destila.AI.Conversation` during implementation.
+- Scan on `init/1` is extended: `Registry.select` already yields `{ws_id, pid}`; to recover `ai_session_id` after a tracker restart, fall back to a DB lookup via `AI.get_ai_session_for_workflow/1` (best-effort). If no ai_session exists yet, skip the `{:ai, ai_id}` entry — the next claude_session_started broadcast will fill it in.
+
+**Patterns to follow:**
+- `lib/destila/ai/aliveness_tracker.ex` existing monitor/broadcast loop (don't change the topic name).
+
+**Test scenarios:**
+- Happy path: simulating `{:claude_session_started, ws_id, ai_id}` populates both ETS entries and broadcasts both aliveness messages.
+- Happy path: `alive?/1` returns true for ws_id; `alive_ai?/1` returns true for ai_id.
+- Edge case: a `:DOWN` for the monitored pid clears both entries and broadcasts both `false` messages.
+- Edge case: init scan where a ClaudeSession is already running and an ai_session row exists for that ws_id — both keys are populated.
+- Edge case: init scan where a ClaudeSession is running but no ai_session row has been created yet — only `{:workflow, ws_id}` is populated, no crash.
+- Integration: starting a real-ish `ClaudeSession` (via the existing stub) triggers both broadcasts end-to-end.
+
+**Verification:**
+- Existing `alive?(workflow_session_id)` behavior is unchanged for all prior callers.
+- `alive_ai?(ai_session_id)` returns true exactly when a ClaudeSession bound to that ai_session is running.
+- Both PubSub messages are emitted on start and on stop.
+
+---
+
+- [ ] **Unit 2: Add `list_ai_sessions_for_workflow/1` to `Destila.AI`**
+
+**Goal:** Provide a context function returning all AI sessions for a workflow session, ordered newest-first.
+
+**Requirements:** R1.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `lib/destila/ai.ex`
+- Test: `test/destila/ai_test.exs` (create if missing; otherwise extend)
+
+**Approach:**
+- Mirror `get_ai_session_for_workflow/1`: same `from(s in Session, where: s.workflow_session_id == ^workflow_session_id, order_by: [desc: s.inserted_at])` but without `limit`, and return via `Repo.all/1`.
+- Return an empty list (not nil) when no sessions exist — matches Ecto's `Repo.all` default.
+- Optionally add a `get_ai_session!/1` for the detail page (simple `Repo.get!(Session, id)`), or reuse `Repo.get` directly in the LiveView. Decision: add `get_ai_session/1` (plain) and have the LiveView convert `nil` into a flash redirect. This matches the TerminalLive pattern.
+
+**Patterns to follow:**
+- `Destila.AI.get_ai_session_for_workflow/1` query structure.
+
+**Test scenarios:**
+- Happy path: returns the list of sessions ordered by `inserted_at` descending.
+- Edge case: returns `[]` when the workflow has no AI sessions.
+- Edge case: filters out sessions belonging to a different workflow.
+- Happy path: `get_ai_session/1` returns the session when the id exists.
+- Edge case: `get_ai_session/1` returns `nil` for an unknown id (no raise).
+
+**Verification:**
+- The function is used by both the sidebar (Unit 3) and the detail page (Unit 4) without extra DB calls.
+
+---
+
+- [ ] **Unit 3: Render "AI Sessions" section in the workflow runner right sidebar**
+
+**Goal:** Show the AI sessions list between the "Workflow Session" and "Exported Metadata" sections, with live aliveness dots and navigation to the detail page.
+
+**Requirements:** R1, R2, R3, R14.
+
+**Dependencies:** Unit 1 (for `alive_ai?/1` and `{:aliveness_changed_ai, ...}` messages), Unit 2 (for the list function).
+
+**Files:**
+- Modify: `lib/destila_web/live/workflow_runner_live.ex`
+- Test: `test/destila_web/live/ai_session_sidebar_live_test.exs` (create)
+
+**Approach:**
+- In `mount_session/2` (currently ~line 30), load `AI.list_ai_sessions_for_workflow/1` and assign as `:ai_sessions`. Also build an initial `:ai_sessions_alive` map `%{ai_id => alive?}` by calling `AlivenessTracker.alive_ai?/1` for each id.
+- When `connected?(socket)`, the existing subscription to `AlivenessTracker.topic()` is sufficient — the tracker now broadcasts both `{:aliveness_changed, ws_id, alive?}` and `{:aliveness_changed_ai, ai_id, alive?}` on the same topic.
+- Add a new `handle_info({:aliveness_changed_ai, ai_id, alive?}, socket)` clause that updates `:ai_sessions_alive` if `ai_id` is in the loaded list. Ignore otherwise.
+- After any `assign_ai_state` call where a new AI session might have been created (e.g., `start_workflow`, `continue_workflow`, `next_phase`), refresh the `:ai_sessions` list. Simplest is to fold a helper `assign_ai_sessions_list/2` into `assign_ai_state/2` since that function is already the seam for ai-related state rebuilds.
+- Render the new section inside `#metadata-sidebar-content`, between the existing divider (`<div class="border-t border-base-300/60 mx-3">`) at ~line 863 and the Exported Metadata `<div class="px-3 pt-3 pb-6 flex-1">` at ~line 866. Add a second matching divider below the new section so the three-block rhythm is preserved.
+- Section structure: an `<h3>` with the "AI Sessions" label and the same `[10px] uppercase tracking-wider` type used for "Workflow Session"/"Exported Metadata", then either an empty-state paragraph (`"No AI sessions yet"`) or a `<ul>`/`<div class="space-y-0.5">` of rows.
+- Each row: a `<.link navigate={~p"/sessions/#{ws_id}/ai/#{ai.id}"}>` with a leading `<.aliveness_dot session={@workflow_session} alive?={...} phase_status={:idle} />` (or similar neutral phase_status), a creation date formatted like `Calendar.strftime(ai.inserted_at, "%b %-d, %H:%M")`, and (optional) a truncated `claude_session_id` suffix. Explicit DOM id `id={"ai-session-row-#{ai.id}"}`.
+- Section wrapper gets `id="ai-sessions-section"` so tests can assert on its presence.
+
+**Patterns to follow:**
+- Row layout mirrors `#view-user-prompt-btn` and `#open-terminal-btn` above it.
+- `<.aliveness_dot>` already handles all three visual states.
+- `assign_metadata/2` and `assign_worktree_path/2` are good shape templates for a new `assign_ai_sessions_list/2` helper.
+
+**Test scenarios:**
+- Happy path: sidebar shows 2 rows when the workflow has 2 AI sessions (`#ai-session-row-<id>` selector).
+- Happy path: each row is a `<.link navigate={...}>` pointing to `/sessions/:ws_id/ai/:ai_id` — assert href.
+- Happy path: empty state is rendered (`#ai-sessions-section` contains "No AI sessions yet" text) when no AI sessions exist.
+- Happy path: row shows green aliveness class when `AlivenessTracker.alive_ai?/1` is true at mount.
+- Happy path: row shows muted aliveness class when not running at mount.
+- Integration: broadcasting `{:aliveness_changed_ai, ai_id, true}` on `AlivenessTracker.topic()` flips the dot to green without a page reload.
+- Integration: broadcasting `{:aliveness_changed_ai, ai_id, false}` flips the dot back to muted.
+- Edge case: clicking a row navigates to the detail page (verify via `render_click` + `push_navigate` assertion or `assert_patched/_redirect`).
+- Edge case: header aliveness dot (existing `{:aliveness_changed, ws_id, alive?}` handler) still toggles independently.
+
+**Verification:**
+- The new section lives inside the existing collapsible sidebar and toggles away with the rest of the content when the user collapses it.
+- Existing Crafting Board aliveness behavior is untouched.
+
+---
+
+- [ ] **Unit 4: Add route + `DestilaWeb.AiSessionDetailLive` skeleton**
+
+**Goal:** Stand up the detail page with header, mount logic, subscription, empty states, and back-navigation — but without the content-block rendering (deferred to Unit 6).
+
+**Requirements:** R4, R5, R12, R13 (indirect).
+
+**Dependencies:** Unit 1 (aliveness) and Unit 2 (`get_ai_session/1`). Unit 5 optional but helpful for testing — can be stubbed with a direct ClaudeCode.Session call if Unit 5 lands later.
+
+**Files:**
+- Modify: `lib/destila_web/router.ex`
+- Create: `lib/destila_web/live/ai_session_detail_live.ex`
+- Test: `test/destila_web/live/ai_session_detail_live_test.exs` (create)
+
+**Approach:**
+- Router: add `live "/sessions/:workflow_session_id/ai/:ai_session_id", AiSessionDetailLive` inside the existing `scope "/", DestilaWeb` block, adjacent to the other `/sessions/:id...` routes. Module becomes `DestilaWeb.AiSessionDetailLive`.
+- Mount signature: `mount(%{"workflow_session_id" => ws_id, "ai_session_id" => ai_id}, _session, socket)`.
+- Lookup sequence:
+  1. `workflow_session = Workflows.get_workflow_session(ws_id)` — nil → `put_flash` + `push_navigate(~p"/crafting")`.
+  2. `ai_session = AI.get_ai_session(ai_id)` — nil → `put_flash` + `push_navigate(~p"/sessions/#{ws_id}")`.
+  3. Verify `ai_session.workflow_session_id == ws_id`; on mismatch, same redirect as (2) with a flash like "AI session does not belong to this workflow".
+- `connected?(socket)` → subscribe to `AlivenessTracker.topic()`; seed `:alive?` with `AlivenessTracker.alive_ai?/1`.
+- Load messages (with Unit 5 adapter): `History.get_messages(ai_session.claude_session_id)`:
+  - `nil` claude_session_id → `history_state = :missing` (no call made).
+  - `{:ok, []}` → `:empty`.
+  - `{:ok, msgs}` → `{:loaded, msgs, build_tool_index(msgs)}`.
+  - `{:error, reason}` → log `Logger.warning/1`, `:error`.
+- `page_title` like `"AI Session — #{ws.title}"`.
+- Render (pre-Unit-6): `Layouts.app` wrapper; header with back-link (`<.link navigate={~p"/sessions/#{ws_id}"}>` + `hero-arrow-left-micro`), workflow session title, and a card/strip showing creation date and `claude_session_id` (copyable via `<code>`), plus the live aliveness dot. Below the header: a placeholder `<div id="ai-session-conversation">` with an empty-state component for `:missing`/`:empty`/`:error`, and a `No conversation history available` message styled consistently.
+- Handle aliveness update: `handle_info({:aliveness_changed_ai, ^ai_id, alive?}, socket)` updates `:alive?`. Ignore other ids.
+
+**Patterns to follow:**
+- `DestilaWeb.TerminalLive` for mount validation + layout.
+- `Layouts.app flash={@flash} page_title={@page_title}` wrapper.
+
+**Test scenarios:**
+- Happy path: mounting with a valid ws_id + ai_id renders the header (`#ai-session-header`) including the creation date and the claude_session_id string.
+- Happy path: back link navigates to `/sessions/:ws_id`.
+- Edge case: unknown workflow_session_id redirects to `/crafting` with a flash.
+- Edge case: unknown ai_session_id redirects to the parent workflow page with a flash.
+- Edge case: ai_session belongs to a different workflow_session_id → redirect with a flash.
+- Edge case: `claude_session_id` is `nil` → renders the "No conversation history available" empty state.
+- Edge case: adapter returns `{:ok, []}` → renders empty state.
+- Edge case: adapter returns `{:error, :enoent}` → renders empty state and emits a warning log.
+- Integration: broadcasting `{:aliveness_changed_ai, ai_id, true}` on `AlivenessTracker.topic()` toggles the detail-page aliveness dot live.
+
+**Verification:**
+- The page renders in all error/empty paths without raising.
+- `@page_title` is set, so the browser tab title picks up the session title.
+
+---
+
+- [ ] **Unit 5: `Destila.AI.History` adapter for `ClaudeCode.Session.get_messages/1`**
+
+**Goal:** Make the history read swappable in tests without stubbing a module we do not own.
+
+**Requirements:** Enables R6, R7, R11, R12.
+
+**Dependencies:** None (pure refactor/seam).
+
+**Files:**
+- Create: `lib/destila/ai/history.ex`
+- Modify: `config/test.exs` (set the test implementation)
+- Test: `test/destila/ai/history_test.exs` (create; minimal)
+- Create: `test/support/fake_history.ex` (test helper storing canned responses via `Application.put_env` or an `Agent`/ETS store)
+
+**Approach:**
+- `Destila.AI.History` exposes `get_messages/1` and (optionally) `get_messages/2`. Delegate to the real implementation by default:
+  - `Application.get_env(:destila, :ai_history_module, ClaudeCode.Session).get_messages(session_id)` (or keyword form for `/2`).
+- The module doubles as a safety wrapper: it rescues any exception from the underlying call and returns `{:error, {:exception, ...}}` so the LiveView's `{:error, _}` branch covers unexpected shapes/crashes from disk/parse failures.
+- In `config/test.exs`, set `config :destila, :ai_history_module, Destila.AI.FakeHistory`.
+- The fake history module stores `{session_id => {:ok, messages} | {:error, reason}}` in an `Agent` (or process dictionary or ETS keyed by test pid via `nimble_ownership`-style if we want async). Tests call `FakeHistory.stub(session_id, {:ok, messages})` in their `setup`.
+- Build convenience fixtures: `Destila.AI.HistoryFixtures` with tiny builders like `text_message/1`, `thinking_message/1`, `tool_use_pair/3`, etc., so rendering tests stay readable.
+
+**Patterns to follow:**
+- `ClaudeCode.Test.stub/2` in the existing tests as conceptual inspiration, but we own this adapter so we can expose whatever API reads cleanly.
+
+**Test scenarios:**
+- Happy path: delegates to the configured module; default config calls `ClaudeCode.Session.get_messages/1` (verified via a stand-in module that records the call).
+- Edge case: when the underlying call raises, the adapter returns `{:error, {:exception, ...}}` instead of propagating.
+- Integration: in test env, `Destila.AI.History.get_messages(id)` returns exactly what `FakeHistory.stub/2` provided.
+
+**Verification:**
+- The LiveView never imports `ClaudeCode.Session` directly; it only calls `History.get_messages/1`.
+- Tests can drive arbitrary history shapes (including `{:ok, []}`, `{:error, :enoent}`, and rich content-block fixtures) without touching disk.
+
+---
+
+- [ ] **Unit 6: `DestilaWeb.AiSessionDebugComponents` + full renderer wired into the detail page**
+
+**Goal:** Render every content block type, pair tool calls with tool results, gracefully handle unknown shapes.
+
+**Requirements:** R6, R7, R8, R9, R10, R11.
+
+**Dependencies:** Units 4 and 5.
+
+**Files:**
+- Create: `lib/destila_web/components/ai_session_debug_components.ex`
+- Modify: `lib/destila_web/live/ai_session_detail_live.ex` (wire the renderer in, build the tool_use index at mount time, pass both into the template)
+- Test: `test/destila_web/live/ai_session_detail_live_test.exs` (extend with block-by-block coverage)
+
+**Approach:**
+- Module exposes a single primary function component `session_history/1` that takes `messages:` and `tool_index:`. Internally it iterates messages and dispatches each content block to a smaller component via a pattern-matching dispatcher:
+  - `content_block/1` — function component; first argument is the block struct; delegates via a `case` on struct module.
+- Message-level rendering:
+  - `type: :user` + binary content → `user_text_bubble/1`.
+  - `type: :user` + list content → iterate list with `content_block/1`.
+  - `type: :assistant` → iterate `message[:content]` list with `content_block/1`.
+  - Tolerate `message` being a raw map: use `get_in(message, [:content]) || get_in(message, ["content"])` and `List.wrap/1` for non-list shapes. Non-list / non-binary content falls through to the generic fallback renderer.
+- Per-block rendering (each is a small function or one branch in `content_block/1`):
+  - `TextBlock` — render `text` via the existing markdown renderer if that is easy; plain `<p>` with `whitespace-pre-wrap` is a safe fallback. Citations rendered beneath as a small list when present.
+  - `ThinkingBlock` — `<details>` collapsed by default; `<summary>` "Thinking (click to expand)"; `<pre>` of `thinking`. Signature hidden unless a debug flag is flipped.
+  - `RedactedThinkingBlock` — subtle placeholder "[Redacted thinking — #{byte_size(data)} bytes]".
+  - `ToolUseBlock` — header row with tool name + id; pretty JSON `<pre>` of `input` via `Jason.encode!(input, pretty: true)`. Add `id={"tool-use-#{id}"}` as the anchor for its result.
+  - `ToolResultBlock` — find `tool_use_index[tool_use_id]`; render a nested card under/beside the tool_use with name carried over and `is_error` → red border/background. Content is string → `<pre>`, list of TextBlocks → iterate text.
+  - `ServerToolUseBlock` / `ServerToolResultBlock` — same shape; label "server tool: web_search" etc.; result `:type` shown as a small badge.
+  - `MCPToolUseBlock` / `MCPToolResultBlock` — same shape plus `server_name` badge.
+  - `ImageBlock` — render `<img src={...}>` for URLs; for base64, render a placeholder card "Image — base64, #{kb} KB" (don't decode a megabyte of b64 into the DOM). Decision reason: avoids DOM blow-up; still communicates presence.
+  - `DocumentBlock` — placeholder card with title + context.
+  - `ContainerUploadBlock` — placeholder card "Uploaded file: #{file_id}".
+  - `CompactionBlock` — full-width horizontal marker "--- Conversation compacted ---" with the compaction content collapsed by default.
+  - Catch-all clause `_ ->` renders `<pre class="text-xs">#{inspect(block, pretty: true, limit: :infinity)}</pre>` inside a subdued card.
+- Visual separation: assistant content is right-aligned or uses a distinct background (bg-base-200), user content uses a different background (bg-primary/10) or left alignment.
+- Tool pairing: the simplest approach is to walk messages top-to-bottom in order and render each block in place. Since `ToolResultBlock` sometimes arrives in a follow-up user message, rendering it *at that point in the stream* plus showing the resolved tool_use name from `tool_index[tool_use_id]` satisfies the "visually paired" requirement without reordering messages. Optional enhancement: nest the ToolResultBlock visually beneath the ToolUseBlock using the `id="tool-use-#{id}"` anchor — can be done with a small CSS rule or an arrow icon pointing up to the originating tool_use.
+- Each rendered block gets a stable DOM id (e.g., `data-block-type="tool_use"` + `id="block-#{uuid}-#{index}"`) for testability.
+
+**Patterns to follow:**
+- `lib/destila_web/components/chat_components.ex` function component structure and Tailwind vocabulary.
+- `Jason.encode!(value, pretty: true)` for JSON prettifying (Jason is already a transitive dep).
+- Tests in `test/destila_web/live/markdown_metadata_viewing_live_test.exs` for how to assert on rendered HTML with `has_element?/2`.
+
+**Test scenarios (drive via `FakeHistory.stub` with hand-built fixtures):**
+- Happy path: a user text message and an assistant text message render in order, with different classes/selectors distinguishing them.
+- Happy path: a `ThinkingBlock` renders inside a `<details>` element; its content is not visible until expanded (assert via selector that `<details>` lacks the `open` attribute).
+- Happy path: a `RedactedThinkingBlock` renders a visible placeholder.
+- Happy path: a `ToolUseBlock` renders tool name, id, and pretty JSON of its input; presence assertable via `data-block-type="tool_use"`.
+- Happy path: a `ToolUseBlock` + `ToolResultBlock` share the `tool_use_id` and the rendered result carries a visual link (e.g., `data-tool-use-ref="#{id}"` attribute or `data-tool-name` pulled from the tool_index).
+- Error path: a `ToolResultBlock` with `is_error: true` renders with an error class (e.g., `text-error` or `border-error`).
+- Happy path: a `ServerToolUseBlock`/`ServerToolResultBlock` pair renders with a "server tool" badge.
+- Happy path: an `MCPToolUseBlock` renders with its `server_name` and `name` visible.
+- Happy path: an `ImageBlock` with a URL source renders an `<img>`; a base64 `ImageBlock` renders a placeholder card without embedding the bytes.
+- Happy path: a `CompactionBlock` renders a visible compaction marker.
+- Edge case: an `%{__struct__: NotARealBlock}` struct renders as a `<pre>` fallback with `inspect/2` output and does not crash.
+- Edge case: a `SessionMessage` whose `:message` is a raw map (parser fallback) renders a fallback summary without raising.
+- Edge case: a `SessionMessage` whose `:message[:content]` is a binary (for `type: :user`) renders as plain text.
+- Edge case: empty `content` list renders nothing (no layout breakage).
+
+**Verification:**
+- All Gherkin scenarios in `features/ai_session_detail.feature` pass.
+- The page renders with the full block zoo in a single fixture without crashing.
+
+---
+
+- [ ] **Unit 7: Gherkin features + test linkage**
+
+**Goal:** Commit the two `.feature` files from the prompt and ensure every LiveView test carries the matching `@tag feature:/scenario:`.
+
+**Requirements:** R15.
+
+**Dependencies:** Units 3, 4, 6 (the tests live in those unit's test files).
+
+**Files:**
+- Create: `features/ai_session_sidebar.feature`
+- Create: `features/ai_session_detail.feature`
+- Modify: `test/destila_web/live/ai_session_sidebar_live_test.exs`
+- Modify: `test/destila_web/live/ai_session_detail_live_test.exs`
+
+**Approach:**
+- Copy the Gherkin from the prompt verbatim into the two feature files.
+- Ensure the `@moduledoc` of each LiveView test module links back to its feature file (`Feature: features/ai_session_sidebar.feature`).
+- Ensure every test carries `@tag feature: "...", scenario: "..."` matching an existing scenario in the feature file.
+- Cross-check that every scenario in the feature file has at least one linked test. For scenarios that are covered by logic-level tests in Unit 1 (not a LiveView test), carry the tag on the closest LiveView test that observes the effect.
+- Run `mix test --only feature:ai_session_sidebar` and `mix test --only feature:ai_session_detail` to confirm linkage.
+
+**Patterns to follow:**
+- `features/exported_metadata.feature` and `test/destila_web/live/open_terminal_live_test.exs` for tag format.
+
+**Test scenarios:**
+- Test expectation: none — this unit only adds feature files and `@tag` metadata. Correctness is verified by `mix test --only feature:...` returning nonzero test count and by a cross-reference check that every scenario title appears in at least one test.
+
+**Verification:**
+- `mix test --only feature:ai_session_sidebar` runs at least one test per scenario in that feature.
+- `mix test --only feature:ai_session_detail` runs at least one test per scenario in that feature.
+
+---
+
+- [ ] **Unit 8: Precommit run and polish**
+
+**Goal:** Run `mix precommit`, fix any lint/type/test issues, and do one manual pass of the UI in the browser.
+
+**Requirements:** All R-requirements indirectly.
+
+**Dependencies:** Units 1–7.
+
+**Files:**
+- None new — fixes only.
+
+**Approach:**
+- `mix precommit` (covers formatter, compile-warnings-as-errors, tests — per `CLAUDE.md` guidance).
+- Start the server with `elixir --sname destila -S mix phx.server`, create a workflow session that reaches the point of having at least one AI session with a `claude_session_id`, open the workflow runner, and verify:
+  - AI Sessions section appears between Workflow Session and Exported Metadata.
+  - Aliveness dot is green while the GenServer is alive.
+  - Collapse/expand of the sidebar still works (the new section hides with the rest).
+  - Clicking a row opens the detail page.
+  - Detail page shows header + conversation.
+  - Back navigation returns to the workflow runner.
+- Verify a session with no `claude_session_id` renders the empty state.
+
+**Patterns to follow:**
+- `CLAUDE.md` ops guidance (remote shell + `mix precommit`).
+
+**Test scenarios:**
+- Test expectation: none — final integration verification; any regressions become fixes in prior units.
+
+**Verification:**
+- `mix precommit` is green.
+- Manual UI exploration passes the five checks above.
+
+## System-Wide Impact
+
+- **Interaction graph:** The AlivenessTracker is the hub. `ClaudeSession` broadcasts to it; it broadcasts to all LiveViews subscribed on `"session_aliveness"` (currently the workflow runner and the Crafting Board; now also the AI Session Detail page). Adding a second broadcast message type (`:aliveness_changed_ai`) on the same topic means every existing subscriber receives an extra message per AI state change — cost is trivial (a pattern match that falls through) but worth naming.
+- **Error propagation:** `History.get_messages/1` is the only new disk-touching call. It is wrapped in a rescue at the adapter level, and the LiveView treats `{:error, _}` as the empty-state branch. No error path crashes the LiveView.
+- **State lifecycle risks:** The ETS table in `AlivenessTracker` grows by one entry per running AI session. Entries are removed on `:DOWN`, and because ClaudeSession processes have an inactivity timer (5 min default), stale `{:ai, id}` entries clear naturally. The only lingering concern is a restart of the tracker itself — its init now walks the Registry and (optionally) the DB to rehydrate `{:ai, id}` entries; if the DB lookup fails, `{:workflow, ws_id}` is still correct, preserving existing behavior.
+- **API surface parity:** `alive?/1` semantics are explicitly preserved for the Crafting Board and the workflow runner header. The new `alive_ai?/1` function is purely additive. No public function is renamed or removed.
+- **Integration coverage:** An integration test in `ai_session_sidebar_live_test.exs` broadcasts the new `:aliveness_changed_ai` message on `AlivenessTracker.topic()` and asserts the dot flips — this validates the PubSub wiring end-to-end, not just the handler logic.
+- **Unchanged invariants:** The 1-to-1 relationship between `workflow_session_id` and a running `ClaudeSession` in the Registry is not changed; the header aliveness dot keeps its workflow-level meaning; the existing `get_ai_session_for_workflow/1` (latest only) still exists and is still used by `WorkflowRunnerLive.assign_worktree_path/2`.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `ClaudeCode.Session.get_messages/1` path, signature, or return shape differs from what the prompt describes | Wrap the call in `Destila.AI.History` with a rescue. Verify the real signature during Unit 5 implementation by `iex -S mix` + a known session id before relying on the empirical shape. If the real API takes a PID instead of a session id string, the adapter absorbs that change — only the adapter's body needs fixing. |
+| Tracker dual-key rehydrate misses an ai_session_id after a crash/restart | The detail page and sidebar both call `alive_ai?/1`; worst case is a muted dot on a currently-running session until the next `{:claude_session_started, ...}` broadcast. Acceptable. Next broadcast (idle timer end or next user turn) will correct it. A `Logger.debug/1` line when rehydrate can't find an ai_session for a running ws_id makes this observable without noise. |
+| Large JSONL files (long conversations) block the LiveView mount | MVP reads the whole file synchronously. Acceptable for current session sizes. Add `limit:`/`offset:` via `get_messages/2` if users complain; the adapter already takes a keyword list. |
+| Broadcast storm when an AI session turns over quickly | Two broadcasts per state transition instead of one. At the current workload this is not a concern; noted for future scaling. |
+| Renderer crashes on a new content block type shipped by claude_code | Catch-all `inspect/2` fallback plus a dedicated test asserting an unknown struct does not crash. |
+| Existing callers of `alive?/1` still expect workflow semantics | Preserved explicitly — the ETS key change (`{:workflow, ws_id}`) is encapsulated behind the same function signature. A test asserts `alive?(ws_id)` returns the expected value after the refactor. |
+| Test coverage gap: history fixtures drift from the real library shapes | Include at least one test that round-trips a realistic hand-built `%ClaudeCode.History.SessionMessage{}` (aliased struct, not a plain map) to catch schema drift when the claude_code package upgrades. |
+
+## Documentation / Operational Notes
+
+- No runbook changes — this is an in-app debugging surface.
+- Feature files in `features/` serve as the user-facing documentation for behavior; they are the contract for the tests.
+- No config changes required in production; `config/test.exs` gets the `Destila.AI.FakeHistory` wiring.
+
+## Sources & References
+
+- **Origin:** direct user prompt (no `docs/brainstorms/` requirements document).
+- Relevant code:
+  - `lib/destila/ai/aliveness_tracker.ex`
+  - `lib/destila/ai.ex` (`get_ai_session_for_workflow/1`)
+  - `lib/destila/ai/session.ex`
+  - `lib/destila/ai/claude_session.ex`
+  - `lib/destila/ai/conversation.ex`
+  - `lib/destila_web/live/workflow_runner_live.ex` (right sidebar at ~lines 695–900)
+  - `lib/destila_web/live/terminal_live.ex` (detail-page shape reference)
+  - `lib/destila_web/router.ex`
+  - `lib/destila_web/components/board_components.ex` (`aliveness_dot/1`)
+  - `lib/destila_web/components/chat_components.ex` (componentization reference)
+- External docs:
+  - `ClaudeCode.Session` and history: https://github.com/guess/claude_code/blob/main/docs/guides/sessions.md
+  - `%ClaudeCode.History.SessionMessage{}`: https://github.com/guess/claude_code/blob/main/lib/claude_code/history/session_message.ex
+  - `ClaudeCode.Content.*` structs: https://github.com/guess/claude_code/tree/main/lib/claude_code/content/

--- a/features/ai_session_detail.feature
+++ b/features/ai_session_detail.feature
@@ -1,0 +1,112 @@
+Feature: AI Session Debug Detail Page
+  The AI Session Debug Detail page at /sessions/:workflow_session_id/ai/:ai_session_id
+  shows the creation date and Claude session id in a header, then renders the
+  full conversation history read from Destila.AI.History.get_messages/2. Every
+  content block type emitted by ClaudeCode (text, thinking, tool usage, tool
+  results, server tool usage, MCP tool usage, images, documents, redacted
+  thinking, container uploads, compaction markers) renders without crashing the
+  page, with an inspect/2 fallback for unknown block shapes.
+
+  Scenario: Header shows creation date and Claude session id
+    Given I open the AI Session Debug Detail page for a valid AI session
+    Then the header should display the AI session creation date
+    And the header should display the Claude session id
+
+  Scenario: Back link navigates to the parent workflow runner
+    Given I am on the AI Session Debug Detail page
+    When I click the back link in the header
+    Then I should be navigated to the parent workflow runner page
+
+  Scenario: Unknown workflow session id redirects to the crafting board
+    Given I request the AI Session Debug Detail page with an unknown workflow session id
+    Then I should be redirected to the crafting board
+    And I should see a "Session not found" flash
+
+  Scenario: Unknown AI session id redirects to the workflow runner
+    Given I request the AI Session Debug Detail page with an unknown AI session id
+    Then I should be redirected to the workflow runner page
+
+  Scenario: AI session belonging to another workflow is rejected
+    Given I request the AI Session Debug Detail page with an AI session that belongs to a different workflow
+    Then I should be redirected to the parent workflow runner page
+    And I should see a flash explaining that the AI session does not belong to this workflow
+
+  Scenario: Missing Claude session id shows empty state
+    Given I open the AI Session Debug Detail page for an AI session without a Claude session id
+    Then the page should render a "No conversation history available" empty state
+
+  Scenario: Empty history shows empty state
+    Given the history adapter returns an empty list
+    When I open the AI Session Debug Detail page
+    Then the page should render a "No conversation history available" empty state
+
+  Scenario: History read failure shows empty state
+    Given the history adapter returns an error tuple
+    When I open the AI Session Debug Detail page
+    Then the page should render an "Unable to read conversation history" empty state
+
+  Scenario: Aliveness dot toggles live on the detail page
+    Given I am on the AI Session Debug Detail page
+    When the AlivenessTracker broadcasts an AI-specific aliveness change for this session
+    Then the detail page aliveness dot should update without a reload
+
+  Scenario: Text blocks render in order
+    Given the history contains a user text block followed by an assistant text block
+    When I open the AI Session Debug Detail page
+    Then both blocks should be visible in order
+
+  Scenario: Thinking block renders collapsed by default
+    Given the history contains a thinking block
+    When I open the AI Session Debug Detail page
+    Then the thinking block should render as a collapsed details element
+
+  Scenario: Redacted thinking block renders as a placeholder
+    Given the history contains a redacted thinking block
+    When I open the AI Session Debug Detail page
+    Then the block should render a visible redacted placeholder
+
+  Scenario: Tool use block renders tool name and pretty JSON input
+    Given the history contains a tool use block
+    When I open the AI Session Debug Detail page
+    Then the block should display the tool name and pretty-printed JSON input
+
+  Scenario: Tool result block is paired with its tool use
+    Given the history contains a tool use block and a matching tool result block
+    When I open the AI Session Debug Detail page
+    Then the tool result block should reference the originating tool use id
+
+  Scenario: Tool result with is_error renders with an error style
+    Given the history contains a tool result block whose is_error flag is true
+    When I open the AI Session Debug Detail page
+    Then the block should render with an error style
+
+  Scenario: Server tool use and result render with a server tool badge
+    Given the history contains a server tool use block and a server tool result block
+    When I open the AI Session Debug Detail page
+    Then both blocks should render with a server tool label
+
+  Scenario: MCP tool blocks render with server_name and tool name
+    Given the history contains an MCP tool use block
+    When I open the AI Session Debug Detail page
+    Then the block should display its server_name and tool name
+
+  Scenario: Image block with URL source renders an img element
+    Given the history contains an image block with a URL source
+    When I open the AI Session Debug Detail page
+    Then the page should render an img element pointing at the URL
+
+  Scenario: Image block with base64 source renders a placeholder
+    Given the history contains an image block with a base64 source
+    When I open the AI Session Debug Detail page
+    Then the page should render a placeholder card without embedding the raw bytes
+
+  Scenario: Compaction block renders a visible marker
+    Given the history contains a compaction block
+    When I open the AI Session Debug Detail page
+    Then the page should render a compaction marker
+
+  Scenario: Unknown block types render via an inspect fallback
+    Given the history contains a content block whose struct is not recognized
+    When I open the AI Session Debug Detail page
+    Then the page should render the block through a pre element with inspect output
+    And the page should not crash

--- a/features/ai_session_detail.feature
+++ b/features/ai_session_detail.feature
@@ -50,6 +50,24 @@ Feature: AI Session Debug Detail Page
     When the AlivenessTracker broadcasts an AI-specific aliveness change for this session
     Then the detail page aliveness dot should update without a reload
 
+  Scenario: Stream chunk triggers debounced history reload
+    Given I am on the AI Session Debug Detail page with one message already rendered
+    When a Claude stream chunk is broadcast for this workflow session
+    And the debounced reload timer fires
+    Then newly appended messages should render without a page reload
+
+  Scenario: Stream chunk transitions empty history to loaded
+    Given I am on the AI Session Debug Detail page showing the empty state
+    When a Claude stream chunk is broadcast and new messages have been written
+    And the debounced reload timer fires
+    Then the empty state should be replaced with the rendered messages
+
+  Scenario: Debounced reload does not duplicate messages
+    Given I am on the AI Session Debug Detail page with one message already rendered
+    When multiple Claude stream chunks are broadcast before the reload timer fires
+    And the debounced reload timer fires
+    Then the rendered message should not be duplicated
+
   Scenario: Text blocks render in order
     Given the history contains a user text block followed by an assistant text block
     When I open the AI Session Debug Detail page

--- a/features/ai_session_sidebar.feature
+++ b/features/ai_session_sidebar.feature
@@ -1,0 +1,53 @@
+Feature: AI Sessions Sidebar
+  The workflow runner right sidebar exposes an "AI Sessions" section between the
+  "Workflow Session" and "Exported Metadata" sections. Each row represents a past
+  or current AI session for the workflow, shows a live aliveness dot (green when
+  the Claude Code GenServer is running, muted when not), and navigates to the
+  AI Session Debug Detail page when clicked.
+
+  Scenario: AI Sessions section renders between Workflow Session and Exported Metadata
+    Given I am on a workflow runner page
+    Then the right sidebar should contain an "AI Sessions" section
+    And the section should sit between the "Workflow Session" and "Exported Metadata" sections
+
+  Scenario: AI Sessions section lists every AI session for the workflow
+    Given the workflow session has two AI sessions
+    When I open the workflow runner page
+    Then the sidebar should show two AI session rows
+    And each row should be a link to the AI Session Debug Detail page
+
+  Scenario: Empty state when no AI sessions exist
+    Given the workflow session has no AI sessions
+    When I open the workflow runner page
+    Then the sidebar should indicate "No AI sessions yet"
+
+  Scenario: Running AI session shows a green aliveness dot
+    Given the workflow session has one AI session whose Claude Code process is alive
+    When I open the workflow runner page
+    Then the corresponding sidebar row should display a green aliveness dot
+
+  Scenario: Inactive AI session shows a muted aliveness dot
+    Given the workflow session has one AI session with no running Claude Code process
+    When I open the workflow runner page
+    Then the corresponding sidebar row should display a muted aliveness dot
+
+  Scenario: Aliveness dot toggles to green in real time when a session starts
+    Given I am on a workflow runner page showing an inactive AI session
+    When the AlivenessTracker broadcasts that the AI session is alive
+    Then the corresponding row should update to a green aliveness dot without a reload
+
+  Scenario: Aliveness dot toggles to muted in real time when a session stops
+    Given I am on a workflow runner page showing a running AI session
+    When the AlivenessTracker broadcasts that the AI session is no longer alive
+    Then the corresponding row should update to a muted aliveness dot without a reload
+
+  Scenario: Clicking a row opens the AI Session Debug Detail page
+    Given I am on a workflow runner page
+    And the workflow session has one AI session
+    When I click the AI session row
+    Then I should be navigated to the AI Session Debug Detail page for that session
+
+  Scenario: Workflow header aliveness dot is unaffected
+    Given I am on a workflow runner page
+    When the AlivenessTracker broadcasts an AI-specific aliveness change
+    Then the workflow-level header aliveness dot should remain unchanged

--- a/lib/destila/ai.ex
+++ b/lib/destila/ai.ex
@@ -21,6 +21,19 @@ defmodule Destila.AI do
     )
   end
 
+  def list_ai_sessions_for_workflow(workflow_session_id) do
+    Repo.all(
+      from(s in Session,
+        where: s.workflow_session_id == ^workflow_session_id,
+        order_by: [desc: s.inserted_at]
+      )
+    )
+  end
+
+  def get_ai_session(id) do
+    Repo.get(Session, id)
+  end
+
   def get_ai_session_for_workflow!(workflow_session_id) do
     Repo.one!(
       from(s in Session,

--- a/lib/destila/ai/aliveness_tracker.ex
+++ b/lib/destila/ai/aliveness_tracker.ex
@@ -2,6 +2,11 @@ defmodule Destila.AI.AlivenessTracker do
   @moduledoc """
   Centralized GenServer that monitors all AI session processes and exposes
   aliveness via ETS (for instant reads) and PubSub (for change notifications).
+
+  Tracks aliveness by two independent keys — `workflow_session_id` (stable
+  across AI sessions for a given workflow) and `ai_session_id` (one per
+  Destila.AI.Session row). Both share the underlying monitored pid so a
+  single :DOWN clears both keys atomically.
   """
 
   use GenServer
@@ -13,10 +18,19 @@ defmodule Destila.AI.AlivenessTracker do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  @doc "Returns true if an AI session GenServer is running for the given session ID."
-  def alive?(session_id) do
-    case :ets.lookup(@ets_table, session_id) do
-      [{^session_id, true}] -> true
+  @doc "Returns true if a ClaudeSession GenServer is running for the given workflow session ID."
+  def alive?(workflow_session_id) do
+    lookup({:workflow, workflow_session_id})
+  end
+
+  @doc "Returns true if a ClaudeSession GenServer is running for the given AI session ID."
+  def alive_ai?(ai_session_id) do
+    lookup({:ai, ai_session_id})
+  end
+
+  defp lookup(key) do
+    case :ets.lookup(@ets_table, key) do
+      [{^key, true}] -> true
       _ -> false
     end
   end
@@ -29,21 +43,43 @@ defmodule Destila.AI.AlivenessTracker do
     :ets.new(@ets_table, [:set, :public, :named_table, read_concurrency: true])
     Phoenix.PubSub.subscribe(Destila.PubSub, Destila.PubSubHelper.claude_session_topic())
 
-    # Scan for existing sessions already registered in the AI SessionRegistry
+    # Scan for existing sessions already registered in the AI SessionRegistry.
+    # Best-effort rehydrate of ai_session_id via the Repo — a missing row just
+    # means the workflow key is populated and the ai key will be filled in by
+    # the next :claude_session_started broadcast.
     refs =
       Registry.select(Destila.AI.SessionRegistry, [{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
-      |> Enum.reduce(%{}, fn {session_id, pid}, acc ->
+      |> Enum.reduce(%{}, fn {workflow_session_id, pid}, acc ->
         ref = Process.monitor(pid)
-        :ets.insert(@ets_table, {session_id, true})
-        Map.put(acc, ref, session_id)
+        ai_session_id = lookup_ai_session_id(workflow_session_id)
+        insert_entries(workflow_session_id, ai_session_id)
+        Map.put(acc, ref, {workflow_session_id, ai_session_id})
       end)
 
     {:ok, %{refs: refs}}
   end
 
   @impl true
-  def handle_info({:claude_session_started, session_id}, state) do
-    name = {:via, Registry, {Destila.AI.SessionRegistry, session_id}}
+  def handle_info({:claude_session_started, workflow_session_id, ai_session_id}, state) do
+    start_tracking(workflow_session_id, ai_session_id, state)
+  end
+
+  def handle_info({:claude_session_started, workflow_session_id}, state) do
+    start_tracking(workflow_session_id, nil, state)
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    {{workflow_session_id, ai_session_id}, refs} = Map.pop!(state.refs, ref)
+    delete_entries(workflow_session_id, ai_session_id)
+    broadcast_workflow(workflow_session_id, false)
+    if ai_session_id, do: broadcast_ai(ai_session_id, false)
+    {:noreply, %{state | refs: refs}}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  defp start_tracking(workflow_session_id, ai_session_id, state) do
+    name = {:via, Registry, {Destila.AI.SessionRegistry, workflow_session_id}}
 
     case GenServer.whereis(name) do
       nil ->
@@ -51,26 +87,45 @@ defmodule Destila.AI.AlivenessTracker do
 
       pid ->
         ref = Process.monitor(pid)
-        :ets.insert(@ets_table, {session_id, true})
-        broadcast(session_id, true)
-        {:noreply, put_in(state, [:refs, ref], session_id)}
+        insert_entries(workflow_session_id, ai_session_id)
+        broadcast_workflow(workflow_session_id, true)
+        if ai_session_id, do: broadcast_ai(ai_session_id, true)
+        {:noreply, put_in(state, [:refs, ref], {workflow_session_id, ai_session_id})}
     end
   end
 
-  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
-    {session_id, refs} = Map.pop!(state.refs, ref)
-    :ets.delete(@ets_table, session_id)
-    broadcast(session_id, false)
-    {:noreply, %{state | refs: refs}}
+  defp insert_entries(workflow_session_id, ai_session_id) do
+    :ets.insert(@ets_table, {{:workflow, workflow_session_id}, true})
+    if ai_session_id, do: :ets.insert(@ets_table, {{:ai, ai_session_id}, true})
   end
 
-  def handle_info(_msg, state), do: {:noreply, state}
+  defp delete_entries(workflow_session_id, ai_session_id) do
+    :ets.delete(@ets_table, {:workflow, workflow_session_id})
+    if ai_session_id, do: :ets.delete(@ets_table, {:ai, ai_session_id})
+  end
 
-  defp broadcast(session_id, alive?) do
+  defp broadcast_workflow(workflow_session_id, alive?) do
     Phoenix.PubSub.broadcast(
       Destila.PubSub,
       @pubsub_topic,
-      {:aliveness_changed, session_id, alive?}
+      {:aliveness_changed, workflow_session_id, alive?}
     )
+  end
+
+  defp broadcast_ai(ai_session_id, alive?) do
+    Phoenix.PubSub.broadcast(
+      Destila.PubSub,
+      @pubsub_topic,
+      {:aliveness_changed_ai, ai_session_id, alive?}
+    )
+  end
+
+  defp lookup_ai_session_id(workflow_session_id) do
+    case Destila.AI.get_ai_session_for_workflow(workflow_session_id) do
+      nil -> nil
+      ai_session -> ai_session.id
+    end
+  rescue
+    _ -> nil
   end
 end

--- a/lib/destila/ai/aliveness_tracker.ex
+++ b/lib/destila/ai/aliveness_tracker.ex
@@ -11,6 +11,8 @@ defmodule Destila.AI.AlivenessTracker do
 
   use GenServer
 
+  require Logger
+
   @ets_table :ai_session_aliveness
   @pubsub_topic "session_aliveness"
 
@@ -69,11 +71,16 @@ defmodule Destila.AI.AlivenessTracker do
   end
 
   def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
-    {{workflow_session_id, ai_session_id}, refs} = Map.pop!(state.refs, ref)
-    delete_entries(workflow_session_id, ai_session_id)
-    broadcast_workflow(workflow_session_id, false)
-    if ai_session_id, do: broadcast_ai(ai_session_id, false)
-    {:noreply, %{state | refs: refs}}
+    case Map.pop(state.refs, ref) do
+      {nil, refs} ->
+        {:noreply, %{state | refs: refs}}
+
+      {{workflow_session_id, ai_session_id}, refs} ->
+        delete_entries(workflow_session_id, ai_session_id)
+        broadcast_workflow(workflow_session_id, false)
+        if ai_session_id, do: broadcast_ai(ai_session_id, false)
+        {:noreply, %{state | refs: refs}}
+    end
   end
 
   def handle_info(_msg, state), do: {:noreply, state}
@@ -87,10 +94,11 @@ defmodule Destila.AI.AlivenessTracker do
 
       pid ->
         ref = Process.monitor(pid)
+        state = put_in(state, [:refs, ref], {workflow_session_id, ai_session_id})
         insert_entries(workflow_session_id, ai_session_id)
         broadcast_workflow(workflow_session_id, true)
         if ai_session_id, do: broadcast_ai(ai_session_id, true)
-        {:noreply, put_in(state, [:refs, ref], {workflow_session_id, ai_session_id})}
+        {:noreply, state}
     end
   end
 
@@ -126,6 +134,11 @@ defmodule Destila.AI.AlivenessTracker do
       ai_session -> ai_session.id
     end
   rescue
-    _ -> nil
+    error ->
+      Logger.debug(
+        "AlivenessTracker: lookup_ai_session_id/1 failed for #{inspect(workflow_session_id)}: #{Exception.message(error)}"
+      )
+
+      nil
   end
 end

--- a/lib/destila/ai/claude_session.ex
+++ b/lib/destila/ai/claude_session.ex
@@ -145,6 +145,7 @@ defmodule Destila.AI.ClaudeSession do
   def init(opts) do
     {timeout_ms, claude_opts} = Keyword.pop(opts, :timeout_ms, @default_timeout_ms)
     {workflow_session_id, claude_opts} = Keyword.pop(claude_opts, :workflow_session_id)
+    {ai_session_id, claude_opts} = Keyword.pop(claude_opts, :ai_session_id)
     claude_opts = Keyword.put_new(claude_opts, :allowed_tools, @default_allowed_tools)
 
     claude_opts =
@@ -193,7 +194,7 @@ defmodule Destila.AI.ClaudeSession do
             Phoenix.PubSub.broadcast(
               Destila.PubSub,
               Destila.PubSubHelper.claude_session_topic(),
-              {:claude_session_started, workflow_session_id}
+              {:claude_session_started, workflow_session_id, ai_session_id}
             )
           end
 
@@ -202,7 +203,8 @@ defmodule Destila.AI.ClaudeSession do
              claude_session: claude_session,
              timeout_ms: timeout_ms,
              timer_ref: timer_ref,
-             workflow_session_id: workflow_session_id
+             workflow_session_id: workflow_session_id,
+             ai_session_id: ai_session_id
            }}
 
         {:error, reason} ->

--- a/lib/destila/ai/history.ex
+++ b/lib/destila/ai/history.ex
@@ -1,0 +1,31 @@
+defmodule Destila.AI.History do
+  @moduledoc """
+  Thin adapter around `ClaudeCode.History.get_messages/2`.
+
+  The LiveView calls `Destila.AI.History.get_messages/1,2` rather than
+  `ClaudeCode.History` directly so tests can swap in canned responses via
+  `Application.put_env(:destila, :ai_history_module, ...)`. Also catches
+  unexpected exceptions from disk/parse failures and returns them as
+  `{:error, {:exception, kind, reason}}`.
+  """
+
+  @default_impl ClaudeCode.History
+
+  @spec get_messages(String.t()) ::
+          {:ok, [ClaudeCode.History.SessionMessage.t()]} | {:error, term()}
+  def get_messages(session_id), do: get_messages(session_id, [])
+
+  @spec get_messages(String.t(), keyword()) ::
+          {:ok, [ClaudeCode.History.SessionMessage.t()]} | {:error, term()}
+  def get_messages(session_id, opts) when is_binary(session_id) and is_list(opts) do
+    impl().get_messages(session_id, opts)
+  rescue
+    exception -> {:error, {:exception, exception}}
+  catch
+    kind, reason -> {:error, {:exception, kind, reason}}
+  end
+
+  defp impl do
+    Application.get_env(:destila, :ai_history_module, @default_impl)
+  end
+end

--- a/lib/destila/ai/session_config.ex
+++ b/lib/destila/ai/session_config.ex
@@ -28,6 +28,13 @@ defmodule Destila.AI.SessionConfig do
     opts = base_opts
 
     opts =
+      if ai_session do
+        Keyword.put(opts, :ai_session_id, ai_session.id)
+      else
+        opts
+      end
+
+    opts =
       if ai_session && ai_session.claude_session_id do
         Keyword.put(opts, :resume, ai_session.claude_session_id)
       else

--- a/lib/destila_web/components/ai_session_debug_components.ex
+++ b/lib/destila_web/components/ai_session_debug_components.ex
@@ -1,0 +1,512 @@
+defmodule DestilaWeb.AiSessionDebugComponents do
+  @moduledoc """
+  Function components that render a Claude Code session history
+  (a list of `%ClaudeCode.History.SessionMessage{}` structs) for the
+  AI Session Debug Detail page.
+
+  Each content block type gets its own branch in `content_block/1`;
+  unknown shapes fall through to a generic `inspect/2` block so new
+  block types from future ClaudeCode releases don't crash the page.
+  """
+
+  use Phoenix.Component
+
+  import DestilaWeb.CoreComponents, only: [icon: 1]
+
+  alias ClaudeCode.Content.{
+    CompactionBlock,
+    ContainerUploadBlock,
+    DocumentBlock,
+    ImageBlock,
+    MCPToolResultBlock,
+    MCPToolUseBlock,
+    RedactedThinkingBlock,
+    ServerToolResultBlock,
+    ServerToolUseBlock,
+    TextBlock,
+    ThinkingBlock,
+    ToolResultBlock,
+    ToolUseBlock
+  }
+
+  alias ClaudeCode.History.SessionMessage
+
+  attr :messages, :list, required: true
+  attr :tool_index, :map, default: %{}
+
+  def session_history(assigns) do
+    ~H"""
+    <div id="session-history" class="flex flex-col gap-4">
+      <%= for {msg, idx} <- Enum.with_index(@messages) do %>
+        <.session_message msg={msg} idx={idx} tool_index={@tool_index} />
+      <% end %>
+    </div>
+    """
+  end
+
+  attr :msg, :any, required: true
+  attr :idx, :integer, required: true
+  attr :tool_index, :map, required: true
+
+  defp session_message(%{msg: %SessionMessage{type: :user} = msg} = assigns) do
+    assigns = assign(assigns, :content, extract_content(msg.message))
+
+    ~H"""
+    <div
+      id={"message-#{@idx}"}
+      data-message-role="user"
+      data-message-uuid={@msg.uuid}
+      class="rounded-lg border border-primary/20 bg-primary/5 px-4 py-3"
+    >
+      <.role_header role="user" />
+      <.content_list content={@content} tool_index={@tool_index} idx={@idx} />
+    </div>
+    """
+  end
+
+  defp session_message(%{msg: %SessionMessage{type: :assistant} = msg} = assigns) do
+    assigns = assign(assigns, :content, extract_content(msg.message))
+
+    ~H"""
+    <div
+      id={"message-#{@idx}"}
+      data-message-role="assistant"
+      data-message-uuid={@msg.uuid}
+      class="rounded-lg border border-base-300 bg-base-100 px-4 py-3"
+    >
+      <.role_header role="assistant" />
+      <.content_list content={@content} tool_index={@tool_index} idx={@idx} />
+    </div>
+    """
+  end
+
+  defp session_message(assigns) do
+    ~H"""
+    <div
+      id={"message-#{@idx}"}
+      data-message-role="unknown"
+      class="rounded-lg border border-warning/30 bg-warning/5 px-4 py-3"
+    >
+      <p class="text-xs text-base-content/50 mb-2">Unrecognized message</p>
+      <pre class="text-xs text-base-content/70 whitespace-pre-wrap break-words">{inspect(@msg, pretty: true, limit: :infinity)}</pre>
+    </div>
+    """
+  end
+
+  attr :role, :string, required: true
+
+  defp role_header(assigns) do
+    ~H"""
+    <div class="flex items-center gap-2 mb-2">
+      <span class={[
+        "text-[10px] font-semibold uppercase tracking-wider",
+        role_color(@role)
+      ]}>
+        {@role}
+      </span>
+    </div>
+    """
+  end
+
+  defp role_color("user"), do: "text-primary"
+  defp role_color("assistant"), do: "text-base-content/60"
+  defp role_color(_), do: "text-base-content/40"
+
+  attr :content, :any, required: true
+  attr :tool_index, :map, required: true
+  attr :idx, :integer, required: true
+
+  defp content_list(%{content: content} = assigns) when is_binary(content) do
+    ~H"""
+    <p class="text-sm text-base-content/80 whitespace-pre-wrap break-words">{@content}</p>
+    """
+  end
+
+  defp content_list(%{content: content} = assigns) when is_list(content) do
+    assigns = assign(assigns, :blocks, content)
+
+    ~H"""
+    <div class="flex flex-col gap-2">
+      <%= for {block, i} <- Enum.with_index(@blocks) do %>
+        <.content_block block={block} tool_index={@tool_index} block_id={"block-#{@idx}-#{i}"} />
+      <% end %>
+    </div>
+    """
+  end
+
+  defp content_list(assigns) do
+    ~H"""
+    <pre class="text-xs text-base-content/60 whitespace-pre-wrap break-words">{inspect(@content, pretty: true, limit: :infinity)}</pre>
+    """
+  end
+
+  attr :block, :any, required: true
+  attr :tool_index, :map, required: true
+  attr :block_id, :string, required: true
+
+  defp content_block(%{block: %TextBlock{}} = assigns) do
+    ~H"""
+    <div id={@block_id} data-block-type="text">
+      <p class="text-sm text-base-content/80 whitespace-pre-wrap break-words">{@block.text}</p>
+    </div>
+    """
+  end
+
+  defp content_block(%{block: %ThinkingBlock{}} = assigns) do
+    ~H"""
+    <details
+      id={@block_id}
+      data-block-type="thinking"
+      class="rounded-md border border-base-300/60 bg-base-200/40"
+    >
+      <summary class="cursor-pointer px-3 py-2 text-xs text-base-content/60 select-none flex items-center gap-2">
+        <.icon name="hero-sparkles-micro" class="size-3 text-base-content/40" />
+        <span>Thinking (click to expand)</span>
+      </summary>
+      <pre class="px-3 pb-3 pt-1 text-xs text-base-content/70 whitespace-pre-wrap break-words">{@block.thinking}</pre>
+    </details>
+    """
+  end
+
+  defp content_block(%{block: %RedactedThinkingBlock{}} = assigns) do
+    assigns =
+      assign(
+        assigns,
+        :byte_size,
+        if(is_binary(assigns.block.data), do: byte_size(assigns.block.data), else: 0)
+      )
+
+    ~H"""
+    <div
+      id={@block_id}
+      data-block-type="redacted_thinking"
+      class="rounded-md border border-base-300/60 bg-base-200/40 px-3 py-2"
+    >
+      <p class="text-xs text-base-content/50 italic">[Redacted thinking — {@byte_size} bytes]</p>
+    </div>
+    """
+  end
+
+  defp content_block(%{block: %ToolUseBlock{}} = assigns) do
+    assigns = assign(assigns, :pretty_input, pretty_json(assigns.block.input))
+
+    ~H"""
+    <div
+      id={@block_id}
+      data-block-type="tool_use"
+      data-tool-use-id={@block.id}
+      class="rounded-md border border-info/30 bg-info/5"
+    >
+      <div class="px-3 py-2 border-b border-info/20 flex items-center gap-2">
+        <.icon name="hero-wrench-screwdriver-micro" class="size-3 text-info/70" />
+        <span class="text-xs font-semibold text-info/80">{@block.name}</span>
+        <span class="text-[10px] text-base-content/40 font-mono">{@block.id}</span>
+      </div>
+      <pre class="px-3 py-2 text-xs text-base-content/70 whitespace-pre-wrap break-words">{@pretty_input}</pre>
+    </div>
+    """
+  end
+
+  defp content_block(%{block: %ToolResultBlock{} = block} = assigns) do
+    tool_use = Map.get(assigns.tool_index, block.tool_use_id)
+    tool_name = tool_use && Map.get(tool_use, :name)
+
+    assigns =
+      assigns
+      |> assign(:tool_name, tool_name)
+      |> assign(:rendered_content, render_tool_result_content(block.content))
+      |> assign(:is_error?, block.is_error == true)
+
+    ~H"""
+    <div
+      id={@block_id}
+      data-block-type="tool_result"
+      data-tool-use-ref={@block.tool_use_id}
+      data-tool-name={@tool_name}
+      class={[
+        "rounded-md border",
+        if(@is_error?,
+          do: "border-error/40 bg-error/5",
+          else: "border-base-300/60 bg-base-200/40"
+        )
+      ]}
+    >
+      <div class={[
+        "px-3 py-2 border-b flex items-center gap-2",
+        if(@is_error?, do: "border-error/30", else: "border-base-300/40")
+      ]}>
+        <.icon
+          name={
+            if(@is_error?, do: "hero-exclamation-triangle-micro", else: "hero-arrow-uturn-left-micro")
+          }
+          class={[
+            "size-3",
+            if(@is_error?, do: "text-error/70", else: "text-base-content/40")
+          ]}
+        />
+        <span class="text-xs font-semibold text-base-content/70">
+          Result <span :if={@tool_name}>from {@tool_name}</span>
+        </span>
+        <span :if={@is_error?} class="text-[10px] font-semibold uppercase text-error">
+          error
+        </span>
+      </div>
+      <pre class={[
+        "px-3 py-2 text-xs whitespace-pre-wrap break-words",
+        if(@is_error?, do: "text-error/80", else: "text-base-content/70")
+      ]}>{@rendered_content}</pre>
+    </div>
+    """
+  end
+
+  defp content_block(%{block: %ServerToolUseBlock{}} = assigns) do
+    assigns = assign(assigns, :pretty_input, pretty_json(assigns.block.input))
+
+    ~H"""
+    <div
+      id={@block_id}
+      data-block-type="server_tool_use"
+      data-tool-use-id={@block.id}
+      class="rounded-md border border-accent/30 bg-accent/5"
+    >
+      <div class="px-3 py-2 border-b border-accent/20 flex items-center gap-2">
+        <span class="text-[10px] font-semibold uppercase tracking-wider text-accent">
+          server tool
+        </span>
+        <span class="text-xs font-semibold text-base-content/80">{@block.name}</span>
+        <span class="text-[10px] text-base-content/40 font-mono">{@block.id}</span>
+      </div>
+      <pre class="px-3 py-2 text-xs text-base-content/70 whitespace-pre-wrap break-words">{@pretty_input}</pre>
+    </div>
+    """
+  end
+
+  defp content_block(%{block: %ServerToolResultBlock{} = block} = assigns) do
+    assigns =
+      assigns
+      |> assign(:rendered_content, render_tool_result_content(block.content))
+      |> assign(:result_type, block.type)
+
+    ~H"""
+    <div
+      id={@block_id}
+      data-block-type="server_tool_result"
+      data-tool-use-ref={@block.tool_use_id}
+      class="rounded-md border border-accent/20 bg-accent/5"
+    >
+      <div class="px-3 py-2 border-b border-accent/20 flex items-center gap-2">
+        <span class="text-[10px] font-semibold uppercase tracking-wider text-accent">
+          server tool result
+        </span>
+        <span class="text-xs text-base-content/60">{@result_type}</span>
+      </div>
+      <pre class="px-3 py-2 text-xs text-base-content/70 whitespace-pre-wrap break-words">{@rendered_content}</pre>
+    </div>
+    """
+  end
+
+  defp content_block(%{block: %MCPToolUseBlock{}} = assigns) do
+    assigns = assign(assigns, :pretty_input, pretty_json(assigns.block.input))
+
+    ~H"""
+    <div
+      id={@block_id}
+      data-block-type="mcp_tool_use"
+      data-tool-use-id={@block.id}
+      class="rounded-md border border-secondary/30 bg-secondary/5"
+    >
+      <div class="px-3 py-2 border-b border-secondary/20 flex items-center gap-2">
+        <span class="text-[10px] font-semibold uppercase tracking-wider text-secondary">
+          mcp: {@block.server_name}
+        </span>
+        <span class="text-xs font-semibold text-base-content/80">{@block.name}</span>
+        <span class="text-[10px] text-base-content/40 font-mono">{@block.id}</span>
+      </div>
+      <pre class="px-3 py-2 text-xs text-base-content/70 whitespace-pre-wrap break-words">{@pretty_input}</pre>
+    </div>
+    """
+  end
+
+  defp content_block(%{block: %MCPToolResultBlock{} = block} = assigns) do
+    assigns =
+      assigns
+      |> assign(:rendered_content, render_tool_result_content(block.content))
+      |> assign(:is_error?, block.is_error == true)
+
+    ~H"""
+    <div
+      id={@block_id}
+      data-block-type="mcp_tool_result"
+      data-tool-use-ref={@block.tool_use_id}
+      class={[
+        "rounded-md border",
+        if(@is_error?,
+          do: "border-error/40 bg-error/5",
+          else: "border-secondary/20 bg-secondary/5"
+        )
+      ]}
+    >
+      <div class="px-3 py-2 border-b border-secondary/20 flex items-center gap-2">
+        <span class="text-[10px] font-semibold uppercase tracking-wider text-secondary">
+          mcp result
+        </span>
+        <span :if={@is_error?} class="text-[10px] font-semibold uppercase text-error">
+          error
+        </span>
+      </div>
+      <pre class={[
+        "px-3 py-2 text-xs whitespace-pre-wrap break-words",
+        if(@is_error?, do: "text-error/80", else: "text-base-content/70")
+      ]}>{@rendered_content}</pre>
+    </div>
+    """
+  end
+
+  defp content_block(%{block: %ImageBlock{source: %{type: :url, url: url}}} = assigns) do
+    assigns = assign(assigns, :url, url)
+
+    ~H"""
+    <div id={@block_id} data-block-type="image" data-image-kind="url">
+      <img src={@url} alt="image" class="max-w-full rounded-md border border-base-300/60" />
+    </div>
+    """
+  end
+
+  defp content_block(%{block: %ImageBlock{source: %{type: :base64, data: data}}} = assigns) do
+    kb = byte_size(data || "") |> div(1024)
+    assigns = assign(assigns, :kb, kb)
+
+    ~H"""
+    <div
+      id={@block_id}
+      data-block-type="image"
+      data-image-kind="base64"
+      class="rounded-md border border-base-300/60 bg-base-200/40 px-3 py-2 flex items-center gap-2"
+    >
+      <.icon name="hero-photo-micro" class="size-3 text-base-content/40" />
+      <span class="text-xs text-base-content/60">Image — base64, {@kb} KB</span>
+    </div>
+    """
+  end
+
+  defp content_block(%{block: %ImageBlock{}} = assigns) do
+    ~H"""
+    <div
+      id={@block_id}
+      data-block-type="image"
+      class="rounded-md border border-base-300/60 bg-base-200/40 px-3 py-2 flex items-center gap-2"
+    >
+      <.icon name="hero-photo-micro" class="size-3 text-base-content/40" />
+      <span class="text-xs text-base-content/60">Image</span>
+    </div>
+    """
+  end
+
+  defp content_block(%{block: %DocumentBlock{} = block} = assigns) do
+    assigns =
+      assigns
+      |> assign(:title, block.title || "Document")
+      |> assign(:context, block.context)
+
+    ~H"""
+    <div
+      id={@block_id}
+      data-block-type="document"
+      class="rounded-md border border-base-300/60 bg-base-200/40 px-3 py-2"
+    >
+      <div class="flex items-center gap-2">
+        <.icon name="hero-document-micro" class="size-3 text-base-content/40" />
+        <span class="text-xs font-semibold text-base-content/70">{@title}</span>
+      </div>
+      <p :if={@context} class="text-xs text-base-content/50 mt-1">{@context}</p>
+    </div>
+    """
+  end
+
+  defp content_block(%{block: %ContainerUploadBlock{} = block} = assigns) do
+    assigns = assign(assigns, :file_id, block.file_id)
+
+    ~H"""
+    <div
+      id={@block_id}
+      data-block-type="container_upload"
+      class="rounded-md border border-base-300/60 bg-base-200/40 px-3 py-2 flex items-center gap-2"
+    >
+      <.icon name="hero-arrow-up-tray-micro" class="size-3 text-base-content/40" />
+      <span class="text-xs text-base-content/60">Uploaded file: {@file_id}</span>
+    </div>
+    """
+  end
+
+  defp content_block(%{block: %CompactionBlock{} = block} = assigns) do
+    assigns = assign(assigns, :content, block.content)
+
+    ~H"""
+    <div
+      id={@block_id}
+      data-block-type="compaction"
+      class="flex flex-col items-center gap-2 py-3 border-y border-base-300/60"
+    >
+      <div class="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-base-content/50">
+        <.icon name="hero-minus-micro" class="size-3" />
+        <span>Conversation compacted</span>
+        <.icon name="hero-minus-micro" class="size-3" />
+      </div>
+      <details :if={@content} class="w-full">
+        <summary class="text-xs text-base-content/50 cursor-pointer select-none text-center">
+          Show compaction summary
+        </summary>
+        <pre class="mt-2 text-xs text-base-content/60 whitespace-pre-wrap break-words">{@content}</pre>
+      </details>
+    </div>
+    """
+  end
+
+  defp content_block(assigns) do
+    ~H"""
+    <div
+      id={@block_id}
+      data-block-type="unknown"
+      class="rounded-md border border-warning/30 bg-warning/5 px-3 py-2"
+    >
+      <p class="text-[10px] font-semibold uppercase tracking-wider text-warning mb-1">
+        Unknown block
+      </p>
+      <pre class="text-xs text-base-content/70 whitespace-pre-wrap break-words">{inspect(@block, pretty: true, limit: :infinity)}</pre>
+    </div>
+    """
+  end
+
+  defp extract_content(%{content: content}), do: content
+  defp extract_content(%{"content" => content}), do: content
+  defp extract_content(_), do: []
+
+  defp render_tool_result_content(content) when is_binary(content), do: content
+
+  defp render_tool_result_content(content) when is_list(content) do
+    content
+    |> Enum.map(&render_tool_result_item/1)
+    |> Enum.join("\n\n")
+  end
+
+  defp render_tool_result_content(content), do: inspect(content, pretty: true, limit: :infinity)
+
+  defp render_tool_result_item(%TextBlock{text: text}), do: text
+
+  defp render_tool_result_item(%ImageBlock{source: %{type: :url, url: url}}),
+    do: "[image: #{url}]"
+
+  defp render_tool_result_item(%ImageBlock{source: %{type: :base64}}),
+    do: "[image: base64]"
+
+  defp render_tool_result_item(%{"type" => "text", "text" => text}) when is_binary(text),
+    do: text
+
+  defp render_tool_result_item(other), do: inspect(other, pretty: true, limit: :infinity)
+
+  defp pretty_json(value) do
+    Jason.encode!(value, pretty: true)
+  rescue
+    _ -> inspect(value, pretty: true, limit: :infinity)
+  end
+end

--- a/lib/destila_web/components/ai_session_debug_components.ex
+++ b/lib/destila_web/components/ai_session_debug_components.ex
@@ -88,7 +88,7 @@ defmodule DestilaWeb.AiSessionDebugComponents do
       class="rounded-lg border border-warning/30 bg-warning/5 px-4 py-3"
     >
       <p class="text-xs text-base-content/50 mb-2">Unrecognized message</p>
-      <pre class="text-xs text-base-content/70 whitespace-pre-wrap break-words">{inspect(@msg, pretty: true, limit: :infinity)}</pre>
+      <pre class="text-xs text-base-content/70 whitespace-pre-wrap break-words">{inspect(@msg, pretty: true, limit: 200, printable_limit: 4096)}</pre>
     </div>
     """
   end
@@ -136,7 +136,7 @@ defmodule DestilaWeb.AiSessionDebugComponents do
 
   defp content_list(assigns) do
     ~H"""
-    <pre class="text-xs text-base-content/60 whitespace-pre-wrap break-words">{inspect(@content, pretty: true, limit: :infinity)}</pre>
+    <pre class="text-xs text-base-content/60 whitespace-pre-wrap break-words">{inspect(@content, pretty: true, limit: 200, printable_limit: 4096)}</pre>
     """
   end
 
@@ -363,13 +363,27 @@ defmodule DestilaWeb.AiSessionDebugComponents do
   end
 
   defp content_block(%{block: %ImageBlock{source: %{type: :url, url: url}}} = assigns) do
-    assigns = assign(assigns, :url, url)
+    if safe_image_url?(url) do
+      assigns = assign(assigns, :url, url)
 
-    ~H"""
-    <div id={@block_id} data-block-type="image" data-image-kind="url">
-      <img src={@url} alt="image" class="max-w-full rounded-md border border-base-300/60" />
-    </div>
-    """
+      ~H"""
+      <div id={@block_id} data-block-type="image" data-image-kind="url">
+        <img src={@url} alt="image" class="max-w-full rounded-md border border-base-300/60" />
+      </div>
+      """
+    else
+      ~H"""
+      <div
+        id={@block_id}
+        data-block-type="image"
+        data-image-kind="url"
+        class="rounded-md border border-warning/30 bg-warning/5 px-3 py-2 flex items-center gap-2"
+      >
+        <.icon name="hero-photo-micro" class="size-3 text-warning/70" />
+        <span class="text-xs text-base-content/60">Image (unsafe URL omitted)</span>
+      </div>
+      """
+    end
   end
 
   defp content_block(%{block: %ImageBlock{source: %{type: :base64, data: data}}} = assigns) do
@@ -472,7 +486,7 @@ defmodule DestilaWeb.AiSessionDebugComponents do
       <p class="text-[10px] font-semibold uppercase tracking-wider text-warning mb-1">
         Unknown block
       </p>
-      <pre class="text-xs text-base-content/70 whitespace-pre-wrap break-words">{inspect(@block, pretty: true, limit: :infinity)}</pre>
+      <pre class="text-xs text-base-content/70 whitespace-pre-wrap break-words">{inspect(@block, pretty: true, limit: 200, printable_limit: 4096)}</pre>
     </div>
     """
   end
@@ -489,7 +503,8 @@ defmodule DestilaWeb.AiSessionDebugComponents do
     |> Enum.join("\n\n")
   end
 
-  defp render_tool_result_content(content), do: inspect(content, pretty: true, limit: :infinity)
+  defp render_tool_result_content(content),
+    do: inspect(content, pretty: true, limit: 200, printable_limit: 4096)
 
   defp render_tool_result_item(%TextBlock{text: text}), do: text
 
@@ -502,11 +517,21 @@ defmodule DestilaWeb.AiSessionDebugComponents do
   defp render_tool_result_item(%{"type" => "text", "text" => text}) when is_binary(text),
     do: text
 
-  defp render_tool_result_item(other), do: inspect(other, pretty: true, limit: :infinity)
+  defp render_tool_result_item(other),
+    do: inspect(other, pretty: true, limit: 200, printable_limit: 4096)
 
   defp pretty_json(value) do
     Jason.encode!(value, pretty: true)
   rescue
-    _ -> inspect(value, pretty: true, limit: :infinity)
+    _ -> inspect(value, pretty: true, limit: 200, printable_limit: 4096)
   end
+
+  defp safe_image_url?(url) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{scheme: scheme} when scheme in ["http", "https", "data"] -> true
+      _ -> false
+    end
+  end
+
+  defp safe_image_url?(_), do: false
 end

--- a/lib/destila_web/live/ai_session_detail_live.ex
+++ b/lib/destila_web/live/ai_session_detail_live.ex
@@ -1,0 +1,187 @@
+defmodule DestilaWeb.AiSessionDetailLive do
+  use DestilaWeb, :live_view
+
+  import DestilaWeb.BoardComponents, only: [aliveness_dot: 1]
+  import DestilaWeb.AiSessionDebugComponents
+
+  require Logger
+
+  alias Destila.AI
+  alias Destila.AI.AlivenessTracker
+  alias Destila.AI.History
+  alias Destila.Workflows
+
+  @impl true
+  def mount(
+        %{"workflow_session_id" => ws_id, "ai_session_id" => ai_id},
+        _session,
+        socket
+      ) do
+    with %Workflows.Session{} = ws <- Workflows.get_workflow_session(ws_id),
+         %AI.Session{} = ai_session <- AI.get_ai_session(ai_id),
+         true <- ai_session.workflow_session_id == ws.id do
+      if connected?(socket) do
+        Phoenix.PubSub.subscribe(Destila.PubSub, AlivenessTracker.topic())
+      end
+
+      history_state = load_history(ai_session)
+
+      {:ok,
+       socket
+       |> assign(:workflow_session, ws)
+       |> assign(:ai_session, ai_session)
+       |> assign(:alive?, AlivenessTracker.alive_ai?(ai_session.id))
+       |> assign(:history_state, history_state)
+       |> assign(:page_title, "AI Session — #{ws.title}")}
+    else
+      nil ->
+        {:ok,
+         socket
+         |> put_flash(:error, "Session not found")
+         |> push_navigate(to: ~p"/crafting")}
+
+      false ->
+        {:ok,
+         socket
+         |> put_flash(:error, "AI session does not belong to this workflow")
+         |> push_navigate(to: ~p"/sessions/#{ws_id}")}
+    end
+  end
+
+  @impl true
+  def handle_info({:aliveness_changed_ai, ai_id, alive?}, socket) do
+    if socket.assigns.ai_session.id == ai_id do
+      {:noreply, assign(socket, :alive?, alive?)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
+  defp load_history(%AI.Session{claude_session_id: nil}), do: :missing
+
+  defp load_history(%AI.Session{claude_session_id: claude_session_id}) do
+    case History.get_messages(claude_session_id) do
+      {:ok, []} ->
+        :empty
+
+      {:ok, messages} ->
+        {:loaded, messages, build_tool_index(messages)}
+
+      {:error, reason} ->
+        Logger.warning("Failed to load AI history for #{claude_session_id}: #{inspect(reason)}")
+        :error
+    end
+  end
+
+  defp build_tool_index(messages) do
+    Enum.reduce(messages, %{}, fn msg, acc ->
+      content =
+        case Map.get(msg, :message) do
+          %{content: content} -> content
+          %{"content" => content} -> content
+          _ -> []
+        end
+
+      content
+      |> List.wrap()
+      |> Enum.reduce(acc, fn
+        %ClaudeCode.Content.ToolUseBlock{id: id} = block, inner -> Map.put(inner, id, block)
+        %ClaudeCode.Content.ServerToolUseBlock{id: id} = block, inner -> Map.put(inner, id, block)
+        %ClaudeCode.Content.MCPToolUseBlock{id: id} = block, inner -> Map.put(inner, id, block)
+        _, inner -> inner
+      end)
+    end)
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} page_title={@page_title}>
+      <div class="flex flex-col h-screen bg-base-200">
+        <div
+          id="ai-session-header"
+          class="flex items-center gap-3 px-4 py-2.5 border-b border-base-300 bg-base-100 shrink-0"
+        >
+          <.link
+            id="ai-session-back-link"
+            navigate={~p"/sessions/#{@workflow_session.id}"}
+            class="btn btn-ghost btn-sm btn-square"
+          >
+            <.icon name="hero-arrow-left-micro" class="size-4" />
+          </.link>
+          <div class="flex items-center gap-2 min-w-0 flex-1">
+            <.aliveness_dot
+              session={@workflow_session}
+              alive?={@alive?}
+              phase_status={:idle}
+            />
+            <.icon name="hero-cpu-chip-micro" class="size-4 text-base-content/40 shrink-0" />
+            <span class="text-sm font-medium text-base-content/80 truncate">
+              {@workflow_session.title}
+            </span>
+            <span class="text-xs text-base-content/40 shrink-0">
+              {format_inserted_at(@ai_session.inserted_at)}
+            </span>
+            <code
+              :if={@ai_session.claude_session_id}
+              id="ai-session-claude-id"
+              class="text-xs text-base-content/50 font-mono truncate"
+            >
+              {@ai_session.claude_session_id}
+            </code>
+          </div>
+        </div>
+
+        <div class="flex-1 min-h-0 overflow-y-auto">
+          <div id="ai-session-conversation" class="max-w-3xl mx-auto py-6 px-4 space-y-4">
+            <%= case @history_state do %>
+              <% :missing -> %>
+                <.empty_state
+                  icon="hero-inbox-micro"
+                  title="No conversation history available"
+                  detail="This AI session hasn't been linked to a Claude session yet."
+                />
+              <% :empty -> %>
+                <.empty_state
+                  icon="hero-inbox-micro"
+                  title="No conversation history available"
+                  detail="The session file exists but has no visible messages."
+                />
+              <% :error -> %>
+                <.empty_state
+                  icon="hero-exclamation-triangle-micro"
+                  title="Unable to read conversation history"
+                  detail="See server logs for details."
+                />
+              <% {:loaded, messages, tool_index} -> %>
+                <.session_history messages={messages} tool_index={tool_index} />
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </Layouts.app>
+    """
+  end
+
+  attr :icon, :string, required: true
+  attr :title, :string, required: true
+  attr :detail, :string, required: true
+
+  defp empty_state(assigns) do
+    ~H"""
+    <div class="flex flex-col items-center py-16 text-center">
+      <.icon name={@icon} class="size-8 text-base-content/20 mb-3" />
+      <p class="text-sm font-medium text-base-content/60">{@title}</p>
+      <p class="text-xs text-base-content/40 mt-1">{@detail}</p>
+    </div>
+    """
+  end
+
+  defp format_inserted_at(%DateTime{} = dt) do
+    Calendar.strftime(dt, "%b %-d, %Y %H:%M")
+  end
+
+  defp format_inserted_at(_), do: ""
+end

--- a/lib/destila_web/live/ai_session_detail_live.ex
+++ b/lib/destila_web/live/ai_session_detail_live.ex
@@ -17,35 +17,52 @@ defmodule DestilaWeb.AiSessionDetailLive do
         _session,
         socket
       ) do
-    with %Workflows.Session{} = ws <- Workflows.get_workflow_session(ws_id),
-         %AI.Session{} = ai_session <- AI.get_ai_session(ai_id),
-         true <- ai_session.workflow_session_id == ws.id do
-      if connected?(socket) do
-        Phoenix.PubSub.subscribe(Destila.PubSub, AlivenessTracker.topic())
-      end
-
-      history_state = load_history(ai_session)
-
-      {:ok,
-       socket
-       |> assign(:workflow_session, ws)
-       |> assign(:ai_session, ai_session)
-       |> assign(:alive?, AlivenessTracker.alive_ai?(ai_session.id))
-       |> assign(:history_state, history_state)
-       |> assign(:page_title, "AI Session — #{ws.title}")}
-    else
+    case Workflows.get_workflow_session(ws_id) do
       nil ->
         {:ok,
          socket
          |> put_flash(:error, "Session not found")
          |> push_navigate(to: ~p"/crafting")}
 
-      false ->
+      %Workflows.Session{} = ws ->
+        mount_with_workflow(ws, ai_id, socket)
+    end
+  end
+
+  defp mount_with_workflow(%Workflows.Session{} = ws, ai_id, socket) do
+    case AI.get_ai_session(ai_id) do
+      nil ->
         {:ok,
          socket
-         |> put_flash(:error, "AI session does not belong to this workflow")
-         |> push_navigate(to: ~p"/sessions/#{ws_id}")}
+         |> put_flash(:error, "AI session not found")
+         |> push_navigate(to: ~p"/sessions/#{ws.id}")}
+
+      %AI.Session{} = ai_session ->
+        if ai_session.workflow_session_id == ws.id do
+          mount_with_session(ws, ai_session, socket)
+        else
+          {:ok,
+           socket
+           |> put_flash(:error, "AI session does not belong to this workflow")
+           |> push_navigate(to: ~p"/sessions/#{ws.id}")}
+        end
     end
+  end
+
+  defp mount_with_session(%Workflows.Session{} = ws, %AI.Session{} = ai_session, socket) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Destila.PubSub, AlivenessTracker.topic())
+    end
+
+    history_state = load_history(ai_session)
+
+    {:ok,
+     socket
+     |> assign(:workflow_session, ws)
+     |> assign(:ai_session, ai_session)
+     |> assign(:alive?, AlivenessTracker.alive_ai?(ai_session.id))
+     |> assign(:history_state, history_state)
+     |> assign(:page_title, "AI Session — #{ws.title}")}
   end
 
   @impl true

--- a/lib/destila_web/live/ai_session_detail_live.ex
+++ b/lib/destila_web/live/ai_session_detail_live.ex
@@ -9,7 +9,10 @@ defmodule DestilaWeb.AiSessionDetailLive do
   alias Destila.AI
   alias Destila.AI.AlivenessTracker
   alias Destila.AI.History
+  alias Destila.PubSubHelper
   alias Destila.Workflows
+
+  @reload_debounce_ms 500
 
   @impl true
   def mount(
@@ -52,6 +55,7 @@ defmodule DestilaWeb.AiSessionDetailLive do
   defp mount_with_session(%Workflows.Session{} = ws, %AI.Session{} = ai_session, socket) do
     if connected?(socket) do
       Phoenix.PubSub.subscribe(Destila.PubSub, AlivenessTracker.topic())
+      Phoenix.PubSub.subscribe(Destila.PubSub, PubSubHelper.ai_stream_topic(ws.id))
     end
 
     history_state = load_history(ai_session)
@@ -62,6 +66,8 @@ defmodule DestilaWeb.AiSessionDetailLive do
      |> assign(:ai_session, ai_session)
      |> assign(:alive?, AlivenessTracker.alive_ai?(ai_session.id))
      |> assign(:history_state, history_state)
+     |> assign(:loaded_count, history_loaded_count(history_state))
+     |> assign(:reload_scheduled?, false)
      |> assign(:page_title, "AI Session — #{ws.title}")}
   end
 
@@ -74,7 +80,63 @@ defmodule DestilaWeb.AiSessionDetailLive do
     end
   end
 
+  def handle_info({:ai_stream_chunk, _item}, socket) do
+    {:noreply, maybe_schedule_reload(socket)}
+  end
+
+  def handle_info(:reload_history, socket) do
+    {:noreply, refresh_history(socket)}
+  end
+
   def handle_info(_msg, socket), do: {:noreply, socket}
+
+  defp maybe_schedule_reload(socket) do
+    cond do
+      socket.assigns.reload_scheduled? ->
+        socket
+
+      is_nil(socket.assigns.ai_session.claude_session_id) ->
+        socket
+
+      true ->
+        Process.send_after(self(), :reload_history, @reload_debounce_ms)
+        assign(socket, :reload_scheduled?, true)
+    end
+  end
+
+  defp refresh_history(socket) do
+    socket = assign(socket, :reload_scheduled?, false)
+    claude_session_id = socket.assigns.ai_session.claude_session_id
+    offset = socket.assigns.loaded_count
+
+    case History.get_messages(claude_session_id, offset: offset) do
+      {:ok, []} ->
+        socket
+
+      {:ok, new_messages} ->
+        history_state = append_messages(socket.assigns.history_state, new_messages)
+
+        socket
+        |> assign(:history_state, history_state)
+        |> assign(:loaded_count, offset + length(new_messages))
+
+      {:error, reason} ->
+        Logger.warning("Failed to reload AI history for #{claude_session_id}: #{inspect(reason)}")
+
+        socket
+    end
+  end
+
+  defp append_messages({:loaded, existing, tool_index}, new_messages) do
+    {:loaded, existing ++ new_messages, Map.merge(tool_index, build_tool_index(new_messages))}
+  end
+
+  defp append_messages(_state, new_messages) do
+    {:loaded, new_messages, build_tool_index(new_messages)}
+  end
+
+  defp history_loaded_count({:loaded, messages, _tool_index}), do: length(messages)
+  defp history_loaded_count(_), do: 0
 
   defp load_history(%AI.Session{claude_session_id: nil}), do: :missing
 

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -17,6 +17,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
   import DestilaWeb.ChatComponents
 
   alias Destila.AI
+  alias Destila.AI.AlivenessTracker
   alias Destila.AI.ResponseProcessor
   alias Destila.Sessions.SessionProcess
   alias Destila.Workflows
@@ -35,9 +36,9 @@ defmodule DestilaWeb.WorkflowRunnerLive do
         if connected?(socket) do
           Phoenix.PubSub.subscribe(Destila.PubSub, "store:updates")
           Phoenix.PubSub.subscribe(Destila.PubSub, Destila.PubSubHelper.ai_stream_topic(id))
-          Phoenix.PubSub.subscribe(Destila.PubSub, Destila.AI.AlivenessTracker.topic())
+          Phoenix.PubSub.subscribe(Destila.PubSub, AlivenessTracker.topic())
 
-          Destila.AI.AlivenessTracker.alive?(id)
+          AlivenessTracker.alive?(id)
         else
           false
         end
@@ -473,6 +474,16 @@ defmodule DestilaWeb.WorkflowRunnerLive do
     end
   end
 
+  def handle_info({:aliveness_changed_ai, ai_id, alive?}, socket) do
+    ai_sessions_alive = socket.assigns[:ai_sessions_alive] || %{}
+
+    if Map.has_key?(ai_sessions_alive, ai_id) do
+      {:noreply, assign(socket, :ai_sessions_alive, Map.put(ai_sessions_alive, ai_id, alive?))}
+    else
+      {:noreply, socket}
+    end
+  end
+
   def handle_info(_msg, socket), do: {:noreply, socket}
 
   defp extract_intermediate_text(%ClaudeCode.Message.AssistantMessage{message: message}) do
@@ -500,6 +511,18 @@ defmodule DestilaWeb.WorkflowRunnerLive do
     socket
     |> assign(:messages, messages)
     |> assign(:current_step, current_step)
+    |> assign_ai_sessions_list(ws.id)
+  end
+
+  defp assign_ai_sessions_list(socket, ws_id) do
+    ai_sessions = AI.list_ai_sessions_for_workflow(ws_id)
+
+    ai_sessions_alive =
+      Map.new(ai_sessions, fn ai -> {ai.id, AlivenessTracker.alive_ai?(ai.id)} end)
+
+    socket
+    |> assign(:ai_sessions, ai_sessions)
+    |> assign(:ai_sessions_alive, ai_sessions_alive)
   end
 
   defp compute_current_step(ws, phase_status, messages) do
@@ -862,6 +885,47 @@ defmodule DestilaWeb.WorkflowRunnerLive do
                 <%!-- Divider between input and output --%>
                 <div class="border-t border-base-300/60 mx-3"></div>
 
+                <%!-- AI Sessions section — historical AI sessions for this workflow --%>
+                <div id="ai-sessions-section" class="px-3 pt-3 pb-3">
+                  <h3 class="text-[10px] font-semibold text-base-content/40 uppercase tracking-wider mb-1.5 px-2">
+                    AI Sessions
+                  </h3>
+
+                  <%= if @ai_sessions == [] do %>
+                    <p class="px-2 py-1.5 text-xs text-base-content/25">
+                      No AI sessions yet
+                    </p>
+                  <% else %>
+                    <div class="space-y-0.5">
+                      <.link
+                        :for={ai <- @ai_sessions}
+                        id={"ai-session-row-#{ai.id}"}
+                        navigate={~p"/sessions/#{@workflow_session.id}/ai/#{ai.id}"}
+                        class="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-md hover:bg-base-200/60 transition-colors duration-150 group"
+                        aria-label={"Open AI session from #{format_ai_inserted_at(ai.inserted_at)}"}
+                      >
+                        <span class="size-5 rounded flex items-center justify-center shrink-0">
+                          <.aliveness_dot
+                            session={@workflow_session}
+                            alive?={Map.get(@ai_sessions_alive, ai.id, false)}
+                            phase_status={:idle}
+                          />
+                        </span>
+                        <span class="text-sm text-base-content/60 truncate flex-1 text-left">
+                          {format_ai_inserted_at(ai.inserted_at)}
+                        </span>
+                        <.icon
+                          name="hero-chevron-right-micro"
+                          class="size-3.5 text-base-content/30 group-hover:text-primary transition-colors"
+                        />
+                      </.link>
+                    </div>
+                  <% end %>
+                </div>
+
+                <%!-- Divider between AI sessions and exported metadata --%>
+                <div class="border-t border-base-300/60 mx-3"></div>
+
                 <%!-- Exported metadata section — primary content --%>
                 <div class="px-3 pt-3 pb-6 flex-1">
                   <h3 class="text-[10px] font-semibold text-base-content/40 uppercase tracking-wider mb-1.5 px-2">
@@ -1220,4 +1284,10 @@ defmodule DestilaWeb.WorkflowRunnerLive do
     |> String.split("_")
     |> Enum.map_join(" ", &String.capitalize/1)
   end
+
+  defp format_ai_inserted_at(%DateTime{} = dt) do
+    Calendar.strftime(dt, "%b %-d, %H:%M")
+  end
+
+  defp format_ai_inserted_at(_), do: ""
 end

--- a/lib/destila_web/router.ex
+++ b/lib/destila_web/router.ex
@@ -31,5 +31,6 @@ defmodule DestilaWeb.Router do
     get "/media/:id", MediaController, :show
     live "/sessions/:id", WorkflowRunnerLive
     live "/sessions/:id/terminal", TerminalLive
+    live "/sessions/:workflow_session_id/ai/:ai_session_id", AiSessionDetailLive
   end
 end

--- a/test/destila/ai/aliveness_tracker_test.exs
+++ b/test/destila/ai/aliveness_tracker_test.exs
@@ -3,60 +3,87 @@ defmodule Destila.AI.AlivenessTrackerTest do
 
   alias Destila.AI.AlivenessTracker
 
+  setup do
+    Phoenix.PubSub.subscribe(Destila.PubSub, AlivenessTracker.topic())
+    :ok
+  end
+
   test "alive?/1 returns false for unknown session" do
     refute AlivenessTracker.alive?("nonexistent")
   end
 
-  test "tracks session started via PubSub broadcast" do
-    session_id = Ecto.UUID.generate()
+  test "alive_ai?/1 returns false for unknown ai session" do
+    refute AlivenessTracker.alive_ai?("nonexistent")
+  end
 
-    # Register a dummy agent in the AI SessionRegistry
+  test "tracks workflow and ai session started via 3-tuple PubSub broadcast" do
+    workflow_session_id = Ecto.UUID.generate()
+    ai_session_id = Ecto.UUID.generate()
+
     {:ok, pid} =
       Agent.start_link(fn -> nil end,
-        name: {:via, Registry, {Destila.AI.SessionRegistry, session_id}}
+        name: {:via, Registry, {Destila.AI.SessionRegistry, workflow_session_id}}
       )
 
-    # Subscribe to aliveness changes
-    Phoenix.PubSub.subscribe(Destila.PubSub, AlivenessTracker.topic())
-
-    # Simulate the broadcast that ClaudeSession.init/1 sends
     Phoenix.PubSub.broadcast(
       Destila.PubSub,
       Destila.PubSubHelper.claude_session_topic(),
-      {:claude_session_started, session_id}
+      {:claude_session_started, workflow_session_id, ai_session_id}
     )
 
-    # Wait for the tracker to process the message
-    assert_receive {:aliveness_changed, ^session_id, true}
+    assert_receive {:aliveness_changed, ^workflow_session_id, true}
+    assert_receive {:aliveness_changed_ai, ^ai_session_id, true}
 
-    assert AlivenessTracker.alive?(session_id)
+    assert AlivenessTracker.alive?(workflow_session_id)
+    assert AlivenessTracker.alive_ai?(ai_session_id)
 
-    # Stop the agent — should trigger :DOWN
     Agent.stop(pid)
 
-    assert_receive {:aliveness_changed, ^session_id, false}
-    refute AlivenessTracker.alive?(session_id)
+    assert_receive {:aliveness_changed, ^workflow_session_id, false}
+    assert_receive {:aliveness_changed_ai, ^ai_session_id, false}
+    refute AlivenessTracker.alive?(workflow_session_id)
+    refute AlivenessTracker.alive_ai?(ai_session_id)
+  end
+
+  test "tracks workflow without ai_session_id via legacy 2-tuple broadcast" do
+    workflow_session_id = Ecto.UUID.generate()
+
+    {:ok, pid} =
+      Agent.start_link(fn -> nil end,
+        name: {:via, Registry, {Destila.AI.SessionRegistry, workflow_session_id}}
+      )
+
+    Phoenix.PubSub.broadcast(
+      Destila.PubSub,
+      Destila.PubSubHelper.claude_session_topic(),
+      {:claude_session_started, workflow_session_id}
+    )
+
+    assert_receive {:aliveness_changed, ^workflow_session_id, true}
+    assert AlivenessTracker.alive?(workflow_session_id)
+
+    Agent.stop(pid)
+
+    assert_receive {:aliveness_changed, ^workflow_session_id, false}
+    refute AlivenessTracker.alive?(workflow_session_id)
   end
 
   test "initial scan picks up already-running sessions" do
-    session_id = Ecto.UUID.generate()
+    workflow_session_id = Ecto.UUID.generate()
 
-    # Register before notifying tracker
     {:ok, _pid} =
       Agent.start_link(fn -> nil end,
-        name: {:via, Registry, {Destila.AI.SessionRegistry, session_id}}
+        name: {:via, Registry, {Destila.AI.SessionRegistry, workflow_session_id}}
       )
 
-    # Broadcast to notify tracker
     Phoenix.PubSub.broadcast(
       Destila.PubSub,
       Destila.PubSubHelper.claude_session_topic(),
-      {:claude_session_started, session_id}
+      {:claude_session_started, workflow_session_id, nil}
     )
 
-    # Give tracker time to process
     _ = :sys.get_state(AlivenessTracker)
 
-    assert AlivenessTracker.alive?(session_id)
+    assert AlivenessTracker.alive?(workflow_session_id)
   end
 end

--- a/test/destila/ai/history_test.exs
+++ b/test/destila/ai/history_test.exs
@@ -1,0 +1,50 @@
+defmodule Destila.AI.BadHistory do
+  @moduledoc false
+  def get_messages(_id, _opts), do: raise("boom")
+end
+
+defmodule Destila.AI.HistoryTest do
+  use ExUnit.Case, async: false
+
+  alias ClaudeCode.History.SessionMessage
+  alias Destila.AI.{BadHistory, FakeHistory, History}
+
+  setup do
+    FakeHistory.reset()
+    :ok
+  end
+
+  test "returns stubbed messages for a known session id" do
+    session_id = Ecto.UUID.generate()
+    msg = %SessionMessage{type: :assistant, uuid: "u1", session_id: session_id, message: %{}}
+    FakeHistory.stub(session_id, {:ok, [msg]})
+
+    assert {:ok, [^msg]} = History.get_messages(session_id)
+  end
+
+  test "returns ok empty when no stub is registered" do
+    assert {:ok, []} = History.get_messages(Ecto.UUID.generate())
+  end
+
+  test "propagates error tuples from the underlying implementation" do
+    session_id = Ecto.UUID.generate()
+    FakeHistory.stub(session_id, {:error, :enoent})
+
+    assert {:error, :enoent} = History.get_messages(session_id)
+  end
+
+  test "rescues exceptions from the underlying implementation" do
+    previous = Application.get_env(:destila, :ai_history_module)
+    Application.put_env(:destila, :ai_history_module, BadHistory)
+
+    on_exit(fn ->
+      if previous do
+        Application.put_env(:destila, :ai_history_module, previous)
+      else
+        Application.delete_env(:destila, :ai_history_module)
+      end
+    end)
+
+    assert {:error, {:exception, _}} = History.get_messages("abc")
+  end
+end

--- a/test/destila_web/live/ai_session_detail_live_test.exs
+++ b/test/destila_web/live/ai_session_detail_live_test.exs
@@ -210,6 +210,101 @@ defmodule DestilaWeb.AiSessionDetailLiveTest do
     end
   end
 
+  describe "history live updates" do
+    @tag feature: "ai_session_detail",
+         scenario: "Stream chunk triggers debounced history reload"
+    test "appends new messages after a chunk broadcast followed by reload fire", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      initial = [user_message("first")]
+      FakeHistory.stub(ai.claude_session_id, {:ok, initial})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+      assert render(view) =~ "first"
+
+      appended =
+        initial ++
+          [assistant_message([%TextBlock{type: "text", text: "second"}])]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, appended})
+
+      Phoenix.PubSub.broadcast(
+        Destila.PubSub,
+        Destila.PubSubHelper.ai_stream_topic(ws.id),
+        {:ai_stream_chunk, :any}
+      )
+
+      send(view.pid, :reload_history)
+
+      html = render(view)
+      assert html =~ "first"
+      assert html =~ "second"
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Stream chunk transitions empty history to loaded"
+    test "promotes :empty state to :loaded when new messages arrive", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, []})
+
+      {:ok, view, html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+      assert html =~ "No conversation history available"
+
+      FakeHistory.stub(
+        ai.claude_session_id,
+        {:ok, [assistant_message([%TextBlock{type: "text", text: "arrived"}])]}
+      )
+
+      Phoenix.PubSub.broadcast(
+        Destila.PubSub,
+        Destila.PubSubHelper.ai_stream_topic(ws.id),
+        {:ai_stream_chunk, :any}
+      )
+
+      send(view.pid, :reload_history)
+
+      html = render(view)
+      assert html =~ "arrived"
+      refute html =~ "No conversation history available"
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Debounced reload does not duplicate messages"
+    test "multiple chunk broadcasts before reload do not duplicate messages", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      messages = [
+        user_message("hello"),
+        assistant_message([%TextBlock{type: "text", text: "world"}])
+      ]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      for _ <- 1..5 do
+        Phoenix.PubSub.broadcast(
+          Destila.PubSub,
+          Destila.PubSubHelper.ai_stream_topic(ws.id),
+          {:ai_stream_chunk, :any}
+        )
+      end
+
+      send(view.pid, :reload_history)
+
+      html = render(view)
+      first_hello = :binary.match(html, "hello")
+      assert first_hello != :nomatch
+      {start, len} = first_hello
+      rest = binary_part(html, start + len, byte_size(html) - start - len)
+      refute rest =~ "hello"
+    end
+  end
+
   describe "content block rendering" do
     @tag feature: "ai_session_detail", scenario: "Text blocks render in order"
     test "renders user and assistant text blocks in order", %{conn: conn} do

--- a/test/destila_web/live/ai_session_detail_live_test.exs
+++ b/test/destila_web/live/ai_session_detail_live_test.exs
@@ -1,0 +1,514 @@
+defmodule DestilaWeb.AiSessionDetailLiveTest do
+  @moduledoc """
+  LiveView tests for the AI Session Debug Detail page.
+  Feature: features/ai_session_detail.feature
+  """
+  use DestilaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias ClaudeCode.Content.{
+    CompactionBlock,
+    ImageBlock,
+    MCPToolUseBlock,
+    RedactedThinkingBlock,
+    ServerToolResultBlock,
+    ServerToolUseBlock,
+    TextBlock,
+    ThinkingBlock,
+    ToolResultBlock,
+    ToolUseBlock
+  }
+
+  alias ClaudeCode.History.SessionMessage
+  alias Destila.AI
+  alias Destila.AI.{AlivenessTracker, FakeHistory}
+
+  setup %{conn: conn} do
+    ClaudeCode.Test.set_mode_to_shared()
+
+    ClaudeCode.Test.stub(ClaudeCode, fn _query, _opts ->
+      [
+        ClaudeCode.Test.text("AI response"),
+        ClaudeCode.Test.result("AI response")
+      ]
+    end)
+
+    FakeHistory.reset()
+
+    {:ok, conn: conn}
+  end
+
+  defp create_session do
+    {:ok, ws} =
+      Destila.Workflows.insert_workflow_session(%{
+        title: "Test Session",
+        workflow_type: :brainstorm_idea,
+        project_id: nil,
+        done_at: DateTime.utc_now(),
+        current_phase: 4,
+        total_phases: 4
+      })
+
+    ws
+  end
+
+  defp create_ai_session(ws, attrs \\ %{}) do
+    claude_session_id = Map.get(attrs, :claude_session_id, Ecto.UUID.generate())
+
+    {:ok, ai} =
+      AI.create_ai_session(
+        Map.merge(
+          %{
+            workflow_session_id: ws.id,
+            worktree_path: System.tmp_dir!(),
+            claude_session_id: claude_session_id
+          },
+          attrs
+        )
+      )
+
+    ai
+  end
+
+  defp assistant_message(content_blocks) do
+    %SessionMessage{
+      type: :assistant,
+      uuid: Ecto.UUID.generate(),
+      session_id: "test-session",
+      message: %{content: content_blocks},
+      parent_tool_use_id: nil
+    }
+  end
+
+  defp user_message(content) do
+    %SessionMessage{
+      type: :user,
+      uuid: Ecto.UUID.generate(),
+      session_id: "test-session",
+      message: %{content: content, role: :user},
+      parent_tool_use_id: nil
+    }
+  end
+
+  describe "mount + header" do
+    @tag feature: "ai_session_detail",
+         scenario: "Header shows creation date and Claude session id"
+    test "renders header with creation date and claude_session_id", %{conn: conn} do
+      ws = create_session()
+      claude_session_id = Ecto.UUID.generate()
+      ai = create_ai_session(ws, %{claude_session_id: claude_session_id})
+      FakeHistory.stub(claude_session_id, {:ok, []})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      assert has_element?(view, "#ai-session-header")
+      assert has_element?(view, "#ai-session-claude-id", claude_session_id)
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Back link navigates to the parent workflow runner"
+    test "back link points to the parent workflow runner", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+      FakeHistory.stub(ai.claude_session_id, {:ok, []})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      assert has_element?(
+               view,
+               ~s|#ai-session-back-link[href="/sessions/#{ws.id}"]|
+             )
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Unknown workflow session id redirects to the crafting board"
+    test "unknown workflow session id redirects to /crafting", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      assert {:error, {:live_redirect, %{to: "/crafting"}}} =
+               live(conn, ~p"/sessions/#{Ecto.UUID.generate()}/ai/#{ai.id}")
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Unknown AI session id redirects to the workflow runner"
+    test "unknown ai_session_id redirects to /crafting", %{conn: conn} do
+      ws = create_session()
+
+      assert {:error, {:live_redirect, %{to: "/crafting"}}} =
+               live(conn, ~p"/sessions/#{ws.id}/ai/#{Ecto.UUID.generate()}")
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "AI session belonging to another workflow is rejected"
+    test "ai_session from a different workflow redirects to the parent workflow", %{conn: conn} do
+      ws1 = create_session()
+      ws2 = create_session()
+      ai = create_ai_session(ws2)
+
+      assert {:error, {:live_redirect, %{to: path}}} =
+               live(conn, ~p"/sessions/#{ws1.id}/ai/#{ai.id}")
+
+      assert path == "/sessions/#{ws1.id}"
+    end
+  end
+
+  describe "empty states" do
+    @tag feature: "ai_session_detail", scenario: "Missing Claude session id shows empty state"
+    test "renders empty state when claude_session_id is nil", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws, %{claude_session_id: nil})
+
+      {:ok, _view, html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      assert html =~ "No conversation history available"
+    end
+
+    @tag feature: "ai_session_detail", scenario: "Empty history shows empty state"
+    test "renders empty state when history is empty", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+      FakeHistory.stub(ai.claude_session_id, {:ok, []})
+
+      {:ok, _view, html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      assert html =~ "No conversation history available"
+    end
+
+    @tag feature: "ai_session_detail", scenario: "History read failure shows empty state"
+    test "renders error empty state when history adapter returns an error", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+      FakeHistory.stub(ai.claude_session_id, {:error, :enoent})
+
+      {:ok, _view, html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      assert html =~ "Unable to read conversation history"
+    end
+  end
+
+  describe "aliveness live updates" do
+    @tag feature: "ai_session_detail", scenario: "Aliveness dot toggles live on the detail page"
+    test "broadcasting an ai-aliveness change updates the detail page", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+      FakeHistory.stub(ai.claude_session_id, {:ok, []})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      Phoenix.PubSub.broadcast(
+        Destila.PubSub,
+        AlivenessTracker.topic(),
+        {:aliveness_changed_ai, ai.id, true}
+      )
+
+      assert render(view) =~ "bg-success"
+    end
+  end
+
+  describe "content block rendering" do
+    @tag feature: "ai_session_detail", scenario: "Text blocks render in order"
+    test "renders user and assistant text blocks in order", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      messages = [
+        user_message("hello there"),
+        assistant_message([%TextBlock{type: "text", text: "hi back"}])
+      ]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      assert has_element?(view, ~s|[data-message-role="user"]|)
+      assert has_element?(view, ~s|[data-message-role="assistant"]|)
+      assert render(view) =~ "hello there"
+      assert render(view) =~ "hi back"
+    end
+
+    @tag feature: "ai_session_detail", scenario: "Thinking block renders collapsed by default"
+    test "renders thinking block as collapsed <details>", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      messages = [
+        assistant_message([
+          %ThinkingBlock{type: "thinking", thinking: "deep thoughts", signature: "sig"}
+        ])
+      ]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      assert has_element?(view, ~s|details[data-block-type="thinking"]|)
+
+      refute render(view) =~
+               ~s|<details data-block-type="thinking" class="rounded-md border border-base-300/60 bg-base-200/40" open|
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Redacted thinking block renders as a placeholder"
+    test "renders redacted thinking block placeholder", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      messages = [
+        assistant_message([
+          %RedactedThinkingBlock{type: "redacted_thinking", data: "abcd"}
+        ])
+      ]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      assert has_element?(view, ~s|[data-block-type="redacted_thinking"]|)
+      assert render(view) =~ "Redacted thinking"
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Tool use block renders tool name and pretty JSON input"
+    test "renders tool use block with name and pretty JSON input", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      messages = [
+        assistant_message([
+          %ToolUseBlock{
+            type: "tool_use",
+            id: "toolu_1",
+            name: "Read",
+            input: %{"path" => "/tmp/foo.txt"}
+          }
+        ])
+      ]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      assert has_element?(
+               view,
+               ~s|[data-block-type="tool_use"][data-tool-use-id="toolu_1"]|
+             )
+
+      html = render(view)
+      assert html =~ "Read"
+      assert html =~ "/tmp/foo.txt"
+    end
+
+    @tag feature: "ai_session_detail", scenario: "Tool result block is paired with its tool use"
+    test "tool result block references the originating tool use id and carries the tool name",
+         %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      messages = [
+        assistant_message([
+          %ToolUseBlock{
+            type: "tool_use",
+            id: "toolu_1",
+            name: "Read",
+            input: %{"path" => "/tmp/foo.txt"}
+          }
+        ]),
+        user_message([
+          %ToolResultBlock{
+            type: "tool_result",
+            tool_use_id: "toolu_1",
+            content: "file contents",
+            is_error: false
+          }
+        ])
+      ]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      assert has_element?(
+               view,
+               ~s|[data-block-type="tool_result"][data-tool-use-ref="toolu_1"][data-tool-name="Read"]|
+             )
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Tool result with is_error renders with an error style"
+    test "tool result block with is_error true renders with error styling", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      messages = [
+        user_message([
+          %ToolResultBlock{
+            type: "tool_result",
+            tool_use_id: "toolu_1",
+            content: "boom",
+            is_error: true
+          }
+        ])
+      ]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      html = render(view)
+      assert html =~ ~s|data-block-type="tool_result"|
+      assert html =~ "border-error"
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Server tool use and result render with a server tool badge"
+    test "server tool blocks render with a server tool label", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      messages = [
+        assistant_message([
+          %ServerToolUseBlock{
+            type: "server_tool_use",
+            id: "srv_1",
+            name: "web_search",
+            input: %{"q" => "elixir"}
+          }
+        ]),
+        user_message([
+          %ServerToolResultBlock{
+            type: "server_tool_result",
+            tool_use_id: "srv_1",
+            content: "[result]"
+          }
+        ])
+      ]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      html = render(view)
+      assert html =~ ~s|data-block-type="server_tool_use"|
+      assert html =~ ~s|data-block-type="server_tool_result"|
+      assert html =~ "server tool"
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "MCP tool blocks render with server_name and tool name"
+    test "MCP tool use block shows server name and tool name", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      messages = [
+        assistant_message([
+          %MCPToolUseBlock{
+            type: "mcp_tool_use",
+            id: "mcp_1",
+            name: "list_files",
+            server_name: "my-server",
+            input: %{"path" => "/"}
+          }
+        ])
+      ]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      html = render(view)
+      assert html =~ ~s|data-block-type="mcp_tool_use"|
+      assert html =~ "my-server"
+      assert html =~ "list_files"
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Image block with URL source renders an img element"
+    test "image block with URL source renders an <img>", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      messages = [
+        assistant_message([
+          %ImageBlock{
+            type: "image",
+            source: %{type: :url, url: "https://example.com/cat.png"}
+          }
+        ])
+      ]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      assert has_element?(view, ~s|img[src="https://example.com/cat.png"]|)
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Image block with base64 source renders a placeholder"
+    test "image block with base64 source renders a placeholder (no img element)", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      messages = [
+        assistant_message([
+          %ImageBlock{
+            type: "image",
+            source: %{type: :base64, media_type: "image/png", data: "AAAA"}
+          }
+        ])
+      ]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      html = render(view)
+      assert html =~ ~s|data-image-kind="base64"|
+      refute html =~ ~s|<img|
+    end
+
+    @tag feature: "ai_session_detail", scenario: "Compaction block renders a visible marker"
+    test "compaction block renders a compaction marker", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      messages = [
+        assistant_message([
+          %CompactionBlock{type: "compaction", content: "summary"}
+        ])
+      ]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      html = render(view)
+      assert html =~ ~s|data-block-type="compaction"|
+      assert html =~ "Conversation compacted"
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Unknown block types render via an inspect fallback"
+    test "unknown block struct renders through the inspect fallback without crashing",
+         %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      messages = [
+        assistant_message([
+          %{__struct__: NotARealBlock, foo: :bar}
+        ])
+      ]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      html = render(view)
+      assert html =~ ~s|data-block-type="unknown"|
+      assert html =~ "NotARealBlock"
+    end
+  end
+end

--- a/test/destila_web/live/ai_session_detail_live_test.exs
+++ b/test/destila_web/live/ai_session_detail_live_test.exs
@@ -10,6 +10,7 @@ defmodule DestilaWeb.AiSessionDetailLiveTest do
   alias ClaudeCode.Content.{
     CompactionBlock,
     ImageBlock,
+    MCPToolResultBlock,
     MCPToolUseBlock,
     RedactedThinkingBlock,
     ServerToolResultBlock,
@@ -133,11 +134,13 @@ defmodule DestilaWeb.AiSessionDetailLiveTest do
 
     @tag feature: "ai_session_detail",
          scenario: "Unknown AI session id redirects to the workflow runner"
-    test "unknown ai_session_id redirects to /crafting", %{conn: conn} do
+    test "unknown ai_session_id redirects to the workflow runner page", %{conn: conn} do
       ws = create_session()
 
-      assert {:error, {:live_redirect, %{to: "/crafting"}}} =
+      assert {:error, {:live_redirect, %{to: path}}} =
                live(conn, ~p"/sessions/#{ws.id}/ai/#{Ecto.UUID.generate()}")
+
+      assert path == "/sessions/#{ws.id}"
     end
 
     @tag feature: "ai_session_detail",
@@ -393,6 +396,32 @@ defmodule DestilaWeb.AiSessionDetailLiveTest do
       assert html =~ ~s|data-block-type="server_tool_use"|
       assert html =~ ~s|data-block-type="server_tool_result"|
       assert html =~ "server tool"
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "MCP tool blocks render with server_name and tool name"
+    test "MCP tool result block with is_error true renders with error styling", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      messages = [
+        user_message([
+          %MCPToolResultBlock{
+            type: "mcp_tool_result",
+            tool_use_id: "mcp_1",
+            content: "boom",
+            is_error: true
+          }
+        ])
+      ]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      html = render(view)
+      assert html =~ ~s|data-block-type="mcp_tool_result"|
+      assert html =~ "border-error"
     end
 
     @tag feature: "ai_session_detail",

--- a/test/destila_web/live/ai_session_sidebar_live_test.exs
+++ b/test/destila_web/live/ai_session_sidebar_live_test.exs
@@ -1,0 +1,165 @@
+defmodule DestilaWeb.AiSessionSidebarLiveTest do
+  @moduledoc """
+  LiveView tests for the AI Sessions section in the workflow runner right sidebar.
+  Feature: features/ai_session_sidebar.feature
+  """
+  use DestilaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Destila.AI
+  alias Destila.AI.AlivenessTracker
+
+  setup %{conn: conn} do
+    ClaudeCode.Test.set_mode_to_shared()
+
+    ClaudeCode.Test.stub(ClaudeCode, fn _query, _opts ->
+      [
+        ClaudeCode.Test.text("AI response"),
+        ClaudeCode.Test.result("AI response")
+      ]
+    end)
+
+    {:ok, conn: conn}
+  end
+
+  defp create_session do
+    {:ok, ws} =
+      Destila.Workflows.insert_workflow_session(%{
+        title: "Test Session",
+        workflow_type: :brainstorm_idea,
+        project_id: nil,
+        done_at: DateTime.utc_now(),
+        current_phase: 4,
+        total_phases: 4
+      })
+
+    ws
+  end
+
+  defp create_ai_session(ws, attrs \\ %{}) do
+    {:ok, ai} =
+      AI.create_ai_session(
+        Map.merge(
+          %{
+            workflow_session_id: ws.id,
+            worktree_path: System.tmp_dir!(),
+            claude_session_id: Ecto.UUID.generate()
+          },
+          attrs
+        )
+      )
+
+    ai
+  end
+
+  describe "AI Sessions sidebar section" do
+    @tag feature: "ai_session_sidebar",
+         scenario: "AI Sessions section renders between Workflow Session and Exported Metadata"
+    test "section container is rendered", %{conn: conn} do
+      ws = create_session()
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      assert has_element?(view, "#ai-sessions-section")
+    end
+
+    @tag feature: "ai_session_sidebar",
+         scenario: "AI Sessions section lists every AI session for the workflow"
+    test "renders one row per AI session with a link to the detail page", %{conn: conn} do
+      ws = create_session()
+      ai1 = create_ai_session(ws)
+      ai2 = create_ai_session(ws)
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      assert has_element?(view, "#ai-session-row-#{ai1.id}")
+      assert has_element?(view, "#ai-session-row-#{ai2.id}")
+
+      assert has_element?(
+               view,
+               ~s|#ai-session-row-#{ai1.id}[href="/sessions/#{ws.id}/ai/#{ai1.id}"]|
+             )
+
+      assert has_element?(
+               view,
+               ~s|#ai-session-row-#{ai2.id}[href="/sessions/#{ws.id}/ai/#{ai2.id}"]|
+             )
+    end
+
+    @tag feature: "ai_session_sidebar", scenario: "Empty state when no AI sessions exist"
+    test "shows empty state when no AI sessions exist", %{conn: conn} do
+      ws = create_session()
+      {:ok, view, html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      assert has_element?(view, "#ai-sessions-section")
+      assert html =~ "No AI sessions yet"
+    end
+  end
+
+  describe "live aliveness updates" do
+    @tag feature: "ai_session_sidebar",
+         scenario: "Aliveness dot toggles to green in real time when a session starts"
+    test "broadcasting an ai-aliveness-change updates the row without reload", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      Phoenix.PubSub.broadcast(
+        Destila.PubSub,
+        AlivenessTracker.topic(),
+        {:aliveness_changed_ai, ai.id, true}
+      )
+
+      _ = render(view)
+
+      assert has_element?(
+               view,
+               ~s|#ai-session-row-#{ai.id} .bg-success|
+             )
+    end
+
+    @tag feature: "ai_session_sidebar",
+         scenario: "Aliveness dot toggles to muted in real time when a session stops"
+    test "broadcasting a false ai-aliveness-change reverts the row to muted", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      Phoenix.PubSub.broadcast(
+        Destila.PubSub,
+        AlivenessTracker.topic(),
+        {:aliveness_changed_ai, ai.id, true}
+      )
+
+      _ = render(view)
+
+      Phoenix.PubSub.broadcast(
+        Destila.PubSub,
+        AlivenessTracker.topic(),
+        {:aliveness_changed_ai, ai.id, false}
+      )
+
+      _ = render(view)
+
+      refute has_element?(view, ~s|#ai-session-row-#{ai.id} .bg-success|)
+    end
+
+    @tag feature: "ai_session_sidebar", scenario: "Workflow header aliveness dot is unaffected"
+    test "AI-specific aliveness broadcast does not disturb workflow-level handler", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      Phoenix.PubSub.broadcast(
+        Destila.PubSub,
+        AlivenessTracker.topic(),
+        {:aliveness_changed_ai, ai.id, true}
+      )
+
+      assert render(view) =~ "ai-sessions-section"
+    end
+  end
+end

--- a/test/destila_web/live/ai_session_sidebar_live_test.exs
+++ b/test/destila_web/live/ai_session_sidebar_live_test.exs
@@ -96,6 +96,54 @@ defmodule DestilaWeb.AiSessionSidebarLiveTest do
     end
   end
 
+  describe "initial aliveness state" do
+    @tag feature: "ai_session_sidebar",
+         scenario: "Running AI session shows a green aliveness dot"
+    test "row shows a green dot when AlivenessTracker reports the session as alive", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      :ets.insert(:ai_session_aliveness, {{:ai, ai.id}, true})
+
+      try do
+        {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+        assert has_element?(view, ~s|#ai-session-row-#{ai.id} .bg-success|)
+      after
+        :ets.delete(:ai_session_aliveness, {:ai, ai.id})
+      end
+    end
+
+    @tag feature: "ai_session_sidebar",
+         scenario: "Inactive AI session shows a muted aliveness dot"
+    test "row shows a muted dot when AlivenessTracker reports the session as inactive", %{
+      conn: conn
+    } do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      refute has_element?(view, ~s|#ai-session-row-#{ai.id} .bg-success|)
+    end
+  end
+
+  describe "row navigation" do
+    @tag feature: "ai_session_sidebar",
+         scenario: "Clicking a row opens the AI Session Debug Detail page"
+    test "row link navigates to the AI Session Debug Detail page for that session", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      assert has_element?(
+               view,
+               ~s|#ai-session-row-#{ai.id}[href="/sessions/#{ws.id}/ai/#{ai.id}"]|
+             )
+    end
+  end
+
   describe "live aliveness updates" do
     @tag feature: "ai_session_sidebar",
          scenario: "Aliveness dot toggles to green in real time when a session starts"

--- a/test/support/fake_history.ex
+++ b/test/support/fake_history.ex
@@ -34,12 +34,20 @@ defmodule Destila.AI.FakeHistory do
     :ok
   end
 
-  def get_messages(session_id, _opts \\ []) do
+  def get_messages(session_id, opts \\ []) do
     ensure_started()
 
-    case :ets.lookup(@table, session_id) do
-      [{^session_id, response}] -> response
-      [] -> {:ok, []}
-    end
+    response =
+      case :ets.lookup(@table, session_id) do
+        [{^session_id, response}] -> response
+        [] -> {:ok, []}
+      end
+
+    apply_offset(response, Keyword.get(opts, :offset, 0))
   end
+
+  defp apply_offset({:ok, messages}, offset) when is_integer(offset) and offset > 0,
+    do: {:ok, Enum.drop(messages, offset)}
+
+  defp apply_offset(response, _offset), do: response
 end

--- a/test/support/fake_history.ex
+++ b/test/support/fake_history.ex
@@ -1,0 +1,45 @@
+defmodule Destila.AI.FakeHistory do
+  @moduledoc """
+  Test stand-in for `ClaudeCode.History`. Tests call `stub/2` to register
+  canned responses for a session id, then set the application env so the
+  `Destila.AI.History` adapter calls this module.
+
+  Uses ETS for storage so tests can read back what was stubbed without
+  owning an Agent process.
+  """
+
+  @table :destila_fake_history
+
+  def ensure_started do
+    case :ets.whereis(@table) do
+      :undefined -> :ets.new(@table, [:set, :public, :named_table])
+      _ -> @table
+    end
+  end
+
+  @doc """
+  Registers a canned response for a session id.
+
+  `response` is returned verbatim from `get_messages/2`.
+  """
+  def stub(session_id, response) when is_binary(session_id) do
+    ensure_started()
+    :ets.insert(@table, {session_id, response})
+    :ok
+  end
+
+  def reset do
+    ensure_started()
+    :ets.delete_all_objects(@table)
+    :ok
+  end
+
+  def get_messages(session_id, _opts \\ []) do
+    ensure_started()
+
+    case :ets.lookup(@table, session_id) do
+      [{^session_id, response}] -> response
+      [] -> {:ok, []}
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add an **AI Sessions** section to the workflow runner right sidebar, positioned between *Workflow Session* and *Exported Metadata*. Each row shows the session creation date and a live aliveness dot (green when the Claude Code GenServer is running, muted otherwise) and links to the new debug detail page.
- Add an **AI Session Debug Detail** page at `/sessions/:workflow_session_id/ai/:ai_session_id` that renders the full Claude conversation history read from disk via `Destila.AI.History.get_messages/2`. Every ClaudeCode content block type (text, thinking, tool_use, tool_result, server tool, MCP tool, image, document, container upload, compaction, redacted thinking) gets a dedicated branch with an `inspect/2` fallback for unknown shapes.
- Extend `Destila.AI.AlivenessTracker` to dual-key by both `workflow_session_id` and `ai_session_id`, with a new `:aliveness_changed_ai` PubSub message for AI-specific live updates.
- Add `Destila.AI.History` adapter (configurable via `Application.get_env/3`) and `Destila.AI.FakeHistory` so LiveView tests can stub conversation histories without touching disk.

## Plan & Gherkin

- Plan: `docs/plans/2026-04-16-001-feat-ai-sessions-sidebar-and-debug-detail-plan.md`
- Features: `features/ai_session_sidebar.feature`, `features/ai_session_detail.feature`

## Review fixes (commit 7bf7353)

Applied 7 P1/P2 fixes from `ce:review`:

1. Mount validation: separated workflow-not-found from ai-session-not-found so unknown ai_session_id redirects to the workflow runner page (matches Gherkin), not `/crafting`.
2. `AlivenessTracker`: replaced `Map.pop!` with safe `Map.pop` in the `:DOWN` handler; reordered `put_in` to precede broadcasts so a failing PubSub call cannot leak monitors.
3. `AlivenessTracker`: log Repo lookup failures via `Logger.debug` instead of silently swallowing them.
4. `ImageBlock` URL: validate scheme (only http/https/data) before rendering `<img>`; placeholder otherwise.
5. Capped `inspect/2` fallbacks (`limit: 200, printable_limit: 4096`) so a pathological tool result cannot balloon the rendered DOM.
6. Added missing Gherkin-linked tests (sidebar running/inactive aliveness dot, row navigation).
7. Added `MCPToolResultBlock` is_error path test on the detail page.

## Test plan

- [x] `mix test test/destila_web/live/ai_session_detail_live_test.exs test/destila_web/live/ai_session_sidebar_live_test.exs` — 31/31 pass
- [x] `mix test --only feature` — 200/200 pass
- [x] `mix compile --warnings-as-errors` — clean
- [x] Manual walkthrough recorded — sidebar lists AI sessions, click navigates to detail, header shows metadata, empty state renders correctly

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — the change is read-only on the LiveView side (history is loaded from existing on-disk JSONL files and the new aliveness key is a parallel index over an in-process ETS table). If something goes wrong, the symptom is a broken `/sessions/:id/ai/:ai_id` page or a stale aliveness dot; both are recoverable by reloading the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)