### PR TITLE
feat: start service before recording feature video

### DIFF
--- a/lib/destila/workflows/implement_general_prompt_workflow.ex
+++ b/lib/destila/workflows/implement_general_prompt_workflow.ex
@@ -198,9 +198,12 @@ defmodule Destila.Workflows.ImplementGeneralPromptWorkflow do
     Record a feature video walkthrough of the implemented changes.
 
     Steps:
-    1. You MUST use the compound engineering skill `feature-video` to record a walkthrough \
+    1. Start the development service by calling `mcp__destila__service` with \
+    `action: "start"`. Use the returned port mappings when accessing the service \
+    in the walkthrough.
+    2. You MUST use the compound engineering skill `feature-video` to record a walkthrough \
     demonstrating the changes
-    2. Call `mcp__destila__session` with these exact parameters: `action: "export"`, \
+    3. Call `mcp__destila__session` with these exact parameters: `action: "export"`, \
     `key` set to the name of the file without extension, and `value` set to the path \
     to the video. This ensures each video has a distinct, descriptive key.
     """


### PR DESCRIPTION
## Summary
- Update the Feature Video phase prompt in `ImplementGeneralPromptWorkflow` to instruct the AI to start the development service via `mcp__destila__service` (`action: "start"`) before recording, and use the returned port mappings during the walkthrough.

## Test plan
- [ ] Run a workflow through the Feature Video phase and confirm the AI starts the service before invoking the `feature-video` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)