### PR TITLE
fix: render empty thinking blocks as placeholder in AI session detail

### DIFF
--- a/features/ai_session_detail.feature
+++ b/features/ai_session_detail.feature
@@ -80,6 +80,11 @@ Feature: AI Session Debug Detail Page
     When I open the AI Session Debug Detail page
     Then the thinking block should render as a collapsed details element
 
+  Scenario: Thinking block with empty content renders as a placeholder
+    Given the history contains a thinking block whose thinking text is empty
+    When I open the AI Session Debug Detail page
+    Then the block should render a visible placeholder noting the content is not preserved
+
   Scenario: Redacted thinking block renders as a placeholder
     Given the history contains a redacted thinking block
     When I open the AI Session Debug Detail page

--- a/lib/destila_web/components/ai_session_debug_components.ex
+++ b/lib/destila_web/components/ai_session_debug_components.ex
@@ -306,7 +306,8 @@ defmodule DestilaWeb.AiSessionDebugComponents do
     """
   end
 
-  defp content_block(%{block: %ThinkingBlock{}} = assigns) do
+  defp content_block(%{block: %ThinkingBlock{thinking: thinking}} = assigns)
+       when is_binary(thinking) and byte_size(thinking) > 0 do
     ~H"""
     <details
       id={@block_id}
@@ -319,6 +320,21 @@ defmodule DestilaWeb.AiSessionDebugComponents do
       </summary>
       <pre class="px-3 pb-3 pt-1 text-xs text-base-content/70 whitespace-pre-wrap break-words">{@block.thinking}</pre>
     </details>
+    """
+  end
+
+  defp content_block(%{block: %ThinkingBlock{}} = assigns) do
+    ~H"""
+    <div
+      id={@block_id}
+      data-block-type="thinking"
+      class="rounded-md border border-base-300/60 bg-base-200/40 px-3 py-2 flex items-center gap-2"
+    >
+      <.icon name="hero-sparkles-micro" class="size-3 text-base-content/40" />
+      <p class="text-xs text-base-content/50 italic">
+        Thinking (content not preserved in transcript)
+      </p>
+    </div>
     """
   end
 

--- a/test/destila_web/live/ai_session_detail_live_test.exs
+++ b/test/destila_web/live/ai_session_detail_live_test.exs
@@ -348,6 +348,27 @@ defmodule DestilaWeb.AiSessionDetailLiveTest do
     end
 
     @tag feature: "ai_session_detail",
+         scenario: "Thinking block with empty content renders as a placeholder"
+    test "renders empty thinking block as placeholder", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      messages = [
+        assistant_message([
+          %ThinkingBlock{type: "thinking", thinking: "", signature: "sig"}
+        ])
+      ]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      refute has_element?(view, ~s|details[data-block-type="thinking"]|)
+      assert has_element?(view, ~s|div[data-block-type="thinking"]|)
+      assert render(view) =~ "not preserved in transcript"
+    end
+
+    @tag feature: "ai_session_detail",
          scenario: "Redacted thinking block renders as a placeholder"
     test "renders redacted thinking block placeholder", %{conn: conn} do
       ws = create_session()


### PR DESCRIPTION
## Summary
- Claude Code's persisted JSONL transcript strips the `thinking` text from thinking blocks and keeps only the `signature`, so the AI session detail page rendered a collapsible `<details>` that revealed an empty body.
- When `ThinkingBlock.thinking` is empty, render a flat placeholder ("Thinking (content not preserved in transcript)") styled like the existing redacted-thinking placeholder. Non-empty thinking blocks still render as the expandable details element.
- Added a linked Gherkin scenario and LiveView test covering the empty case.

## Test plan
- [x] `mix test test/destila_web/live/ai_session_detail_live_test.exs` (27 tests, 0 failures)
- [ ] Manually verify on `/sessions/:ws/ai/:ai` for a session containing signature-only thinking blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)