### PR TITLE
Refactor project service config to single service_env_var

### DIFF
--- a/docs/plans/2026-04-17-001-refactor-project-service-env-var-plan.md
+++ b/docs/plans/2026-04-17-001-refactor-project-service-env-var-plan.md
@@ -1,0 +1,519 @@
+---
+title: Refactor project service configuration to a single service env var
+type: refactor
+status: active
+date: 2026-04-17
+---
+
+# Refactor project service configuration to a single service env var
+
+## Overview
+
+Replace the multi-port `port_definitions` array on `Destila.Projects.Project` with a single optional `service_env_var` string. Presence of this value marks the project as a webservice — no separate boolean flag. Ports are allocated only when the service starts or restarts for a webservice project, and the service AI tool returns a single `url` string instead of a `ports` map.
+
+## Problem Frame
+
+The current design treats "ports" as a first-class, multi-valued configuration on projects: `port_definitions` is an array of env var names (`["PORT", "API_PORT"]`), and the service lifecycle reserves one ephemeral port per name and exports each as an env var. Downstream (service sidebar link, MCP AI tool, AI conversation context) only ever surfaces the *first* port, which leaks multi-port complexity into a UI that can only present a single URL. Additionally, `PrepareWorkflowSession` currently reserves ports for the post-worktree setup run, even though nothing consumes that allocation — the setup command just happens to see the env vars.
+
+The refactor collapses the model to its actual usage: a project is a webservice when it has a single env var name declared. A single port is allocated on start/restart, exported as that env var, and the service URL is `http://localhost:<port>`. Post-worktree setup runs without any port allocation.
+
+## Requirements Trace
+
+- **R1.** Replace `port_definitions` array with a single optional `service_env_var` string on `Destila.Projects.Project`, validated by the existing `^[A-Z][A-Z0-9_]*$` regex and the reserved-name denylist (`PATH`, `HOME`, `SHELL`, `USER`, `TERM`, `LANG`, `LD_PRELOAD`, `LD_LIBRARY_PATH`).
+- **R2.** A project is a webservice iff it has both `run_command` and a non-empty `service_env_var`. Empty string is equivalent to nil.
+- **R3.** `ServiceManager.start`/`restart` reserve exactly one ephemeral port, export it as the configured env var, and send `setup_command; run_command` (or just run command) to the tmux service window. Both actions require the webservice preconditions; otherwise they return a clear error.
+- **R4.** `PrepareWorkflowSession` always runs the setup command after worktree creation when a setup command is configured, with no port allocated and no env var exported. Failures remain logged and non-blocking.
+- **R5.** `service_state` persists a scalar `port` integer (not a `ports` map), plus `status`, `run_command`, `setup_command`. Stop/status/cleanup paths update accordingly.
+- **R6.** The `mcp__destila__service` tool returns a JSON object with `status`, `run_command`, `setup_command`, and a single `url` of the form `http://localhost:<port>`. `url` is omitted when no port is allocated. The tool's description states the project-must-be-a-webservice precondition.
+- **R7.** The service sidebar item renders only when the project has both `run_command` and `service_env_var`. When the service is running it links to `http://localhost:<port>` opening in a new tab. Otherwise it is hidden. Running vs. stopped/nil continues to drive icon color.
+- **R8.** The project form replaces the multi-port input with a single optional text input for `service_env_var` and surfaces validation errors on that field.
+- **R9.** Legacy `service_state` values still shaped like `%{"ports" => %{...}}` after deploy are tolerated: treated as stopped-with-no-url for reads; the next start/restart refreshes them to the new shape.
+- **R10.** Gherkin scenarios in `features/project_management.feature`, `features/service_status_sidebar.feature`, and `features/service_setup_command.feature` are updated per the user's prompt. Tests referencing `port_definitions` or the `ports` map are updated to match the new contract. `mix precommit` passes.
+
+## Scope Boundaries
+
+- Existing `port_definitions` data is **discarded**: one migration drops the column and adds `service_env_var`. No data-preserving backfill.
+- Multi-port support is fully removed — no adapter layer, no "ports list with a primary" intermediate shape.
+- No changes to tmux window index (stays at 9), port probe timing, or `@startup_timeout_ms`.
+- No new UI affordances beyond replacing the existing port definitions input.
+- No change to the AI session/worktree lifecycle beyond dropping the port reservation inside `run_post_worktree_setup/3`.
+- AI conversation context (`build_service_section/1` in `lib/destila/ai/conversation.ex`) is updated mechanically to use the new shape; no prompt-engineering changes beyond that.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Schema + validator:** `lib/destila/projects/project.ex` — `port_definitions` array, `@port_definition_pattern`, `@denied_env_vars`, `validate_port_definitions/1`. Existing regex/denylist and `Ecto.Changeset.validate_format/3` + `validate_change/3` patterns are reused for the scalar field.
+- **ServiceManager:** `lib/destila/services/service_manager.ex` — `do_start/2`, `do_stop/2`, `do_restart/2`, `do_status/2`, `reserve_ports/1`, `build_service_command/3`, `cleanup/1`. The existing `cond`-based precondition pattern at the top of `do_start/2` is the template for adding the new `service_env_var` precondition.
+- **Worktree setup:** `lib/destila/workers/prepare_workflow_session.ex` — `run_post_worktree_setup/3`, `build_setup_command/2`. Keep the rescue-and-log pattern that makes setup failures non-blocking.
+- **MCP tool:** `lib/destila/ai/tools.ex` — `tool :service` block and its `execute/2`. JSON response is produced by `Jason.encode!(state)`; switching the returned map is sufficient.
+- **AI conversation context:** `lib/destila/ai/conversation.ex:254-268` — `build_service_section/1` currently iterates the `ports` map; update to read scalar `port` and the project's `service_env_var`.
+- **Sidebar:** `lib/destila_web/live/workflow_runner_live.ex:827-935` for rendering; `service_url/2` at lines 1288-1299 for URL derivation. The existing `cond`/pattern-match approach on `service_state` is preserved.
+- **Form:** `lib/destila_web/live/project_form_live.ex` — replace array add/remove/update handlers with a single `<.input>` bound to the form, following the Phoenix v1.8 form conventions already used for `name`, `run_command`, and `setup_command`.
+- **Feature/test pairing:** `@tag feature: "...", scenario: "..."` annotations are already the project's convention (see `test/destila_web/live/service_status_sidebar_live_test.exs`, `test/destila_web/live/projects_live_test.exs`).
+
+### Institutional Learnings
+
+- No direct `docs/solutions/` hit for this refactor. Adjacent prior work lives at `docs/plans/2026-04-14-001-feat-project-service-management-plan.md` (introduced the current port_definitions model) and `docs/plans/2026-04-16-002-feat-project-setup-command-plan.md` (introduced the `setup_command; run_command` chaining). Both are the conventions to continue matching.
+
+### External References
+
+- None required: this is a bounded refactor of in-repo primitives with no new framework surface. Phoenix LiveView form conventions, Ecto changeset validators, and Oban worker patterns already in-repo are sufficient.
+
+## Key Technical Decisions
+
+- **Single migration, no backfill.** Per the prompt, drop `port_definitions` and add `service_env_var` in one migration; existing values are discarded. Rationale: product is pre-production; multi-port data is not worth migrating to a single value.
+- **Empty string ≡ nil.** The form may submit `""`. Normalize blank strings to `nil` at the changeset boundary (same pattern already used for `run_command`, `setup_command` in `project_form_live.ex`'s `non_blank/1`). Rationale: keeps the "is a webservice?" predicate a simple `present?` check across readers.
+- **Preconditions computed in one place.** A private `Project.webservice?/1` predicate (non-exhaustive public API — just a private helper on the struct or a `Projects` context helper) is defined once and reused by `ServiceManager`, the sidebar, the MCP tool, and `build_service_section/1`. Rationale: one source of truth for "both `run_command` and `service_env_var` are present and non-blank".
+- **`service_state["port"]` is scalar int or absent.** Not `nil` in the map — absent. Rationale: the MCP tool's JSON must omit `url` when there is no port; the cleanest way is to never put `port` in the state map when there isn't one (e.g., after a `do_stop/2` that never ran before, or a legacy `ports`-shaped record on read).
+- **Tolerate legacy `%{"ports" => _}` service_state on read.** Every reader (sidebar URL, status checks, MCP tool, AI conversation context) matches on `state["port"]`/missing and ignores an unknown `state["ports"]` key. The next start/restart rewrites it. Rationale: avoids a separate data migration without keeping a compat branch forever.
+- **Error message copy on precondition failure.** `do_start`/`do_restart` return `{:error, "Project is not configured as a webservice (requires run_command and service_env_var)"}` when either is missing. The MCP tool propagates this through its existing `"Service error: #{reason}"` path. Rationale: one message covers both missing-command and missing-env-var cases, matching how the current "no run command" error is surfaced.
+- **Post-worktree setup uses a plain command.** `PrepareWorkflowSession.run_post_worktree_setup/3` drops the `ServiceManager.reserve_ports/1` call and sends `setup_command` verbatim to tmux (no env exports). Rationale: per the prompt, this path is not a service start and should not touch ports.
+- **Form field type is plain text input.** Reuse `<.input type="text">` with the existing form; do not invent a new component. Rationale: matches the other project fields and avoids bespoke UI for a one-line string.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should the DB column be dropped in the same migration that adds `service_env_var`?** Yes — per the prompt, one migration, no data preservation.
+- **How do we express the `url` absence in JSON?** Omit the key from the map before `Jason.encode!/1`. `Jason` does not emit missing keys; this yields `{"status":"stopped", ...}` without a `url` field.
+- **Does post-worktree setup need any env var exported?** No — the prompt is explicit. Plain command only.
+- **Where does the `webservice?` check live?** As a private helper. It is *not* exposed on the schema struct as a virtual field; it is a derived predicate used by a handful of callers. Adding a `Projects.webservice?/1` helper in the `Destila.Projects` context and importing at call sites is acceptable; keeping it inline as a local `if` is also acceptable. Implementation unit allows either — see Unit 2 Approach.
+- **What happens to `service_state` on a project that loses webservice configuration later (env var cleared on an existing project)?** Next `do_start` returns the precondition error and the session's existing `service_state` is unchanged (possibly "running" for a stale process). The sidebar will hide the item entirely once the project no longer qualifies, so the stale state is not user-visible. Acceptable.
+
+### Deferred to Implementation
+
+- Final method/helper names (e.g., `Projects.webservice?/1` vs. a private `service_env_var_present?/1` helper in each module).
+- Exact tmux `send_keys` string after the `build_service_command/3` refactor — prose shows the shape, but the final concatenation is decided when writing the code.
+- Whether the `:service_env_var` cast uses `validate_format` + `validate_change` (matching the current two-step pattern) or a single `validate_change` that runs both checks. Either is fine.
+- Exact wording of the MCP tool description update beyond "requires the project to be configured as a webservice (run command + service env var)".
+
+## High-Level Technical Design
+
+> *This illustrates the intended shape and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+**Service lifecycle state transitions (new shape):**
+
+```
+┌──────────────┐   start/restart   ┌───────────┐   ports respond   ┌─────────┐
+│  stopped /   │ ────────────────▶ │  starting │ ────────────────▶ │ running │
+│     nil      │   (reserve 1      │           │                   │         │
+│              │    port, export   └───────────┘                   └─────────┘
+│              │    ENV=port)           │                                │
+│              │                        │ timeout / stop                 │ stop
+│              │◀───────────────────────┴────────────────────────────────┘
+└──────────────┘
+
+service_state (after refactor):
+  %{
+    "status"          => "starting" | "running" | "stopped",
+    "port"            => 4712,                     # omitted when no port reserved
+    "run_command"     => "mix phx.server",
+    "setup_command"   => "mix deps.get"            # may be nil
+  }
+```
+
+**MCP tool JSON contract:**
+
+```
+  running   →  {"status":"running","url":"http://localhost:4712","run_command":"...","setup_command":"..."}
+  stopped   →  {"status":"stopped","run_command":"...","setup_command":"..."}              # no url key
+  starting  →  {"status":"starting","url":"http://localhost:4712","run_command":"...","setup_command":"..."}
+  precond   →  "Service error: Project is not configured as a webservice (requires run_command and service_env_var)"
+```
+
+**Webservice predicate (one source of truth):**
+
+```
+  webservice?(project) :=
+      present?(project.run_command) AND present?(project.service_env_var)
+```
+
+**Post-worktree setup path (setup only, no port):**
+
+```
+  PrepareWorkflowSession.perform
+    └─ run_post_worktree_setup(project, worktree, ws)
+         └─ if project.setup_command present:
+              send_keys(service_window, project.setup_command)       # no exports
+              # failures rescued + logged; worktree still marked ready
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Schema + migration for `service_env_var`**
+
+**Goal:** Replace `port_definitions` with `service_env_var` on the Project schema and database.
+
+**Requirements:** R1, R2, R10
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `priv/repo/migrations/YYYYMMDDHHMMSS_replace_port_definitions_with_service_env_var.exs`
+- Modify: `lib/destila/projects/project.ex`
+- Test: `test/destila/projects/project_test.exs`
+
+**Approach:**
+- Single migration: `alter table(:projects) do remove :port_definitions; add :service_env_var, :string end`. No backfill, no default.
+- Schema: drop `field(:port_definitions, {:array, :string}, default: [])`; add `field(:service_env_var, :string)`.
+- Changeset: cast `:service_env_var`; replace `validate_port_definitions/1` with a `validate_service_env_var/1` that:
+  - Short-circuits when the value is `nil` or blank (project is simply not a webservice).
+  - Otherwise applies the existing `@port_definition_pattern` and `@denied_env_vars` checks.
+  - Keep the `@port_definition_pattern` and `@denied_env_vars` module attributes; rename if it reads more clearly (e.g., `@env_var_pattern`), but mechanical rename only.
+- Normalize blank strings to `nil` in the form handler (Unit 5) so the changeset predicate stays simple.
+
+**Patterns to follow:**
+- The existing `validate_required`, `validate_change` pipeline in `lib/destila/projects/project.ex`.
+- Migration style used in `priv/repo/migrations/20260414000000_add_service_fields.exs` and `20260416000000_add_setup_command_to_projects.exs` (plain `alter table`).
+
+**Test scenarios:**
+- Happy path: changeset accepts a valid uppercase identifier (`"PORT"`, `"API_PORT"`, `"MY_SERVICE_PORT"`) → `changeset.valid?` is true and `get_change(changeset, :service_env_var)` returns the value.
+- Happy path: changeset accepts `nil` / omitted `service_env_var` → valid.
+- Edge case: changeset normalizes empty string to nil (or accepts it as valid non-webservice state — specific behavior depends on Unit 5 normalization, but the changeset itself must not emit a format error on `""`).
+- Error path: lowercase value (`"port"`) → error message matches the existing `validate_port_definitions` wording adapted to the scalar field.
+- Error path: starts with digit (`"1PORT"`) → format error on `:service_env_var`.
+- Error path: contains special char (`"PORT-1"`, `"PORT.1"`) → format error.
+- Error path: each reserved name in `@denied_env_vars` → reserved-name error (parameterize or enumerate at minimum `PATH`, `HOME`, `LD_PRELOAD`).
+- Edge case: underscores in the middle and multi-digit suffixes allowed (`"SERVICE_PORT_2"`).
+- Delete: existing tests referencing `port_definitions` in this file are removed or rewritten to point at `service_env_var`.
+
+**Verification:**
+- `mix ecto.migrate` applies cleanly on a dev DB; `mix ecto.rollback` is not a requirement (fresh-data refactor).
+- `mix test test/destila/projects/project_test.exs` passes.
+
+---
+
+- [ ] **Unit 2: `ServiceManager` lifecycle — scalar port and webservice precondition**
+
+**Goal:** Make `start`/`restart` require both `run_command` and `service_env_var`, reserve a single ephemeral port, export it under the configured env var, and persist scalar `port` in `service_state`.
+
+**Requirements:** R3, R5, R9
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `lib/destila/services/service_manager.ex`
+- Test: `test/destila/services/service_manager_test.exs`
+
+**Approach:**
+- Update `do_start/2`'s `cond` to additionally check `blank?(project.service_env_var)` and return `{:error, "Project is not configured as a webservice (requires run_command and service_env_var)"}` when either precondition fails. Fold the existing "Project has no run command configured" branch into the single webservice precondition message (simpler UX; matches the prompt's "not configured as a webservice" wording).
+- Replace `reserve_ports/1`'s map-building with a scalar helper `reserve_port/0` returning `integer` (or inline the 4-line `gen_tcp.listen → :inet.port → close` block in `do_start`). Keep it as a `@doc false` testable function for the new unit tests.
+- Rework `build_service_command/3` into `build_service_command(setup_command, run_command, env_var, port)`:
+  - `env_export = "export #{env_var}=#{port}"`
+  - `body = if blank?(setup_command), do: run_command, else: "#{setup_command}; #{run_command}"`
+  - Returns `"#{env_export} && #{body}"`.
+- `starting_state` becomes `%{"status" => "starting", "port" => port, "run_command" => ..., "setup_command" => ...}`.
+- `wait_for_ports/2` loses its list — replace with `wait_for_port(port, @startup_timeout_ms)`.
+- `do_stop/2`'s preserved state becomes `%{"status" => "stopped", "port" => (ws.service_state || %{})["port"]}`. If no prior port, omit `"port"` entirely (use `Map.put_new_lazy` or conditional `Map.put`). This ensures cleanliness for fresh stops and graceful tolerance of legacy `%{"ports" => _}` state (the `"port"` key is absent and so is omitted, matching R9).
+- `do_status/2` logic is unchanged structurally; it still flips `"running"` → `"stopped"` when the tmux window is gone.
+- `cleanup/1` unchanged (still writes `service_state: nil`).
+
+**Patterns to follow:**
+- Existing `cond` precondition block at the top of `do_start/2`.
+- Existing log-and-return pattern on startup timeout.
+- `Workflows.update_workflow_session/2` shape already used for state persistence.
+
+**Test scenarios:**
+- Happy path: `build_service_command/4` with `setup_command = nil`, `run_command = "run"`, env var `"PORT"`, port `4712` → `"export PORT=4712 && run"`.
+- Happy path: with `setup_command = "setup"` → `"export PORT=4712 && setup; run"`.
+- Edge case: `setup_command = ""` treated as blank → `"export PORT=4712 && run"` (no `;`).
+- Error path (integration): `do_start` on a session whose project has `run_command` but `service_env_var = nil` → returns `{:error, "Project is not configured as a webservice" <> _}`; service_state is unchanged.
+- Error path: same, with `service_env_var` set but `run_command = nil` → same error.
+- Error path: no project linked → existing "No project linked to this session" error preserved.
+- Integration: `do_start` success path writes `service_state` with scalar `"port"` integer, `"status" => "running"`, and includes `run_command`/`setup_command` fields.
+- Edge case: `do_stop` on a session whose prior `service_state` was the legacy `%{"ports" => %{...}}` shape → returns `{:ok, state}` with `status: "stopped"` and **no** `"port"` key in the map; does not raise.
+- Edge case: `do_stop` on nil `service_state` → `{:ok, %{"status" => "stopped"}}` (no `"port"` key).
+
+**Verification:**
+- `mix test test/destila/services/service_manager_test.exs` passes.
+- No references to `port_definitions` or a `ports` map remain in `lib/destila/services/service_manager.ex`.
+
+---
+
+- [ ] **Unit 3: `PrepareWorkflowSession` — setup without port allocation**
+
+**Goal:** Always run `setup_command` (when present) after worktree creation as a plain command. Do not reserve ports or export env vars in this path.
+
+**Requirements:** R4
+
+**Dependencies:** Unit 2 (so the removed `reserve_ports/1` call is not a dangling reference).
+
+**Files:**
+- Modify: `lib/destila/workers/prepare_workflow_session.ex`
+- Test: `test/destila/workers/prepare_workflow_session_test.exs`
+
+**Approach:**
+- Remove the `ServiceManager.reserve_ports(project.port_definitions)` call.
+- Remove `build_setup_command/2` entirely (or reduce it to a no-op passthrough; prefer removal).
+- `send_keys(target, project.setup_command)` directly.
+- Keep the surrounding `try/rescue` with `Logger.warning` and the `:ok` return so worktree readiness is not blocked on failure.
+- Behavior still gated on `if blank?(project.setup_command), do: :ok, else: ...`.
+- `run_post_worktree_setup(nil, _, _)` guard clause unchanged.
+
+**Patterns to follow:**
+- Existing guard-clause + try/rescue shape in the same module.
+
+**Test scenarios:**
+- Happy path: project with a setup command and no env var set → `send_keys` is called with exactly the `setup_command` string (no `export FOO=...` prefix).
+- Happy path: project with a setup command and a `service_env_var` set → `send_keys` is still called with exactly `setup_command` (the prompt is explicit: no env var exported in the post-worktree path).
+- Edge case: project with `setup_command = nil` or `""` → `send_keys` is not called.
+- Edge case: project with no setup command but with `run_command` + `service_env_var` → `send_keys` is not called (no service started here; setup is the only trigger).
+- Error path: tmux raises — worker logs and returns `:ok`; the workflow session is still marked worktree-ready (reassert the existing behavior).
+- Edge case: `project == nil` → guard clause returns `:ok` without tmux interaction.
+
+**Verification:**
+- `mix test test/destila/workers/prepare_workflow_session_test.exs` passes.
+
+---
+
+- [ ] **Unit 4: MCP `service` tool — scalar `url` in JSON output**
+
+**Goal:** Update the MCP tool's JSON response shape to use a single `url` and update the tool description.
+
+**Requirements:** R6, R9
+
+**Dependencies:** Unit 2.
+
+**Files:**
+- Modify: `lib/destila/ai/tools.ex`
+- Modify: `lib/destila/ai/conversation.ex` (`build_service_section/1`)
+- Test: any tests exercising the MCP service tool output (search under `test/destila/ai/` and update or add as needed).
+
+**Approach:**
+- In `tool :service`:
+  - Update the tool `description/1` to include the webservice precondition: e.g., *"Manage the project's development service lifecycle (start/stop/restart/status). Requires the project to be configured as a webservice (a run command and a service env var name)."*
+  - In `execute/2`, after `ServiceManager.execute/3` returns `{:ok, state}`, transform the map before encoding:
+    - Base: `%{"status" => state["status"], "run_command" => state["run_command"], "setup_command" => state["setup_command"]}`.
+    - If `state["port"]` is an integer, add `"url" => "http://localhost:#{port}"`.
+    - Never emit `"http://localhost:"` with no port — controlled by the conditional `Map.put`.
+    - Do not leak internal keys like `"port"` into the JSON output; `url` is the external contract.
+- Update `lib/destila/ai/conversation.ex:254-268` (`build_service_section/1`) to read scalar `state["port"]` instead of iterating `state["ports"]`. When no port is present and status is not `nil`, render `"# Service Status\n\nThe project service is currently #{status}."` with no URL line. When a port is present, render `"\nURL: http://localhost:<port>"` (consistent with the external contract). Tolerate unknown legacy shapes by treating missing `"port"` as "no URL".
+- Also update the top-of-file prompt/documentation block (the block under `# Tools\n\n## Service Management`) if it references "port mappings" — swap to "and service URL when running".
+
+**Patterns to follow:**
+- Existing `try/rescue` in `execute/2` that wraps errors as `"Service error: ..."`.
+- Existing `Jason.encode!/1` pattern — no change to encoding strategy, only to the map.
+
+**Test scenarios:**
+- Happy path (unit-level): given a state map with `"status" => "running", "port" => 4712, "run_command" => "...", "setup_command" => "..."`, the encoded JSON contains `"url":"http://localhost:4712"` and `"status":"running"`.
+- Happy path (stopped): state map with `"status" => "stopped"` and no `"port"` key → encoded JSON has `"status":"stopped"` and does **not** contain `"url"`.
+- Happy path (starting): state map with `"status" => "starting", "port" => 4712` → `"url":"http://localhost:4712"`.
+- Error path: when `ServiceManager.execute/3` returns `{:error, "Project is not configured as a webservice ..."}`, the tool returns `"Service error: Project is not configured as a webservice ..."`.
+- Edge case (legacy state): a legacy state shape like `%{"status" => "running", "ports" => %{"PORT" => 4712}}` fed to the JSON transform is treated as no-port → JSON contains no `"url"`. (This is a unit-level transform test; realistically the next start rewrites the state.)
+- Conversation context: `build_service_section/1` with new shape renders the `URL:` line with scalar port; with missing `"port"` renders no URL line; nil state returns nil.
+
+**Verification:**
+- `mix test` for tool and conversation modules passes.
+- Grep: no remaining `state["ports"]` reads under `lib/destila/ai/`.
+
+---
+
+- [ ] **Unit 5: Project form UI — single `service_env_var` input**
+
+**Goal:** Replace the port-definitions list UI with a single optional text input bound to `service_env_var`, surfacing validation errors on that field.
+
+**Requirements:** R8, R10
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `lib/destila_web/live/project_form_live.ex`
+- Test: `test/destila_web/live/projects_live_test.exs`
+
+**Approach:**
+- Remove the `port_definitions` assign, `add_port` / `remove_port` / `update_port` handlers, and the `params |> filter("port_def_")` logic in `handle_event("validate", ...)`.
+- Use a single `<.input field={@form[:service_env_var]} type="text" label="Service env var name" placeholder="PORT" />` in the template, following the existing pattern for `run_command` and `setup_command`.
+- In `handle_event("save", ...)`, include `service_env_var: non_blank(params["service_env_var"])` in the `attrs` map so blank strings become `nil`.
+- In `handle_event("validate", ...)`, drop the port-filter logic; just rebuild the form from params and assign.
+- Remove the "Port definitions" section label, add-button, and per-row delete-button from the template.
+- Add unique DOM IDs consistent with project form conventions (e.g., `id="project-form"` already likely exists; ensure the new input has a stable label for test selectors).
+
+**Patterns to follow:**
+- `<.input field={@form[:run_command]} ...>` already in the same template.
+- `non_blank/1` helper already present for `setup_command` / `run_command`.
+
+**Test scenarios:**
+- Happy path: user fills in name, git URL, run command, and `service_env_var = "PORT"` → project persists with `service_env_var == "PORT"`.
+- Happy path: user fills in name, git URL, run command, leaves `service_env_var` blank → project persists with `service_env_var == nil` (not `""`).
+- Error path: user submits `service_env_var = "invalid-name"` → validation error appears on the `service_env_var` field (tested via `has_element?(view, "...service_env_var...error...")` or by matching the error copy rendered under the input). The form should not submit.
+- Error path: user submits `service_env_var = "PATH"` → reserved-name validation error on the field.
+- Edit: opening an existing project's form prefills `service_env_var`.
+- UI: no "Port definitions" label, no add-port button, no per-row remove controls exist in the rendered HTML (regression guard against leftover code paths).
+
+**Verification:**
+- `mix test test/destila_web/live/projects_live_test.exs` passes.
+- Hitting the project form in the running dev server shows a single text input for Service env var name; creating and editing a project works end-to-end.
+
+---
+
+- [ ] **Unit 6: Service sidebar — visibility gate + scalar-port link**
+
+**Goal:** Render the service sidebar item only when the project is a webservice. Link to `http://localhost:<port>` (new tab) when running; no link otherwise. Hide entirely when the project has no run command, no env var, or the session has no project.
+
+**Requirements:** R7, R9
+
+**Dependencies:** Units 1, 2.
+
+**Files:**
+- Modify: `lib/destila_web/live/workflow_runner_live.ex`
+- Test: `test/destila_web/live/service_status_sidebar_live_test.exs`
+
+**Approach:**
+- Visibility: introduce a single boolean derived in the template or as a helper, e.g., `webservice? = @project && present?(@project.run_command) && present?(@project.service_env_var)`. Wrap the entire service sidebar block in `<%= if webservice? do %> ... <% end %>`. Remove the `"disabled"` fallback branch currently at lines 917-934 (service item is simply absent for non-webservice projects).
+- `service_url/2`: rewrite to match the new shape.
+  - `service_url(%{service_env_var: env_var}, %{"status" => "running", "port" => port}) when is_integer(port) and is_binary(env_var) -> "http://localhost:#{port}"`
+  - `service_url(_, _) -> nil`
+  - Note: `env_var` is matched but not used in the URL; it's the gate for "this is a webservice" at the readerside (defensive; the outer visibility gate already ensures this). Alternatively, drop the pattern-match on project entirely once the visibility gate is trusted.
+- Icon logic (green for running/starting, muted for stopped/nil) is preserved but simplified because the fallback "no run command" branch is gone.
+- Link renders with `target="_blank"` and `rel="noopener noreferrer"` (already convention) when `service_url/2` returns a URL; renders as non-link span otherwise (icon + label), preserving current styling.
+- Delete the old "Running service without available port shows green icon" special-case — the prompt explicitly removes it.
+
+**Patterns to follow:**
+- The existing sidebar item markup for link vs. non-link rendering (lines 858-892 in the current file).
+- Existing `service_status` / `service_running?` derivation at lines 827-831.
+
+**Test scenarios:**
+- Happy path (visible webservice): project has `run_command` and `service_env_var = "PORT"` → service item renders in the sidebar.
+- Hidden: project has `run_command` but no `service_env_var` → no service item element appears.
+- Hidden: project has `service_env_var` but no `run_command` → no service item element.
+- Hidden: session has no project → no service item element.
+- Icon: service running → icon has the green class (current assertion on class name preserved).
+- Icon: service stopped → icon has the muted/gray class.
+- Icon: service_state is nil (but project is a webservice) → icon has muted class and item is not clickable.
+- Link: running with integer `port` in service_state → `<a>` with `href="http://localhost:<port>"` and `target="_blank"`.
+- No link: stopped state → item renders but is not an `<a>` (assert via selector).
+- No link: nil service_state → not clickable.
+- Real-time update: broadcasting a state change from stopped to running (via the existing PubSub path) flips the item to clickable with the correct port URL.
+- Legacy tolerance: service_state `%{"status" => "running", "ports" => %{"PORT" => 4712}}` (missing `"port"`) → renders icon as running but item is not clickable (no URL). This is the R9 guarantee at the reader.
+
+**Verification:**
+- `mix test test/destila_web/live/service_status_sidebar_live_test.exs` passes.
+- Manual: visit a session whose project has both fields set and start the service; click the link in a new tab and confirm the URL.
+
+---
+
+- [ ] **Unit 7: Gherkin feature updates + tag sync**
+
+**Goal:** Replace the listed scenarios in the three feature files per the user's prompt, and update existing `@tag` annotations on tests to match.
+
+**Requirements:** R10
+
+**Dependencies:** Units 1–6 (so the referenced behavior is implemented before the feature file claims it).
+
+**Files:**
+- Modify: `features/project_management.feature`
+- Modify: `features/service_status_sidebar.feature`
+- Modify: `features/service_setup_command.feature`
+- Modify (tag sync): `test/destila/projects/project_test.exs`, `test/destila/services/service_manager_test.exs`, `test/destila/workers/prepare_workflow_session_test.exs`, `test/destila_web/live/projects_live_test.exs`, `test/destila_web/live/service_status_sidebar_live_test.exs`
+
+**Approach:**
+- `features/project_management.feature`: remove the three port-definition scenarios (lines 80-86, 88-95, 97-103 in the current file). Add the three scenarios from the prompt: "Create a project with run command and a service env var", "Create a project without a service env var name", "Service env var requires a valid environment variable name". Keep the feature-description paragraph updated to mention "a service env var name" instead of "port definitions". Preserve the setup-command scenarios and all pre-port scenarios unchanged.
+- `features/service_status_sidebar.feature`: replace the feature description with the one from the prompt. Replace scenarios lines 27-32, 50-55, and 57-62 per the prompt. Remove the "Running service without available port shows green icon" scenario. Keep or adjust "Service item visible when project has run_command" to the new "Service item visible when project is a webservice" wording; drop "Service item disabled when no run_command configured" and replace with the two "Service item hidden when..." scenarios from the prompt. Preserve the "Service item hidden when session has no project" scenario with the wording from the prompt.
+- `features/service_setup_command.feature`: update the feature description paragraph with the new one from the prompt. Remove the "Setup sees the same port environment variables as the run command" scenario (lines 28-31). Add the two new scenarios: "Post-worktree setup runs without allocating a port" and "Start/restart allocates a port and exports the service env var for both setup and run". Keep the other scenarios; update any that reference "ports" (the "Empty setup_command behaves like nil" scenario is unchanged since it doesn't reference ports).
+- Tag sync: scan all affected test files for `@tag feature:`/`@tag scenario:` pairs, update or remove references to the deleted scenarios, and add tags on new tests introduced in Units 1, 2, 3, 5, 6. Every scenario in the updated feature files should have ≥1 linked test; every test `@tag` should point at an existing scenario.
+
+**Patterns to follow:**
+- Existing scenario wording style in the three feature files.
+- `@tag feature: "Service Status Sidebar", scenario: "..."` pattern already used in `test/destila_web/live/service_status_sidebar_live_test.exs`.
+
+**Test scenarios:**
+- Verify `mix test --only feature:service_status_sidebar` runs a non-empty set and all pass.
+- Verify `mix test --only feature:service_setup_command` runs a non-empty set and all pass.
+- Verify `mix test --only feature:project_management` runs a non-empty set and all pass.
+- Grep for the deleted scenario titles in test files: no stale `@tag scenario:` references should remain.
+- Grep for `port_definitions` and `"ports"` across `features/` and `test/`: no matches (Test expectation: grep assertion as part of Unit 8's precommit pass).
+
+**Verification:**
+- `grep -r "port_definitions\|\"ports\"" features test lib` returns no results (other than any intentionally legacy-tolerance test in Unit 4).
+
+---
+
+- [ ] **Unit 8: Final precommit pass**
+
+**Goal:** Run `mix precommit` and address any residual warnings, formatting, or test failures before finishing.
+
+**Requirements:** R10
+
+**Dependencies:** Units 1–7.
+
+**Files:**
+- N/A (no code changes expected; only follow-ups triggered by the command).
+
+**Approach:**
+- Run `mix precommit` (which is `["compile --warnings-as-errors", "deps.unlock --unused", "format", "test"]` per `mix.exs`).
+- Address any warnings-as-errors (most likely: unused aliases/variables if a handler was removed).
+- Resolve any test failures surfaced by the cross-cutting changes.
+- Re-run until clean.
+
+**Test expectation:** none — this unit runs the existing suite and formatter; it does not introduce new tests.
+
+**Verification:**
+- `mix precommit` exits 0.
+
+## System-Wide Impact
+
+- **Interaction graph:**
+  - `Destila.Projects.Project` → `ServiceManager` (start/stop/restart), `PrepareWorkflowSession` (post-worktree), `WorkflowRunnerLive` (sidebar gate), `ProjectFormLive` (form).
+  - `ServiceManager` → `Workflows.update_workflow_session/2` (persists `service_state`), `Tmux.send_keys/2` (sends the composed shell string).
+  - `AI.Tools.:service` → `ServiceManager.execute/3` (action dispatch) → returns JSON to the AI.
+  - `AI.Conversation.build_service_section/1` → reads `service_state` for context injection into the AI prompt.
+  - `WorkflowRunnerLive` → subscribes to PubSub updates keyed by session id; re-renders on `service_state` change.
+- **Error propagation:**
+  - Precondition failure in `do_start`/`do_restart` returns `{:error, reason}` → the MCP tool wraps as `"Service error: <reason>"` → surfaces to the AI verbatim.
+  - Tmux failures remain wrapped in `try/rescue` blocks in the worker; worktree readiness is not blocked.
+  - Startup port-timeout path is unchanged: `do_stop` is invoked, the stored state becomes `"stopped"` (with `"port"` omitted), and the error is returned up the stack.
+- **State lifecycle risks:**
+  - Legacy `%{"ports" => %{...}}` `service_state` records exist on disk after deploy. Every reader must tolerate a missing `"port"` key and treat it as "no URL". Readers covered: `WorkflowRunnerLive.service_url/2`, `AI.Tools` JSON transform, `AI.Conversation.build_service_section/1`. A fresh `do_start` rewrites the record cleanly.
+  - `do_stop` must not crash on legacy shape: handled by reading `(ws.service_state || %{})["port"]` (absent on legacy records → not added to the output map).
+- **API surface parity:** The MCP tool's JSON is a public contract with the AI. Changing `ports` → `url` is a breaking change for any cached AI behavior, but the AI consumes the tool fresh each turn; no durable contract exists beyond the in-prompt description text, which is updated in the same unit.
+- **Integration coverage:** End-to-end path (form submit → changeset → DB → `do_start` → tmux → sidebar link) needs cross-layer coverage: the projects LiveView test asserts persistence; the ServiceManager test asserts state shape; the sidebar test asserts reader behavior. Together they cover the full flow.
+- **Unchanged invariants:**
+  - Tmux service window index remains 9.
+  - `@startup_timeout_ms` (60s) and port-probe cadence unchanged.
+  - `cleanup/1` still clears `service_state` to nil on archive.
+  - Session archiving, worktree creation ordering, and AI session lifecycle unchanged.
+  - `setup_command; run_command` semicolon-chaining preserved so setup failure does not block run.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Deployed instances have live `service_state` in the old `%{"ports" => _}` shape when this lands. | Every reader tolerates missing `"port"` and treats it as no-URL. Next `do_start`/`do_restart` rewrites to new shape. No backfill needed. |
+| Dropping `port_definitions` loses configured multi-port projects. | Per prompt: acceptable. Single-migration, no backfill. Call out in commit message for visibility. |
+| Removed event handlers (`add_port`, `remove_port`, `update_port`) leave orphan `phx-click` references in another template. | Grep for `"add_port"`, `"remove_port"`, `"update_port"` across `lib/destila_web/` after Unit 5; remove any orphan references. Part of Unit 8 verification. |
+| Feature-test `@tag` annotations drift out of sync with the renamed scenarios. | Unit 7 explicitly includes tag sync. Running `mix test --only feature:<name>` validates coverage per feature. |
+| Webservice predicate duplicated across readers diverges over time. | Key Technical Decisions mandate a single predicate (private helper or `Projects.webservice?/1`). Code review should flag duplications. |
+| The MCP tool prompt doc block and the tool's `description/1` drift out of sync. | Unit 4 updates both in the same change. |
+
+## Documentation / Operational Notes
+
+- No separate docs update required — the in-repo feature files are the user-facing specification.
+- The MCP tool's inline description text (shown to the AI) must be updated alongside the code in Unit 4.
+- No rollout flags or monitoring changes: the change is synchronous at deploy. On first load post-deploy, any session with legacy `service_state` will show the service icon (if the project qualifies as a webservice) with no clickable link until the next start.
+
+## Sources & References
+
+- Origin: user prompt (no upstream requirements document; planning proceeded from the prompt directly).
+- Related prior plans:
+  - `docs/plans/2026-04-14-001-feat-project-service-management-plan.md`
+  - `docs/plans/2026-04-14-003-feat-service-status-sidebar-plan.md`
+  - `docs/plans/2026-04-16-002-feat-project-setup-command-plan.md`
+- Core source files:
+  - `lib/destila/projects/project.ex`
+  - `lib/destila/services/service_manager.ex`
+  - `lib/destila/workers/prepare_workflow_session.ex`
+  - `lib/destila/ai/tools.ex`
+  - `lib/destila/ai/conversation.ex`
+  - `lib/destila_web/live/workflow_runner_live.ex`
+  - `lib/destila_web/live/project_form_live.ex`
+- Feature files:
+  - `features/project_management.feature`
+  - `features/service_status_sidebar.feature`
+  - `features/service_setup_command.feature`
+- Tests:
+  - `test/destila/projects/project_test.exs`
+  - `test/destila/services/service_manager_test.exs`
+  - `test/destila/workers/prepare_workflow_session_test.exs`
+  - `test/destila_web/live/projects_live_test.exs`
+  - `test/destila_web/live/service_status_sidebar_live_test.exs`

--- a/features/project_management.feature
+++ b/features/project_management.feature
@@ -1,9 +1,10 @@
 Feature: Project Management
   Users can manage projects independently from sessions. A project has a name,
   an optional git repository URL, an optional local folder path, an optional
-  setup command, an optional run command, and optional port definitions. At
-  least one of git repository URL or local folder must be provided. Projects
-  can be shared across multiple sessions.
+  setup command, an optional run command, and an optional service env var name.
+  At least one of git repository URL or local folder must be provided. When a
+  project has both a run command and a service env var name it is treated as a
+  webservice. Projects can be shared across multiple sessions.
 
   Scenario: View list of projects
     Given there are existing projects
@@ -77,13 +78,21 @@ Feature: Project Management
     And I click delete on the project
     Then I should see a message indicating the project cannot be deleted while linked to sessions
 
-  Scenario: Create a project with run command and port definitions
+  Scenario: Create a project with run command and a service env var
     When I navigate to the projects page
     And I click "New Project"
-    When I fill in the name, a git repository URL, a run command, and port definitions
+    When I fill in the name, a git repository URL, a run command, and a service env var name
     And I click "Create"
     Then the project should be created
-    And I should see the run command displayed in the project card
+    And the project should be configured as a webservice
+
+  Scenario: Create a project without a service env var name
+    When I navigate to the projects page
+    And I click "New Project"
+    When I fill in the name, a git repository URL, and a run command and leave the service env var blank
+    And I click "Create"
+    Then the project should be created
+    And the project should not be configured as a webservice
 
   Scenario: Edit a project's run configuration
     Given there is an existing project with a run command
@@ -94,13 +103,13 @@ Feature: Project Management
     And I click "Save"
     Then the project should be updated with the new run command
 
-  Scenario: Port definitions require a valid environment variable name
+  Scenario: Service env var requires a valid environment variable name
     When I navigate to the projects page
     And I click "New Project"
     When I fill in the name and a git repository URL
-    And I add a port definition with an invalid name
+    And I enter an invalid service env var name
     And I click "Create"
-    Then I should see a validation error for the port definition
+    Then I should see a validation error for the service env var
 
   Scenario: Create a project with a setup command
     When I navigate to the projects page

--- a/features/service_setup_command.feature
+++ b/features/service_setup_command.feature
@@ -1,11 +1,12 @@
 Feature: Service Setup Command
   A project may declare an optional setup command that runs inside the tmux
   service window (index 9) in two situations: once automatically right after
-  the session's worktree is created, and again before every run command on
-  service start or restart. Setup and run are delivered in a single
-  send_keys call chained with ";" so a non-zero exit from setup still lets
-  the run command proceed. Setup output stays inside the tmux window and is
-  not surfaced in the web UI.
+  the session's worktree is created (without any port allocated or env var
+  exported), and again before every run command on service start or restart
+  (with the project's service env var exported for both setup and run). Setup
+  and run are delivered in a single send_keys call chained with ";" so a
+  non-zero exit from setup still lets the run command proceed. Setup output
+  stays inside the tmux window and is not surfaced in the web UI.
 
   Scenario: Worktree creation triggers setup command in the tmux service window
     Given a project with a setup command
@@ -25,10 +26,17 @@ Feature: Service Setup Command
     Then the composed shell string chains setup and run with ";"
     And the run command executes even if setup exits non-zero
 
-  Scenario: Setup sees the same port environment variables as the run command
-    Given a project with a setup command and port definitions
-    When the setup command is delivered to tmux
-    Then the port environment variables are exported before the setup command
+  Scenario: Post-worktree setup runs without allocating a port
+    Given a project with a setup command and a service env var
+    When a new workflow session's worktree is ready
+    Then the setup command is sent to tmux without any env export
+    And no port is reserved for the setup invocation
+
+  Scenario: Start/restart allocates a port and exports the service env var for both setup and run
+    Given a project with a setup command, a run command, and a service env var
+    When the service is started
+    Then a single ephemeral port is reserved
+    And the service env var is exported with that port before both setup and run
 
   Scenario: Empty setup_command behaves like nil
     Given a project whose setup command is an empty string

--- a/features/service_status_sidebar.feature
+++ b/features/service_status_sidebar.feature
@@ -1,18 +1,31 @@
 Feature: Service Status Sidebar
-  The workflow session sidebar displays a "Service" item that reflects whether
-  the project's development service is running or stopped, with conditional
-  link behavior that opens the service in a new browser tab when running.
+  The workflow session sidebar displays a "Service" item for projects that are
+  configured as webservices (i.e. projects with both a run command and a
+  service env var name). The item reflects whether the project's development
+  service is running or stopped, and becomes a clickable link to
+  http://localhost:<port> in a new browser tab when running. The item is
+  hidden entirely when the project is not a webservice or the session has no
+  project.
 
-  Scenario: Service item visible when project has run_command
+  Scenario: Service item visible when project is a webservice
     Given I am on a session detail page
-    And the session's project has a run_command configured
+    And the session's project has a run_command and a service_env_var configured
     Then I should see a "Service" item in the sidebar
 
-  Scenario: Service item disabled when no run_command configured
+  Scenario: Service item hidden when project has no run_command
     Given I am on a session detail page
     And the session's project has no run_command configured
-    Then I should see a disabled "Service" item in the sidebar
-    And the item should indicate the feature is not set up
+    Then no service item should appear in the sidebar
+
+  Scenario: Service item hidden when project has no service_env_var
+    Given I am on a session detail page
+    And the session's project has no service_env_var configured
+    Then no service item should appear in the sidebar
+
+  Scenario: Service item hidden when session has no project
+    Given I am on a session detail page
+    And the session has no project assigned
+    Then no service item should appear in the sidebar
 
   Scenario: Service icon is green when service is running
     Given I am on a session detail page
@@ -27,7 +40,7 @@ Feature: Service Status Sidebar
   Scenario: Running service with port is a clickable link
     Given I am on a session detail page
     And the session's service_state status is "running"
-    And the project has port_definitions and ports are assigned
+    And the session's service_state has a port assigned
     Then the service item should be a link to http://localhost:<port>
     And the link should open in a new browser tab
 
@@ -41,18 +54,6 @@ Feature: Service Status Sidebar
     And the session's service_state is nil
     Then the service item should not be a clickable link
     And the service icon should be muted/gray
-
-  Scenario: Service item hidden when session has no project
-    Given I am on a session detail page
-    And the session has no project assigned
-    Then no service item should appear in the sidebar
-
-  Scenario: Running service without available port shows green icon
-    Given I am on a session detail page
-    And the session's service_state status is "running"
-    And the project has empty port_definitions or the port is not yet assigned
-    Then the service item should not be a clickable link
-    But the service icon should still be green
 
   Scenario: Service status updates in real-time
     Given I am on a session detail page

--- a/lib/destila/ai/conversation.ex
+++ b/lib/destila/ai/conversation.ex
@@ -255,16 +255,14 @@ defmodule Destila.AI.Conversation do
 
   defp build_service_section(%{service_state: state}) do
     status = state["status"]
-    ports = state["ports"] || %{}
 
-    port_lines =
-      ports
-      |> Enum.map(fn {name, port} -> "#{name}=#{port}" end)
-      |> Enum.join(", ")
+    url_info =
+      case state["port"] do
+        port when is_integer(port) -> "\nURL: http://localhost:#{port}"
+        _ -> ""
+      end
 
-    port_info = if port_lines != "", do: "\nPorts: #{port_lines}", else: ""
-
-    "# Service Status\n\nThe project service is currently #{status}.#{port_info}"
+    "# Service Status\n\nThe project service is currently #{status}.#{url_info}"
   end
 
   defp get_phase(ws, phase_number) do

--- a/lib/destila/ai/tools.ex
+++ b/lib/destila/ai/tools.ex
@@ -123,7 +123,7 @@ defmodule Destila.AI.Tools do
 
   tool :service do
     description(
-      "Manage the project's development service lifecycle. Use this to start, stop, restart, or check the status of the project's service."
+      "Manage the project's development service lifecycle (start/stop/restart/status). Requires the project to be configured as a webservice (a run command and a service env var name)."
     )
 
     field(:action, :string,
@@ -141,12 +141,26 @@ defmodule Destila.AI.Tools do
         worktree_path = ai_session && ai_session.worktree_path
 
         case Destila.Services.ServiceManager.execute(ws, action, worktree_path: worktree_path) do
-          {:ok, state} -> {:ok, Jason.encode!(state)}
+          {:ok, state} -> {:ok, Jason.encode!(Destila.AI.Tools.service_state_to_output(state))}
           {:error, reason} -> {:ok, "Service error: #{reason}"}
         end
       rescue
         e -> {:ok, "Service error: #{Exception.message(e)}"}
       end
+    end
+  end
+
+  @doc false
+  def service_state_to_output(state) do
+    base = %{
+      "status" => state["status"],
+      "run_command" => state["run_command"],
+      "setup_command" => state["setup_command"]
+    }
+
+    case state["port"] do
+      port when is_integer(port) -> Map.put(base, "url", "http://localhost:#{port}")
+      _ -> base
     end
   end
 
@@ -158,15 +172,15 @@ defmodule Destila.AI.Tools do
 
   - `start` — Start the service using the project's configured run command. \
   Blocks until all reserved ports accept TCP connections (returns state with \
-  `"status": "running"` and the port mappings), or fails with an error after \
+  `"status": "running"` and the service URL when running), or fails with an error after \
   a 1-minute timeout — on timeout the service is stopped automatically to \
   avoid leaving an unreachable process running.
   - `stop` — Stop the running service gracefully.
-  - `restart` — Stop and restart the service with fresh port assignments.
-  - `status` — Check the current service status and port mappings.
+  - `restart` — Stop and restart the service with a fresh port assignment.
+  - `status` — Check the current service status and service URL when running.
 
   The tool result contains the service state as JSON, including status and \
-  port mappings. Use these ports when configuring or accessing the service.
+  service URL when running. Use the URL when accessing the service.
   """
 
   @tool_descriptions %{

--- a/lib/destila/projects/project.ex
+++ b/lib/destila/projects/project.ex
@@ -11,7 +11,7 @@ defmodule Destila.Projects.Project do
     field(:local_folder, :string)
     field(:run_command, :string)
     field(:setup_command, :string)
-    field(:port_definitions, {:array, :string}, default: [])
+    field(:service_env_var, :string)
     field(:archived_at, :utc_datetime)
 
     has_many(:workflow_sessions, Destila.Workflows.Session)
@@ -27,14 +27,24 @@ defmodule Destila.Projects.Project do
       :local_folder,
       :run_command,
       :setup_command,
-      :port_definitions,
+      :service_env_var,
       :archived_at
     ])
     |> validate_required([:name])
     |> validate_at_least_one_location()
     |> validate_git_repo_url()
-    |> validate_port_definitions()
+    |> validate_service_env_var()
   end
+
+  @doc """
+  Returns true when the project is configured as a webservice, i.e. it has
+  both a `run_command` and a non-blank `service_env_var`.
+  """
+  def webservice?(%__MODULE__{run_command: run_command, service_env_var: env_var}) do
+    not blank?(run_command) and not blank?(env_var)
+  end
+
+  def webservice?(_), do: false
 
   defp validate_at_least_one_location(changeset) do
     git_repo_url = get_field(changeset, :git_repo_url)
@@ -79,40 +89,31 @@ defmodule Destila.Projects.Project do
   end
 
   @denied_env_vars ~w(PATH HOME SHELL USER TERM LANG LD_PRELOAD LD_LIBRARY_PATH)
-  @port_definition_pattern ~r/^[A-Z][A-Z0-9_]*$/
+  @env_var_pattern ~r/^[A-Z][A-Z0-9_]*$/
 
-  defp validate_port_definitions(changeset) do
-    definitions = get_field(changeset, :port_definitions)
+  defp validate_service_env_var(changeset) do
+    value = get_field(changeset, :service_env_var)
 
-    if definitions in [nil, []] do
-      changeset
-    else
-      invalid =
-        Enum.find(definitions, fn d ->
-          d == "" or not Regex.match?(@port_definition_pattern, d) or d in @denied_env_vars
-        end)
+    cond do
+      blank?(value) ->
+        changeset
 
-      case invalid do
-        nil ->
-          changeset
+      value in @denied_env_vars ->
+        add_error(
+          changeset,
+          :service_env_var,
+          "#{value} is a reserved system environment variable"
+        )
 
-        "" ->
-          add_error(changeset, :port_definitions, "port definition cannot be empty")
+      not Regex.match?(@env_var_pattern, value) ->
+        add_error(
+          changeset,
+          :service_env_var,
+          "#{value} must start with A-Z and contain only uppercase letters, digits, and underscores"
+        )
 
-        name when name in @denied_env_vars ->
-          add_error(
-            changeset,
-            :port_definitions,
-            "#{name} is a reserved system environment variable"
-          )
-
-        name ->
-          add_error(
-            changeset,
-            :port_definitions,
-            "#{name} must start with A-Z and contain only uppercase letters, digits, and underscores"
-          )
-      end
+      true ->
+        changeset
     end
   end
 end

--- a/lib/destila/projects/project.ex
+++ b/lib/destila/projects/project.ex
@@ -44,8 +44,6 @@ defmodule Destila.Projects.Project do
     not blank?(run_command) and not blank?(env_var)
   end
 
-  def webservice?(_), do: false
-
   defp validate_at_least_one_location(changeset) do
     git_repo_url = get_field(changeset, :git_repo_url)
     local_folder = get_field(changeset, :local_folder)

--- a/lib/destila/services/service_manager.ex
+++ b/lib/destila/services/service_manager.ex
@@ -119,18 +119,10 @@ defmodule Destila.Services.ServiceManager do
       prior_state
       |> Map.take(["port", "run_command", "setup_command"])
       |> Map.put("status", "stopped")
-      |> drop_non_integer_port()
 
     Workflows.update_workflow_session(ws, %{service_state: service_state})
 
     {:ok, service_state}
-  end
-
-  defp drop_non_integer_port(state) do
-    case state["port"] do
-      port when is_integer(port) -> state
-      _ -> Map.delete(state, "port")
-    end
   end
 
   defp do_restart(ws, opts) do

--- a/lib/destila/services/service_manager.ex
+++ b/lib/destila/services/service_manager.ex
@@ -9,6 +9,7 @@ defmodule Destila.Services.ServiceManager do
   """
 
   alias Destila.{Projects, Workflows}
+  alias Destila.Projects.Project
   alias Destila.Terminal.Tmux
   import Destila.StringHelper, only: [blank?: 1]
   require Logger
@@ -17,6 +18,8 @@ defmodule Destila.Services.ServiceManager do
   @startup_timeout_ms 60_000
   @port_probe_interval_ms 500
   @port_probe_timeout_ms 500
+
+  @webservice_precondition_error "Project is not configured as a webservice (requires run_command and service_env_var)"
 
   @doc """
   Executes a service action for the given workflow session.
@@ -52,11 +55,11 @@ defmodule Destila.Services.ServiceManager do
       is_nil(project) ->
         {:error, "No project linked to this session"}
 
-      is_nil(project.run_command) or project.run_command == "" ->
-        {:error, "Project has no run command configured"}
+      not Project.webservice?(project) ->
+        {:error, @webservice_precondition_error}
 
       true ->
-        ports = reserve_ports(project.port_definitions)
+        port = reserve_port()
         worktree_path = Keyword.get(opts, :worktree_path)
         session = Tmux.session_name(ws)
         target = service_target(ws)
@@ -67,27 +70,32 @@ defmodule Destila.Services.ServiceManager do
 
         Tmux.send_keys(
           target,
-          build_service_command(project.setup_command, project.run_command, ports)
+          build_service_command(
+            project.setup_command,
+            project.run_command,
+            project.service_env_var,
+            port
+          )
         )
 
         starting_state = %{
           "status" => "starting",
-          "ports" => ports,
+          "port" => port,
           "run_command" => project.run_command,
           "setup_command" => project.setup_command
         }
 
         Workflows.update_workflow_session(ws, %{service_state: starting_state})
-        Logger.info("ServiceManager: #{ws.id} starting; waiting for ports #{inspect(ports)}")
+        Logger.info("ServiceManager: #{ws.id} starting; waiting for port #{port}")
 
-        if wait_for_ports(Map.values(ports), @startup_timeout_ms) do
-          Logger.info("ServiceManager: #{ws.id} ports responded; marking running")
+        if wait_for_port(port, @startup_timeout_ms) do
+          Logger.info("ServiceManager: #{ws.id} port responded; marking running")
           running_state = %{starting_state | "status" => "running"}
           Workflows.update_workflow_session(ws, %{service_state: running_state})
           {:ok, running_state}
         else
           Logger.warning(
-            "ServiceManager: #{ws.id} ports did not respond within #{@startup_timeout_ms}ms; stopping"
+            "ServiceManager: #{ws.id} port did not respond within #{@startup_timeout_ms}ms; stopping"
           )
 
           do_stop(ws)
@@ -105,10 +113,14 @@ defmodule Destila.Services.ServiceManager do
 
     ws = Workflows.get_workflow_session!(ws.id)
 
-    service_state = %{
-      "status" => "stopped",
-      "ports" => (ws.service_state || %{})["ports"]
-    }
+    service_state =
+      case (ws.service_state || %{})["port"] do
+        port when is_integer(port) ->
+          %{"status" => "stopped", "port" => port}
+
+        _ ->
+          %{"status" => "stopped"}
+      end
 
     Workflows.update_workflow_session(ws, %{service_state: service_state})
 
@@ -144,11 +156,8 @@ defmodule Destila.Services.ServiceManager do
   defp service_target(ws), do: "#{Tmux.session_name(ws)}:#{@service_window}"
 
   @doc false
-  def build_service_command(setup_command, run_command, ports) do
-    env_exports =
-      ports
-      |> Enum.map(fn {name, port} -> "export #{name}=#{port}" end)
-      |> Enum.join(" && ")
+  def build_service_command(setup_command, run_command, env_var, port) do
+    env_export = "export #{env_var}=#{port}"
 
     body =
       if blank?(setup_command) do
@@ -157,21 +166,17 @@ defmodule Destila.Services.ServiceManager do
         "#{setup_command}; #{run_command}"
       end
 
-    if env_exports != "" do
-      "#{env_exports} && #{body}"
-    else
-      body
-    end
+    "#{env_export} && #{body}"
   end
 
-  defp wait_for_ports(ports, timeout_ms) do
+  defp wait_for_port(port, timeout_ms) do
     deadline = System.monotonic_time(:millisecond) + timeout_ms
-    do_wait_for_ports(ports, deadline)
+    do_wait_for_port(port, deadline)
   end
 
-  defp do_wait_for_ports(ports, deadline) do
+  defp do_wait_for_port(port, deadline) do
     cond do
-      Enum.all?(ports, &port_open?/1) ->
+      port_open?(port) ->
         true
 
       System.monotonic_time(:millisecond) >= deadline ->
@@ -179,7 +184,7 @@ defmodule Destila.Services.ServiceManager do
 
       true ->
         Process.sleep(@port_probe_interval_ms)
-        do_wait_for_ports(ports, deadline)
+        do_wait_for_port(port, deadline)
     end
   end
 
@@ -195,12 +200,10 @@ defmodule Destila.Services.ServiceManager do
   end
 
   @doc false
-  def reserve_ports(port_definitions) do
-    Map.new(port_definitions, fn name ->
-      {:ok, socket} = :gen_tcp.listen(0, reuseaddr: true)
-      {:ok, port} = :inet.port(socket)
-      :gen_tcp.close(socket)
-      {name, port}
-    end)
+  def reserve_port do
+    {:ok, socket} = :gen_tcp.listen(0, reuseaddr: true)
+    {:ok, port} = :inet.port(socket)
+    :gen_tcp.close(socket)
+    port
   end
 end

--- a/lib/destila/services/service_manager.ex
+++ b/lib/destila/services/service_manager.ex
@@ -113,18 +113,24 @@ defmodule Destila.Services.ServiceManager do
 
     ws = Workflows.get_workflow_session!(ws.id)
 
-    service_state =
-      case (ws.service_state || %{})["port"] do
-        port when is_integer(port) ->
-          %{"status" => "stopped", "port" => port}
+    prior_state = ws.service_state || %{}
 
-        _ ->
-          %{"status" => "stopped"}
-      end
+    service_state =
+      prior_state
+      |> Map.take(["port", "run_command", "setup_command"])
+      |> Map.put("status", "stopped")
+      |> drop_non_integer_port()
 
     Workflows.update_workflow_session(ws, %{service_state: service_state})
 
     {:ok, service_state}
+  end
+
+  defp drop_non_integer_port(state) do
+    case state["port"] do
+      port when is_integer(port) -> state
+      _ -> Map.delete(state, "port")
+    end
   end
 
   defp do_restart(ws, opts) do

--- a/lib/destila/workers/prepare_workflow_session.ex
+++ b/lib/destila/workers/prepare_workflow_session.ex
@@ -4,7 +4,6 @@ defmodule Destila.Workers.PrepareWorkflowSession do
   require Logger
 
   alias Destila.{AI, Git, Workflows}
-  alias Destila.Services.ServiceManager
   alias Destila.Sessions.SessionProcess
   import Destila.StringHelper, only: [blank?: 1]
 
@@ -38,12 +37,11 @@ defmodule Destila.Workers.PrepareWorkflowSession do
         tmux = tmux_impl()
         session = tmux.session_name(ws)
         target = "#{session}:#{@service_window}"
-        ports = ServiceManager.reserve_ports(project.port_definitions)
 
         tmux.ensure_session(session, worktree_path)
         tmux.kill_window(target)
         tmux.new_window(target, cwd: worktree_path)
-        tmux.send_keys(target, build_setup_command(project.setup_command, ports))
+        tmux.send_keys(target, project.setup_command)
         :ok
       rescue
         e ->
@@ -54,19 +52,6 @@ defmodule Destila.Workers.PrepareWorkflowSession do
 
           :ok
       end
-    end
-  end
-
-  defp build_setup_command(setup_command, ports) do
-    env_exports =
-      ports
-      |> Enum.map(fn {name, port} -> "export #{name}=#{port}" end)
-      |> Enum.join(" && ")
-
-    if env_exports != "" do
-      "#{env_exports} && #{setup_command}"
-    else
-      setup_command
     end
   end
 

--- a/lib/destila/workflows/implement_general_prompt_workflow.ex
+++ b/lib/destila/workflows/implement_general_prompt_workflow.ex
@@ -199,7 +199,7 @@ defmodule Destila.Workflows.ImplementGeneralPromptWorkflow do
 
     Steps:
     1. Start the development service by calling `mcp__destila__service` with \
-    `action: "start"`. Use the returned port mappings when accessing the service \
+    `action: "start"`. Use the returned service URL when accessing the service \
     in the walkthrough.
     2. You MUST use the compound engineering skill `feature-video` to record a walkthrough \
     demonstrating the changes

--- a/lib/destila_web/live/project_form_live.ex
+++ b/lib/destila_web/live/project_form_live.ex
@@ -20,40 +20,26 @@ defmodule DestilaWeb.ProjectFormLive do
          "git_repo_url" => project.git_repo_url || "",
          "local_folder" => project.local_folder || "",
          "setup_command" => project.setup_command || "",
-         "run_command" => project.run_command || ""
+         "run_command" => project.run_command || "",
+         "service_env_var" => project.service_env_var || ""
        })
      end)
-     |> assign_new(:port_definitions, fn -> project.port_definitions || [] end)
      |> assign_new(:errors, fn -> %{} end)
      |> assign_new(:inner_block, fn -> [] end)}
   end
 
   def handle_event("validate", params, socket) do
-    port_definitions =
-      params
-      |> Enum.filter(fn {k, _} -> String.starts_with?(k, "port_def_") end)
-      |> Enum.sort_by(fn {k, _} -> k end)
-      |> Enum.map(fn {_, v} -> v end)
-
-    port_definitions =
-      if port_definitions == [], do: socket.assigns.port_definitions, else: port_definitions
-
-    {:noreply,
-     socket
-     |> assign(:form, to_form(params))
-     |> assign(:port_definitions, port_definitions)}
+    {:noreply, assign(socket, :form, to_form(params))}
   end
 
   def handle_event("save", params, socket) do
-    port_defs = Enum.reject(socket.assigns.port_definitions, &(&1 == ""))
-
     attrs = %{
       name: String.trim(params["name"] || ""),
       git_repo_url: non_blank(params["git_repo_url"]),
       local_folder: non_blank(params["local_folder"]),
       setup_command: non_blank(params["setup_command"]),
       run_command: non_blank(params["run_command"]),
-      port_definitions: port_defs
+      service_env_var: non_blank(params["service_env_var"])
     }
 
     result =
@@ -75,29 +61,6 @@ defmodule DestilaWeb.ProjectFormLive do
     end
   end
 
-  def handle_event("add_port", _params, socket) do
-    {:noreply, assign(socket, :port_definitions, socket.assigns.port_definitions ++ [""])}
-  end
-
-  def handle_event("remove_port", %{"index" => index}, socket) do
-    index = String.to_integer(index)
-
-    {:noreply,
-     assign(socket, :port_definitions, List.delete_at(socket.assigns.port_definitions, index))}
-  end
-
-  def handle_event("update_port", params, socket) do
-    index = String.to_integer(params["index"])
-    value = params["value"] || ""
-
-    {:noreply,
-     assign(
-       socket,
-       :port_definitions,
-       List.replace_at(socket.assigns.port_definitions, index, value)
-     )}
-  end
-
   defp non_blank(nil), do: nil
   defp non_blank(""), do: nil
   defp non_blank(str), do: str
@@ -106,7 +69,7 @@ defmodule DestilaWeb.ProjectFormLive do
     Enum.reduce(changeset.errors, %{}, fn
       {:name, {msg, _}}, acc -> Map.put(acc, :name, msg)
       {:git_repo_url, {msg, _}}, acc -> Map.put(acc, :location, msg)
-      {:port_definitions, {msg, _}}, acc -> Map.put(acc, :port_definitions, msg)
+      {:service_env_var, {msg, _}}, acc -> Map.put(acc, :service_env_var, msg)
       _, acc -> acc
     end)
   end
@@ -229,57 +192,26 @@ defmodule DestilaWeb.ProjectFormLive do
           />
         </fieldset>
 
-        <div>
-          <div class="flex items-center justify-between mb-2">
-            <label class="text-xs font-medium text-base-content/70">Port definitions</label>
-            <button
-              type="button"
-              phx-click="add_port"
-              phx-target={@myself}
-              class="btn btn-ghost btn-xs"
-              id={"#{@id}-add-port-btn"}
-            >
-              <.icon name="hero-plus-micro" class="size-3" /> Add port
-            </button>
-          </div>
-
-          <div :if={@port_definitions != []} class="space-y-2">
-            <div
-              :for={{pd, idx} <- Enum.with_index(@port_definitions)}
-              class="flex items-center gap-2"
-              id={"#{@id}-port-def-#{idx}"}
-            >
-              <input
-                type="text"
-                name={"port_def_#{idx}"}
-                value={pd}
-                placeholder="PORT"
-                phx-blur="update_port"
-                phx-target={@myself}
-                phx-value-index={idx}
-                class={[
-                  "input input-bordered w-full input-sm font-mono uppercase",
-                  @errors[:port_definitions] && "input-error"
-                ]}
-                id={"#{@id}-port-input-#{idx}"}
-              />
-              <button
-                type="button"
-                phx-click="remove_port"
-                phx-target={@myself}
-                phx-value-index={idx}
-                class="btn btn-ghost btn-xs text-error/60 hover:text-error"
-                id={"#{@id}-remove-port-#{idx}"}
-              >
-                <.icon name="hero-x-mark-micro" class="size-4" />
-              </button>
-            </div>
-          </div>
-
-          <p :if={@errors[:port_definitions]} class="text-xs text-error mt-1">
-            {@errors[:port_definitions]}
+        <fieldset class="fieldset">
+          <label class="fieldset-label text-xs font-medium" for={"#{@id}-service-env-var"}>
+            Service env var name
+          </label>
+          <input
+            type="text"
+            id={"#{@id}-service-env-var"}
+            name="service_env_var"
+            value={@form["service_env_var"].value}
+            placeholder="PORT"
+            aria-invalid={@errors[:service_env_var] && "true"}
+            class={[
+              "input input-bordered w-full input-sm font-mono uppercase",
+              @errors[:service_env_var] && "input-error"
+            ]}
+          />
+          <p :if={@errors[:service_env_var]} class="text-xs text-error mt-1">
+            {@errors[:service_env_var]}
           </p>
-        </div>
+        </fieldset>
       </div>
 
       <div class="flex gap-2">

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -824,114 +824,92 @@ defmodule DestilaWeb.WorkflowRunnerLive do
                         class="size-3.5 text-base-content/30 group-hover:text-primary transition-colors"
                       />
                     </.link>
-                    <%= if @project do %>
+                    <%= if @project && Destila.Projects.Project.webservice?(@project) do %>
                       <% service_status = @workflow_session.service_state["status"] || "stopped" %>
                       <% service_running? = service_status == "running" %>
                       <% service_starting? = service_status == "starting" %>
                       <% service_active? = service_running? or service_starting? %>
                       <% url = service_url(@project, @workflow_session.service_state) %>
-                      <%= if @project.run_command do %>
-                        <div
-                          id="service-status-item"
-                          class="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-md hover:bg-base-200/60 transition-colors duration-150 group"
-                          aria-label="Service status"
-                        >
-                          <span class="size-5 rounded flex items-center justify-center shrink-0 relative">
-                            <.icon
-                              name="hero-server-micro"
-                              class={[
-                                "size-3.5 transition-colors duration-300",
-                                service_running? && "text-green-500",
-                                service_starting? && "text-amber-500",
-                                !service_active? && "text-base-content/30"
-                              ]}
-                            />
-                            <span
-                              :if={service_active?}
-                              class={[
-                                "absolute -top-0.5 -right-0.5 size-2 rounded-full ring-2 ring-base-100 animate-pulse",
-                                if(service_running?, do: "bg-green-500", else: "bg-amber-500")
-                              ]}
-                            >
-                            </span>
-                          </span>
-                          <%= if url do %>
-                            <a
-                              id="service-status-link"
-                              href={url}
-                              target="_blank"
-                              class="text-sm text-base-content/80 truncate flex-1 text-left hover:text-primary transition-colors"
-                              aria-label="Open service"
-                            >
-                              Service
-                            </a>
-                          <% else %>
-                            <div class="flex-1 min-w-0 flex items-baseline gap-1.5">
-                              <span class={[
-                                "text-sm truncate min-w-0 text-left transition-colors duration-300",
-                                if(service_active?,
-                                  do: "text-base-content/80",
-                                  else: "text-base-content/60"
-                                )
-                              ]}>
-                                Service
-                              </span>
-                              <span
-                                :if={service_running?}
-                                class="shrink-0 text-xs text-green-600 dark:text-green-400"
-                              >
-                                Live
-                              </span>
-                              <span
-                                :if={service_starting?}
-                                class="shrink-0 text-xs text-amber-600 dark:text-amber-400"
-                              >
-                                Starting…
-                              </span>
-                            </div>
-                          <% end %>
-                          <button
-                            type="button"
-                            id={"service-#{if service_active?, do: "stop", else: "start"}-button"}
-                            phx-click={if service_active?, do: "stop_service", else: "start_service"}
+                      <div
+                        id="service-status-item"
+                        class="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-md hover:bg-base-200/60 transition-colors duration-150 group"
+                        aria-label="Service status"
+                      >
+                        <span class="size-5 rounded flex items-center justify-center shrink-0 relative">
+                          <.icon
+                            name="hero-server-micro"
                             class={[
-                              "size-5 rounded flex items-center justify-center shrink-0 cursor-pointer transition-colors",
-                              if(service_active?,
-                                do: "text-red-500 hover:bg-red-500/10",
-                                else: "text-base-content/50 hover:bg-base-200 hover:text-primary"
-                              )
+                              "size-3.5 transition-colors duration-300",
+                              service_running? && "text-green-500",
+                              service_starting? && "text-amber-500",
+                              !service_active? && "text-base-content/30"
                             ]}
-                            aria-label={
-                              if(service_active?, do: "Stop service", else: "Start service")
-                            }
-                            title={if(service_active?, do: "Stop service", else: "Start service")}
+                          />
+                          <span
+                            :if={service_active?}
+                            class={[
+                              "absolute -top-0.5 -right-0.5 size-2 rounded-full ring-2 ring-base-100 animate-pulse",
+                              if(service_running?, do: "bg-green-500", else: "bg-amber-500")
+                            ]}
                           >
-                            <.icon
-                              name={
-                                if service_active?, do: "hero-stop-micro", else: "hero-play-micro"
-                              }
-                              class="size-3.5"
-                            />
-                          </button>
-                        </div>
-                      <% else %>
-                        <div
-                          id="service-status-item"
-                          class="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-md cursor-default"
-                          aria-label="Service not configured"
-                          title="No run command configured"
-                        >
-                          <span class="size-5 rounded flex items-center justify-center shrink-0">
-                            <.icon
-                              name="hero-server-micro"
-                              class="size-3.5 text-base-content/15"
-                            />
                           </span>
-                          <span class="text-sm text-base-content/30 truncate flex-1 text-left">
+                        </span>
+                        <%= if url do %>
+                          <a
+                            id="service-status-link"
+                            href={url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="text-sm text-base-content/80 truncate flex-1 text-left hover:text-primary transition-colors"
+                            aria-label="Open service"
+                          >
                             Service
-                          </span>
-                        </div>
-                      <% end %>
+                          </a>
+                        <% else %>
+                          <div class="flex-1 min-w-0 flex items-baseline gap-1.5">
+                            <span class={[
+                              "text-sm truncate min-w-0 text-left transition-colors duration-300",
+                              if(service_active?,
+                                do: "text-base-content/80",
+                                else: "text-base-content/60"
+                              )
+                            ]}>
+                              Service
+                            </span>
+                            <span
+                              :if={service_running?}
+                              class="shrink-0 text-xs text-green-600 dark:text-green-400"
+                            >
+                              Live
+                            </span>
+                            <span
+                              :if={service_starting?}
+                              class="shrink-0 text-xs text-amber-600 dark:text-amber-400"
+                            >
+                              Starting…
+                            </span>
+                          </div>
+                        <% end %>
+                        <button
+                          type="button"
+                          id={"service-#{if service_active?, do: "stop", else: "start"}-button"}
+                          phx-click={if service_active?, do: "stop_service", else: "start_service"}
+                          class={[
+                            "size-5 rounded flex items-center justify-center shrink-0 cursor-pointer transition-colors",
+                            if(service_active?,
+                              do: "text-red-500 hover:bg-red-500/10",
+                              else: "text-base-content/50 hover:bg-base-200 hover:text-primary"
+                            )
+                          ]}
+                          aria-label={if(service_active?, do: "Stop service", else: "Start service")}
+                          title={if(service_active?, do: "Stop service", else: "Start service")}
+                        >
+                          <.icon
+                            name={if service_active?, do: "hero-stop-micro", else: "hero-play-micro"}
+                            class="size-3.5"
+                          />
+                        </button>
+                      </div>
                     <% end %>
                   </div>
                 </div>
@@ -1285,16 +1263,8 @@ defmodule DestilaWeb.WorkflowRunnerLive do
     |> assign(:exported_metadata, Enum.filter(all, & &1.exported))
   end
 
-  defp service_url(%{port_definitions: [first_port | _]}, %{
-         "status" => "running",
-         "ports" => ports
-       })
-       when is_map(ports) do
-    case Map.get(ports, first_port) do
-      nil -> nil
-      port -> "http://localhost:#{port}"
-    end
-  end
+  defp service_url(_project, %{"status" => "running", "port" => port}) when is_integer(port),
+    do: "http://localhost:#{port}"
 
   defp service_url(_project, _service_state), do: nil
 

--- a/priv/repo/migrations/20260417000000_replace_port_definitions_with_service_env_var.exs
+++ b/priv/repo/migrations/20260417000000_replace_port_definitions_with_service_env_var.exs
@@ -1,0 +1,10 @@
+defmodule Destila.Repo.Migrations.ReplacePortDefinitionsWithServiceEnvVar do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      remove :port_definitions
+      add :service_env_var, :string
+    end
+  end
+end

--- a/test/destila/ai/tools_test.exs
+++ b/test/destila/ai/tools_test.exs
@@ -76,12 +76,18 @@ defmodule Destila.AI.ToolsTest do
       assert output["url"] == "http://localhost:4712"
     end
 
-    test "stopped state without port omits url" do
-      state = %{"status" => "stopped", "run_command" => "run", "setup_command" => nil}
+    test "stopped state without port omits url and preserves commands" do
+      state = %{
+        "status" => "stopped",
+        "run_command" => "mix phx.server",
+        "setup_command" => "mix deps.get"
+      }
 
       output = Tools.service_state_to_output(state)
 
       assert output["status"] == "stopped"
+      assert output["run_command"] == "mix phx.server"
+      assert output["setup_command"] == "mix deps.get"
       refute Map.has_key?(output, "url")
     end
 

--- a/test/destila/ai/tools_test.exs
+++ b/test/destila/ai/tools_test.exs
@@ -44,4 +44,60 @@ defmodule Destila.AI.ToolsTest do
       assert "mcp__destila__ask_user_question" in names
     end
   end
+
+  describe "service_state_to_output/1" do
+    test "running state with port includes url" do
+      state = %{
+        "status" => "running",
+        "port" => 4712,
+        "run_command" => "mix phx.server",
+        "setup_command" => "mix deps.get"
+      }
+
+      output = Tools.service_state_to_output(state)
+
+      assert output["status"] == "running"
+      assert output["url"] == "http://localhost:4712"
+      assert output["run_command"] == "mix phx.server"
+      assert output["setup_command"] == "mix deps.get"
+    end
+
+    test "starting state with port includes url" do
+      state = %{
+        "status" => "starting",
+        "port" => 4712,
+        "run_command" => "run",
+        "setup_command" => nil
+      }
+
+      output = Tools.service_state_to_output(state)
+
+      assert output["status"] == "starting"
+      assert output["url"] == "http://localhost:4712"
+    end
+
+    test "stopped state without port omits url" do
+      state = %{"status" => "stopped", "run_command" => "run", "setup_command" => nil}
+
+      output = Tools.service_state_to_output(state)
+
+      assert output["status"] == "stopped"
+      refute Map.has_key?(output, "url")
+    end
+
+    test "legacy state with ports map omits url" do
+      state = %{"status" => "running", "ports" => %{"PORT" => 4712}}
+
+      output = Tools.service_state_to_output(state)
+
+      refute Map.has_key?(output, "url")
+    end
+
+    test "serializes to JSON without a url key when no port" do
+      state = %{"status" => "stopped", "run_command" => "run", "setup_command" => nil}
+      json = Jason.encode!(Tools.service_state_to_output(state))
+      refute json =~ "url"
+      assert json =~ ~s("status":"stopped")
+    end
+  end
 end

--- a/test/destila/projects/project_test.exs
+++ b/test/destila/projects/project_test.exs
@@ -135,11 +135,6 @@ defmodule Destila.Projects.ProjectTest do
       refute Project.webservice?(%Project{run_command: "run", service_env_var: nil})
       refute Project.webservice?(%Project{run_command: "run", service_env_var: ""})
     end
-
-    test "false for non-project values" do
-      refute Project.webservice?(nil)
-      refute Project.webservice?(%{})
-    end
   end
 
   describe "changeset/2 with setup_command" do

--- a/test/destila/projects/project_test.exs
+++ b/test/destila/projects/project_test.exs
@@ -5,95 +5,130 @@ defmodule Destila.Projects.ProjectTest do
 
   @valid_attrs %{name: "Test Project", git_repo_url: "https://github.com/test/repo"}
 
-  describe "changeset/2 with run_command and port_definitions" do
-    test "accepts valid run_command and port_definitions" do
+  describe "changeset/2 with run_command and service_env_var" do
+    @tag feature: "project_management",
+         scenario: "Create a project with run command and a service env var"
+    test "accepts valid run_command and service_env_var" do
       changeset =
         Project.changeset(
           %Project{},
           Map.merge(@valid_attrs, %{
             run_command: "mix phx.server",
-            port_definitions: ["PORT", "API_PORT"]
+            service_env_var: "PORT"
           })
         )
 
       assert changeset.valid?
+      assert Ecto.Changeset.get_change(changeset, :service_env_var) == "PORT"
     end
 
-    test "accepts nil run_command and empty port_definitions" do
+    @tag feature: "project_management",
+         scenario: "Create a project without a service env var name"
+    test "accepts nil run_command and nil service_env_var" do
       changeset = Project.changeset(%Project{}, @valid_attrs)
       assert changeset.valid?
     end
 
-    test "rejects port definition with lowercase letters" do
+    test "accepts empty-string service_env_var" do
       changeset =
         Project.changeset(
           %Project{},
-          Map.merge(@valid_attrs, %{
-            port_definitions: ["my_port"]
-          })
-        )
-
-      refute changeset.valid?
-
-      assert {"my_port must start with A-Z and contain only uppercase letters, digits, and underscores",
-              _} = changeset.errors[:port_definitions]
-    end
-
-    test "rejects port definition starting with digit" do
-      changeset =
-        Project.changeset(
-          %Project{},
-          Map.merge(@valid_attrs, %{
-            port_definitions: ["123"]
-          })
-        )
-
-      refute changeset.valid?
-    end
-
-    test "rejects port definition with special characters" do
-      changeset =
-        Project.changeset(
-          %Project{},
-          Map.merge(@valid_attrs, %{
-            port_definitions: ["MY-PORT"]
-          })
-        )
-
-      refute changeset.valid?
-    end
-
-    test "accepts valid underscore names" do
-      changeset =
-        Project.changeset(
-          %Project{},
-          Map.merge(@valid_attrs, %{
-            port_definitions: ["DB_PORT", "PORT_3000", "A"]
-          })
+          Map.merge(@valid_attrs, %{service_env_var: ""})
         )
 
       assert changeset.valid?
+      refute changeset.errors[:service_env_var]
     end
 
-    test "rejects reserved system env var names" do
+    @tag feature: "project_management",
+         scenario: "Service env var requires a valid environment variable name"
+    test "rejects service_env_var with lowercase letters" do
       changeset =
         Project.changeset(
           %Project{},
-          Map.merge(@valid_attrs, %{
-            port_definitions: ["PATH"]
-          })
+          Map.merge(@valid_attrs, %{service_env_var: "port"})
         )
 
       refute changeset.valid?
 
-      assert {"PATH is a reserved system environment variable", _} =
-               changeset.errors[:port_definitions]
+      assert {"port must start with A-Z and contain only uppercase letters, digits, and underscores",
+              _} = changeset.errors[:service_env_var]
+    end
+
+    test "rejects service_env_var starting with digit" do
+      changeset =
+        Project.changeset(
+          %Project{},
+          Map.merge(@valid_attrs, %{service_env_var: "1PORT"})
+        )
+
+      refute changeset.valid?
+      assert changeset.errors[:service_env_var]
+    end
+
+    test "rejects service_env_var with special characters" do
+      changeset =
+        Project.changeset(
+          %Project{},
+          Map.merge(@valid_attrs, %{service_env_var: "PORT-1"})
+        )
+
+      refute changeset.valid?
+      assert changeset.errors[:service_env_var]
+    end
+
+    test "accepts valid underscore names and multi-digit suffixes" do
+      for name <- ~w(PORT API_PORT SERVICE_PORT_2 DB_PORT A PORT_3000) do
+        changeset =
+          Project.changeset(
+            %Project{},
+            Map.merge(@valid_attrs, %{service_env_var: name})
+          )
+
+        assert changeset.valid?, "expected #{name} to be valid"
+      end
+    end
+
+    test "rejects reserved system env var names" do
+      for reserved <- ~w(PATH HOME SHELL USER TERM LANG LD_PRELOAD LD_LIBRARY_PATH) do
+        changeset =
+          Project.changeset(
+            %Project{},
+            Map.merge(@valid_attrs, %{service_env_var: reserved})
+          )
+
+        refute changeset.valid?, "expected #{reserved} to be rejected"
+
+        {message, _} = changeset.errors[:service_env_var]
+        assert message == "#{reserved} is a reserved system environment variable"
+      end
     end
 
     test "existing validations still pass unchanged" do
       changeset = Project.changeset(%Project{}, %{name: "Test"})
       refute changeset.valid?
       assert changeset.errors[:git_repo_url]
+    end
+  end
+
+  describe "webservice?/1" do
+    test "true when project has run_command and service_env_var" do
+      assert Project.webservice?(%Project{run_command: "run", service_env_var: "PORT"})
+    end
+
+    test "false when run_command is missing" do
+      refute Project.webservice?(%Project{run_command: nil, service_env_var: "PORT"})
+      refute Project.webservice?(%Project{run_command: "", service_env_var: "PORT"})
+    end
+
+    test "false when service_env_var is missing" do
+      refute Project.webservice?(%Project{run_command: "run", service_env_var: nil})
+      refute Project.webservice?(%Project{run_command: "run", service_env_var: ""})
+    end
+
+    test "false for non-project values" do
+      refute Project.webservice?(nil)
+      refute Project.webservice?(%{})
     end
   end
 

--- a/test/destila/projects/project_test.exs
+++ b/test/destila/projects/project_test.exs
@@ -29,6 +29,8 @@ defmodule Destila.Projects.ProjectTest do
       assert changeset.valid?
     end
 
+    @tag feature: "project_management",
+         scenario: "Create a project without a service env var name"
     test "accepts empty-string service_env_var" do
       changeset =
         Project.changeset(
@@ -55,6 +57,8 @@ defmodule Destila.Projects.ProjectTest do
               _} = changeset.errors[:service_env_var]
     end
 
+    @tag feature: "project_management",
+         scenario: "Service env var requires a valid environment variable name"
     test "rejects service_env_var starting with digit" do
       changeset =
         Project.changeset(
@@ -66,6 +70,8 @@ defmodule Destila.Projects.ProjectTest do
       assert changeset.errors[:service_env_var]
     end
 
+    @tag feature: "project_management",
+         scenario: "Service env var requires a valid environment variable name"
     test "rejects service_env_var with special characters" do
       changeset =
         Project.changeset(
@@ -77,6 +83,8 @@ defmodule Destila.Projects.ProjectTest do
       assert changeset.errors[:service_env_var]
     end
 
+    @tag feature: "project_management",
+         scenario: "Service env var requires a valid environment variable name"
     test "accepts valid underscore names and multi-digit suffixes" do
       for name <- ~w(PORT API_PORT SERVICE_PORT_2 DB_PORT A PORT_3000) do
         changeset =
@@ -89,6 +97,8 @@ defmodule Destila.Projects.ProjectTest do
       end
     end
 
+    @tag feature: "project_management",
+         scenario: "Service env var requires a valid environment variable name"
     test "rejects reserved system env var names" do
       for reserved <- ~w(PATH HOME SHELL USER TERM LANG LD_PRELOAD LD_LIBRARY_PATH) do
         changeset =

--- a/test/destila/services/service_manager_test.exs
+++ b/test/destila/services/service_manager_test.exs
@@ -9,74 +9,53 @@ defmodule Destila.Services.ServiceManagerTest do
 
   @feature "service_setup_command"
 
-  describe "build_service_command/3 without setup_command" do
+  describe "build_service_command/4 without setup_command" do
     @tag feature: @feature,
          scenario: "A project without a setup command keeps its current behavior"
-    test "returns run_command unchanged when no setup and no ports" do
-      assert ServiceManager.build_service_command(nil, "mix phx.server", %{}) ==
-               "mix phx.server"
-    end
-
-    @tag feature: @feature,
-         scenario: "A project without a setup command keeps its current behavior"
-    test "prepends port exports with && when no setup" do
-      result =
-        ServiceManager.build_service_command(
-          nil,
-          "mix phx.server",
-          %{"PORT" => 4000, "API_PORT" => 4001}
-        )
-
-      assert result =~ "export PORT=4000"
-      assert result =~ "export API_PORT=4001"
-      assert result =~ " && mix phx.server"
-      refute result =~ ";"
+    test "returns run_command prefixed with env export when no setup" do
+      assert ServiceManager.build_service_command(nil, "mix phx.server", "PORT", 4712) ==
+               "export PORT=4712 && mix phx.server"
     end
   end
 
-  describe "build_service_command/3 with setup_command" do
+  describe "build_service_command/4 with setup_command" do
     @tag feature: @feature,
          scenario: "Setup and run are chained with ; so setup failure does not block run"
-    test "chains setup and run with ; when no ports" do
-      assert ServiceManager.build_service_command(
-               "mix deps.get",
-               "mix phx.server",
-               %{}
-             ) == "mix deps.get; mix phx.server"
+    test "chains setup and run with ; and prefixes the env export" do
+      assert ServiceManager.build_service_command("setup", "run", "PORT", 4712) ==
+               "export PORT=4712 && setup; run"
     end
 
     @tag feature: @feature,
-         scenario: "Setup and run are chained with ; so setup failure does not block run"
-    test "exports ports with &&, then chains setup and run with ;" do
+         scenario:
+           "Start/restart allocates a port and exports the service env var for both setup and run"
+    test "exposes the env var to both setup and run commands" do
       result =
-        ServiceManager.build_service_command(
-          "mix deps.get",
-          "mix phx.server",
-          %{"PORT" => 4000, "API_PORT" => 4001}
-        )
+        ServiceManager.build_service_command("mix deps.get", "mix phx.server", "API_PORT", 4001)
 
-      assert result =~ "export PORT=4000"
-      assert result =~ "export API_PORT=4001"
-      assert result =~ " && mix deps.get; mix phx.server"
+      assert result == "export API_PORT=4001 && mix deps.get; mix phx.server"
     end
   end
 
-  describe "build_service_command/3 edge cases" do
+  describe "build_service_command/4 edge cases" do
     @tag feature: @feature, scenario: "Empty setup_command behaves like nil"
     test "treats empty-string setup_command like nil" do
-      assert ServiceManager.build_service_command("", "mix phx.server", %{}) ==
-               "mix phx.server"
+      assert ServiceManager.build_service_command("", "run", "PORT", 4712) ==
+               "export PORT=4712 && run"
     end
 
     @tag feature: @feature, scenario: "Empty setup_command behaves like nil"
     test "treats whitespace-only setup_command like nil" do
-      assert ServiceManager.build_service_command("   ", "mix phx.server", %{}) ==
-               "mix phx.server"
+      assert ServiceManager.build_service_command("   ", "run", "PORT", 4712) ==
+               "export PORT=4712 && run"
     end
+  end
 
-    test "empty ports map behaves like no ports" do
-      assert ServiceManager.build_service_command(nil, "run", %{}) == "run"
-      assert ServiceManager.build_service_command("setup", "run", %{}) == "setup; run"
+  describe "reserve_port/0" do
+    test "returns an integer port" do
+      port = ServiceManager.reserve_port()
+      assert is_integer(port)
+      assert port > 0
     end
   end
 end

--- a/test/destila/workers/prepare_workflow_session_test.exs
+++ b/test/destila/workers/prepare_workflow_session_test.exs
@@ -26,11 +26,11 @@ defmodule Destila.Workers.PrepareWorkflowSessionTest do
 
   describe "run_post_worktree_setup/3" do
     @tag feature: @feature,
-         scenario: "Worktree creation triggers setup command in the tmux service window"
-    test "sends the setup command to window 9 when project has setup_command and no ports" do
+         scenario: "Post-worktree setup runs without allocating a port"
+    test "sends the setup command plain, without any env exports" do
       project = %Destila.Projects.Project{
         setup_command: "mix deps.get",
-        port_definitions: []
+        service_env_var: nil
       }
 
       ws = make_ws("my-session")
@@ -44,25 +44,27 @@ defmodule Destila.Workers.PrepareWorkflowSessionTest do
     end
 
     @tag feature: @feature,
-         scenario: "Setup sees the same port environment variables as the run command"
-    test "prefixes port exports before the setup command" do
+         scenario: "Post-worktree setup runs without allocating a port"
+    test "does not export the service_env_var even when configured" do
       project = %Destila.Projects.Project{
         setup_command: "mix deps.get",
-        port_definitions: ["PORT"]
+        service_env_var: "PORT",
+        run_command: "mix phx.server"
       }
 
-      ws = make_ws("session-with-ports")
+      ws = make_ws("session-with-env-var")
 
       assert :ok = PrepareWorkflowSession.run_post_worktree_setup(project, "/tmp/wt", ws)
 
-      assert_received {:tmux, :send_keys, ["ws-session-with-ports:9", command]}
-      assert command =~ ~r/^export PORT=\d+ && mix deps\.get$/
+      assert_received {:tmux, :send_keys, ["ws-session-with-env-var:9", command]}
+      assert command == "mix deps.get"
+      refute command =~ "export"
     end
 
     @tag feature: @feature,
          scenario: "A project without a setup command keeps its current behavior"
     test "does nothing when setup_command is nil" do
-      project = %Destila.Projects.Project{setup_command: nil, port_definitions: []}
+      project = %Destila.Projects.Project{setup_command: nil}
       ws = make_ws("no-setup")
 
       assert :ok = PrepareWorkflowSession.run_post_worktree_setup(project, "/tmp/wt", ws)
@@ -74,7 +76,7 @@ defmodule Destila.Workers.PrepareWorkflowSessionTest do
     @tag feature: @feature,
          scenario: "A project without a setup command keeps its current behavior"
     test "does nothing when setup_command is an empty string" do
-      project = %Destila.Projects.Project{setup_command: "", port_definitions: []}
+      project = %Destila.Projects.Project{setup_command: ""}
       ws = make_ws("empty-setup")
 
       assert :ok = PrepareWorkflowSession.run_post_worktree_setup(project, "/tmp/wt", ws)
@@ -97,7 +99,7 @@ defmodule Destila.Workers.PrepareWorkflowSessionTest do
     test "returns :ok when tmux raises so perform/1 still calls worktree_ready/1" do
       FakeTmux.stub_send_keys(fn _target, _cmd -> raise "boom" end)
 
-      project = %Destila.Projects.Project{setup_command: "mix deps.get", port_definitions: []}
+      project = %Destila.Projects.Project{setup_command: "mix deps.get"}
       ws = make_ws("raising-session")
 
       assert :ok = PrepareWorkflowSession.run_post_worktree_setup(project, "/tmp/wt", ws)

--- a/test/destila_web/live/projects_live_test.exs
+++ b/test/destila_web/live/projects_live_test.exs
@@ -166,27 +166,52 @@ defmodule DestilaWeb.ProjectsLiveTest do
   end
 
   describe "run configuration" do
-    @tag feature: @feature, scenario: "Create a project with run command and port definitions"
-    test "creates a project with run command and port definitions", %{conn: conn} do
+    @tag feature: @feature,
+         scenario: "Create a project with run command and a service env var"
+    test "creates a project with run command and a service env var", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/projects")
 
       view |> element("#new-project-btn") |> render_click()
-
-      # Add a port definition
-      view |> element("#project-form-create-add-port-btn") |> render_click()
-      assert has_element?(view, "#project-form-create-port-input-0")
+      assert has_element?(view, "#project-form-create-service-env-var")
 
       view
       |> form("#project-form-create-form", %{
         "name" => "Service Project",
         "git_repo_url" => "https://github.com/test/service",
-        "run_command" => "mix phx.server"
+        "run_command" => "mix phx.server",
+        "service_env_var" => "PORT"
       })
       |> render_submit()
 
       html = render(view)
       assert html =~ "Service Project"
       assert html =~ "mix phx.server"
+
+      [project] = Destila.Projects.list_projects()
+      assert project.service_env_var == "PORT"
+    end
+
+    @tag feature: @feature,
+         scenario: "Create a project without a service env var name"
+    test "creates a project without a service env var name", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      view |> element("#new-project-btn") |> render_click()
+
+      view
+      |> form("#project-form-create-form", %{
+        "name" => "No Env Project",
+        "git_repo_url" => "https://github.com/test/no-env",
+        "run_command" => "mix phx.server",
+        "service_env_var" => ""
+      })
+      |> render_submit()
+
+      html = render(view)
+      assert html =~ "No Env Project"
+
+      [project] = Destila.Projects.list_projects()
+      assert is_nil(project.service_env_var)
     end
 
     @tag feature: @feature, scenario: "Edit a project's run configuration"
@@ -302,27 +327,50 @@ defmodule DestilaWeb.ProjectsLiveTest do
     end
 
     @tag feature: @feature,
-         scenario: "Port definitions require a valid environment variable name"
-    test "shows error for invalid port definition name", %{conn: conn} do
+         scenario: "Service env var requires a valid environment variable name"
+    test "shows error for invalid service env var name", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/projects")
 
       view |> element("#new-project-btn") |> render_click()
 
-      # Add a port and set an invalid value
-      view |> element("#project-form-create-add-port-btn") |> render_click()
-
-      view
-      |> element("#project-form-create-port-input-0")
-      |> render_blur(%{"index" => "0", "value" => "invalid-port"})
-
       view
       |> form("#project-form-create-form", %{
-        "name" => "Bad Port Project",
-        "git_repo_url" => "https://github.com/test/repo"
+        "name" => "Bad Env Project",
+        "git_repo_url" => "https://github.com/test/repo",
+        "service_env_var" => "invalid-name"
       })
       |> render_submit()
 
       assert render(view) =~ "must start with A-Z"
+    end
+
+    @tag feature: @feature,
+         scenario: "Service env var requires a valid environment variable name"
+    test "shows error for reserved service env var name", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      view |> element("#new-project-btn") |> render_click()
+
+      view
+      |> form("#project-form-create-form", %{
+        "name" => "Reserved Env Project",
+        "git_repo_url" => "https://github.com/test/repo",
+        "service_env_var" => "PATH"
+      })
+      |> render_submit()
+
+      assert render(view) =~ "reserved system environment variable"
+    end
+
+    test "form has no port definitions UI", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      view |> element("#new-project-btn") |> render_click()
+
+      html = render(view)
+      refute html =~ "Port definitions"
+      refute html =~ "add-port"
+      refute html =~ "port-input-"
     end
   end
 

--- a/test/destila_web/live/projects_live_test.exs
+++ b/test/destila_web/live/projects_live_test.exs
@@ -362,6 +362,7 @@ defmodule DestilaWeb.ProjectsLiveTest do
       assert render(view) =~ "reserved system environment variable"
     end
 
+    @tag feature: @feature, scenario: "Create a project with run command and a service env var"
     test "form has no port definitions UI", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/projects")
 

--- a/test/destila_web/live/service_status_sidebar_live_test.exs
+++ b/test/destila_web/live/service_status_sidebar_live_test.exs
@@ -7,6 +7,8 @@ defmodule DestilaWeb.ServiceStatusSidebarLiveTest do
 
   import Phoenix.LiveViewTest
 
+  @feature "service_status_sidebar"
+
   setup %{conn: conn} do
     ClaudeCode.Test.set_mode_to_shared()
 
@@ -52,30 +54,39 @@ defmodule DestilaWeb.ServiceStatusSidebarLiveTest do
   end
 
   describe "service item visibility" do
-    @tag feature: "service_status_sidebar",
-         scenario: "Service item visible when project has run_command"
-    test "shows service item when project has run_command", %{conn: conn} do
-      project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
-      ws = create_session(%{project_id: project.id})
-      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+    @tag feature: @feature,
+         scenario: "Service item visible when project is a webservice"
+    test "shows service item when project has run_command and service_env_var", %{conn: conn} do
+      project =
+        create_project(%{run_command: "mix phx.server", service_env_var: "PORT"})
 
-      assert has_element?(view, "#service-status-item") or
-               has_element?(view, "#service-status-link")
-    end
-
-    @tag feature: "service_status_sidebar",
-         scenario: "Service item disabled when no run_command configured"
-    test "shows disabled service item when project has no run_command", %{conn: conn} do
-      project = create_project(%{run_command: nil})
       ws = create_session(%{project_id: project.id})
       {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
 
       assert has_element?(view, "#service-status-item")
-      refute has_element?(view, "#service-status-link")
-      assert has_element?(view, "#service-status-item .text-base-content\\/15")
     end
 
-    @tag feature: "service_status_sidebar",
+    @tag feature: @feature,
+         scenario: "Service item hidden when project has no run_command"
+    test "hides service item when project has no run_command", %{conn: conn} do
+      project = create_project(%{run_command: nil, service_env_var: "PORT"})
+      ws = create_session(%{project_id: project.id})
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      refute has_element?(view, "#service-status-item")
+    end
+
+    @tag feature: @feature,
+         scenario: "Service item hidden when project has no service_env_var"
+    test "hides service item when project has no service_env_var", %{conn: conn} do
+      project = create_project(%{run_command: "mix phx.server", service_env_var: nil})
+      ws = create_session(%{project_id: project.id})
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      refute has_element?(view, "#service-status-item")
+    end
+
+    @tag feature: @feature,
          scenario: "Service item hidden when session has no project"
     test "does not show service item when session has no project", %{conn: conn} do
       ws = create_session(%{project_id: nil})
@@ -87,15 +98,16 @@ defmodule DestilaWeb.ServiceStatusSidebarLiveTest do
   end
 
   describe "service icon color" do
-    @tag feature: "service_status_sidebar",
+    @tag feature: @feature,
          scenario: "Service icon is green when service is running"
     test "icon is green when service is running", %{conn: conn} do
-      project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
+      project =
+        create_project(%{run_command: "mix phx.server", service_env_var: "PORT"})
 
       ws =
         create_session(%{
           project_id: project.id,
-          service_state: %{"status" => "running", "ports" => %{"PORT" => 4000}}
+          service_state: %{"status" => "running", "port" => 4000}
         })
 
       {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
@@ -104,10 +116,11 @@ defmodule DestilaWeb.ServiceStatusSidebarLiveTest do
       assert has_element?(view, "#service-status-item .text-green-500")
     end
 
-    @tag feature: "service_status_sidebar",
+    @tag feature: @feature,
          scenario: "Service icon is muted when service is stopped"
     test "icon is muted when service is stopped", %{conn: conn} do
-      project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
+      project =
+        create_project(%{run_command: "mix phx.server", service_env_var: "PORT"})
 
       ws =
         create_session(%{
@@ -120,10 +133,12 @@ defmodule DestilaWeb.ServiceStatusSidebarLiveTest do
       assert has_element?(view, "#service-status-item .text-base-content\\/30")
     end
 
-    @tag feature: "service_status_sidebar",
+    @tag feature: @feature,
          scenario: "Nil service_state treated as stopped"
     test "icon is muted when service_state is nil", %{conn: conn} do
-      project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
+      project =
+        create_project(%{run_command: "mix phx.server", service_env_var: "PORT"})
+
       ws = create_session(%{project_id: project.id, service_state: nil})
       {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
 
@@ -132,15 +147,16 @@ defmodule DestilaWeb.ServiceStatusSidebarLiveTest do
   end
 
   describe "service link behavior" do
-    @tag feature: "service_status_sidebar",
+    @tag feature: @feature,
          scenario: "Running service with port is a clickable link"
     test "renders link with correct href when running with port", %{conn: conn} do
-      project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
+      project =
+        create_project(%{run_command: "mix phx.server", service_env_var: "PORT"})
 
       ws =
         create_session(%{
           project_id: project.id,
-          service_state: %{"status" => "running", "ports" => %{"PORT" => 4000}}
+          service_state: %{"status" => "running", "port" => 4000}
         })
 
       {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
@@ -149,10 +165,11 @@ defmodule DestilaWeb.ServiceStatusSidebarLiveTest do
       assert has_element?(view, ~s|#service-status-link[target="_blank"]|)
     end
 
-    @tag feature: "service_status_sidebar",
+    @tag feature: @feature,
          scenario: "Stopped service is not clickable"
     test "renders static element when stopped", %{conn: conn} do
-      project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
+      project =
+        create_project(%{run_command: "mix phx.server", service_env_var: "PORT"})
 
       ws =
         create_session(%{
@@ -166,33 +183,27 @@ defmodule DestilaWeb.ServiceStatusSidebarLiveTest do
       refute has_element?(view, "#service-status-link")
     end
 
-    @tag feature: "service_status_sidebar",
-         scenario: "Running service without available port shows green icon"
-    test "renders static element when running but port_definitions is empty", %{conn: conn} do
-      project = create_project(%{run_command: "mix phx.server", port_definitions: []})
+    @tag feature: @feature,
+         scenario: "Nil service_state treated as stopped"
+    test "not a link when service_state is nil", %{conn: conn} do
+      project =
+        create_project(%{run_command: "mix phx.server", service_env_var: "PORT"})
 
-      ws =
-        create_session(%{
-          project_id: project.id,
-          service_state: %{"status" => "running", "ports" => %{}}
-        })
-
+      ws = create_session(%{project_id: project.id, service_state: nil})
       {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
 
       assert has_element?(view, "#service-status-item")
       refute has_element?(view, "#service-status-link")
-      assert has_element?(view, "#service-status-item .text-green-500")
     end
 
-    @tag feature: "service_status_sidebar",
-         scenario: "Running service without available port shows green icon"
-    test "renders static element when running but first port not in ports map", %{conn: conn} do
-      project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
+    test "legacy service_state with ports map renders running icon but no link", %{conn: conn} do
+      project =
+        create_project(%{run_command: "mix phx.server", service_env_var: "PORT"})
 
       ws =
         create_session(%{
           project_id: project.id,
-          service_state: %{"status" => "running", "ports" => %{"OTHER" => 5000}}
+          service_state: %{"status" => "running", "ports" => %{"PORT" => 4712}}
         })
 
       {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
@@ -204,10 +215,12 @@ defmodule DestilaWeb.ServiceStatusSidebarLiveTest do
   end
 
   describe "real-time updates" do
-    @tag feature: "service_status_sidebar",
+    @tag feature: @feature,
          scenario: "Service status updates in real-time"
     test "updates when service state changes via PubSub", %{conn: conn} do
-      project = create_project(%{run_command: "mix phx.server", port_definitions: ["PORT"]})
+      project =
+        create_project(%{run_command: "mix phx.server", service_env_var: "PORT"})
+
       ws = create_session(%{project_id: project.id, service_state: nil})
       {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
 
@@ -216,7 +229,7 @@ defmodule DestilaWeb.ServiceStatusSidebarLiveTest do
 
       {:ok, updated_ws} =
         Destila.Workflows.update_workflow_session(ws, %{
-          service_state: %{"status" => "running", "ports" => %{"PORT" => 4000}}
+          service_state: %{"status" => "running", "port" => 4000}
         })
 
       send(view.pid, {:workflow_session_updated, updated_ws})


### PR DESCRIPTION
## Summary

Replaces the multi-port `port_definitions` array on projects with a single `service_env_var` string. Simplifies project configuration: each project declares one environment variable name, and the service manager reserves a port and exports that variable when starting the service.

## Changes

- **Schema**: migration removes `port_definitions` and adds `service_env_var :string` on `projects`.
- **Validation**: `service_env_var` must match `/^[A-Z][A-Z0-9_]*$/` and is rejected if it matches common reserved names (`PATH`, `HOME`, `SHELL`, `USER`, `TERM`, `LANG`, `LD_PRELOAD`, `LD_LIBRARY_PATH`).
- **Project form** (`/projects`): replaced the add/remove port rows with a single "Service env var name" text input.
- **ServiceManager**: starts the service with `export <env_var>=<port> && <setup>; <run>` in tmux window 9. `do_stop/1` now preserves `run_command` / `setup_command` in the persisted `service_state` (previously dropped).
- **MCP tool output**: `service_state_to_output/1` returns `url: http://localhost:<port>` only when `port` is an integer; omits it otherwise.
- **Webservice predicate**: `Project.webservice?/1` requires both `run_command` and `service_env_var` to be present. Service sidebar visibility now gates on this predicate.
- **Feature-video prompt**: updated wording from "port mappings" to "service URL".
- **Tests**: new `Project.changeset` coverage for env-var name rules (valid names, digit-leading, special chars, reserved names); new `Tools.service_state_to_output/1` coverage including JSON round-trip; existing LiveView tests updated to assert the single text input.

## Test plan

- [x] `mix precommit` (410 tests pass)
- [x] Browser smoke: /projects create + validation errors (lowercase, reserved) + edit prefill

## Post-Deploy Monitoring & Validation

- **Logs to watch**: `ServiceManager: ... port did not respond within 60000ms` indicating env-var misconfiguration breaking service start.
- **Expected healthy signals**: `ServiceManager: ... port responded; marking running` shortly after start.
- **Failure signals / rollback trigger**: existing projects whose `service_env_var` is `nil` after migration should continue to function as non-webservices (sidebar hidden, start returns "not configured"). If any project's service cannot start because of env-var rejection, inspect the value against the regex and reserved list.
- **Validation window**: first 24 hours after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)