### PR TITLE
feat: order AI sessions oldest-first with browser-local timestamps

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -25,6 +25,7 @@ import {LiveSocket} from "phoenix_live_view"
 import {hooks as colocatedHooks} from "phoenix-colocated/destila"
 import topbar from "../vendor/topbar"
 import TerminalPanel from "./hooks/terminal_panel"
+import LocalTime from "./hooks/local_time"
 
 const ScrollBottomHook = {
   mounted() { this.el.scrollTop = this.el.scrollHeight },
@@ -60,6 +61,7 @@ const Hooks = {
   FocusFirstError: FocusFirstErrorHook,
   AutoDismiss: AutoDismissHook,
   TerminalPanel: TerminalPanel,
+  LocalTime: LocalTime,
 }
 
 const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")

--- a/assets/js/hooks/local_time.js
+++ b/assets/js/hooks/local_time.js
@@ -1,0 +1,19 @@
+const LocalTime = {
+  mounted() { this.format() },
+  updated() { this.format() },
+  format() {
+    const ts = this.el.dataset.ts
+    if (!ts) return
+    const d = new Date(ts)
+    if (isNaN(d.getTime())) return
+    this.el.textContent = d.toLocaleString([], {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false
+    })
+  }
+}
+
+export default LocalTime

--- a/features/ai_session_sidebar.feature
+++ b/features/ai_session_sidebar.feature
@@ -15,6 +15,12 @@ Feature: AI Sessions Sidebar
     When I open the workflow runner page
     Then the sidebar should show two AI session rows
     And each row should be a link to the AI Session Debug Detail page
+    And the rows should be ordered from oldest to newest
+
+  Scenario: AI session row displays the creation time in the browser timezone
+    Given the workflow session has one AI session
+    When I open the workflow runner page
+    Then the row should render the session timestamp in the browser's local timezone
 
   Scenario: Empty state when no AI sessions exist
     Given the workflow session has no AI sessions

--- a/lib/destila/ai.ex
+++ b/lib/destila/ai.ex
@@ -25,7 +25,7 @@ defmodule Destila.AI do
     Repo.all(
       from(s in Session,
         where: s.workflow_session_id == ^workflow_session_id,
-        order_by: [desc: s.inserted_at]
+        order_by: [asc: s.inserted_at]
       )
     )
   end

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -945,7 +945,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
                         </span>
                         <span
                           id={"ai-session-time-#{ai.id}"}
-                          phx-hook=".LocalTime"
+                          phx-hook="LocalTime"
                           phx-update="ignore"
                           data-ts={DateTime.to_iso8601(ai.inserted_at)}
                           class="text-sm text-base-content/60 truncate flex-1 text-left"
@@ -1177,25 +1177,6 @@ defmodule DestilaWeb.WorkflowRunnerLive do
           </div>
         </div>
       <% end %>
-
-      <script :type={Phoenix.LiveView.ColocatedHook} name=".LocalTime">
-        export default {
-          mounted() { this.format() },
-          format() {
-            const ts = this.el.dataset.ts
-            if (!ts) return
-            const d = new Date(ts)
-            if (isNaN(d.getTime())) return
-            this.el.textContent = d.toLocaleString([], {
-              month: "short",
-              day: "numeric",
-              hour: "2-digit",
-              minute: "2-digit",
-              hour12: false
-            })
-          }
-        }
-      </script>
 
       <script :type={Phoenix.LiveView.ColocatedHook} name=".MetadataSidebar">
         export default {

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -943,7 +943,13 @@ defmodule DestilaWeb.WorkflowRunnerLive do
                             phase_status={:idle}
                           />
                         </span>
-                        <span class="text-sm text-base-content/60 truncate flex-1 text-left">
+                        <span
+                          id={"ai-session-time-#{ai.id}"}
+                          phx-hook=".LocalTime"
+                          phx-update="ignore"
+                          data-ts={DateTime.to_iso8601(ai.inserted_at)}
+                          class="text-sm text-base-content/60 truncate flex-1 text-left"
+                        >
                           {format_ai_inserted_at(ai.inserted_at)}
                         </span>
                         <.icon
@@ -1171,6 +1177,25 @@ defmodule DestilaWeb.WorkflowRunnerLive do
           </div>
         </div>
       <% end %>
+
+      <script :type={Phoenix.LiveView.ColocatedHook} name=".LocalTime">
+        export default {
+          mounted() { this.format() },
+          format() {
+            const ts = this.el.dataset.ts
+            if (!ts) return
+            const d = new Date(ts)
+            if (isNaN(d.getTime())) return
+            this.el.textContent = d.toLocaleString([], {
+              month: "short",
+              day: "numeric",
+              hour: "2-digit",
+              minute: "2-digit",
+              hour12: false
+            })
+          }
+        }
+      </script>
 
       <script :type={Phoenix.LiveView.ColocatedHook} name=".MetadataSidebar">
         export default {

--- a/test/destila_web/live/ai_session_sidebar_live_test.exs
+++ b/test/destila_web/live/ai_session_sidebar_live_test.exs
@@ -94,6 +94,37 @@ defmodule DestilaWeb.AiSessionSidebarLiveTest do
       assert has_element?(view, "#ai-sessions-section")
       assert html =~ "No AI sessions yet"
     end
+
+    @tag feature: "ai_session_sidebar",
+         scenario: "AI Sessions section lists every AI session for the workflow"
+    test "rows are rendered in ascending order (oldest first)", %{conn: conn} do
+      ws = create_session()
+      ai_old = create_ai_session(ws)
+      # ensure distinct inserted_at ordering
+      Process.sleep(10)
+      ai_new = create_ai_session(ws)
+
+      {:ok, _view, html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      old_idx = :binary.match(html, "ai-session-row-#{ai_old.id}") |> elem(0)
+      new_idx = :binary.match(html, "ai-session-row-#{ai_new.id}") |> elem(0)
+
+      assert old_idx < new_idx
+    end
+
+    @tag feature: "ai_session_sidebar",
+         scenario: "AI session row displays the creation time in the browser timezone"
+    test "row includes an ISO timestamp hook for browser-local formatting", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      {:ok, view, html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      iso = DateTime.to_iso8601(ai.inserted_at)
+
+      assert has_element?(view, "#ai-session-time-#{ai.id}")
+      assert html =~ ~s|data-ts="#{iso}"|
+    end
   end
 
   describe "initial aliveness state" do


### PR DESCRIPTION
## Summary
- List AI sessions in the workflow runner right sidebar in ascending order (oldest first) by flipping the `order_by` in `AI.list_ai_sessions_for_workflow/1`.
- Render each row's timestamp in the user's browser timezone via a new colocated `.LocalTime` hook that reformats a UTC ISO `data-ts` using `toLocaleString`.
- Update the `ai_session_sidebar` feature file and add tests for ordering and the hook-bound span.

## Test plan
- [x] `mix test test/destila_web/live/ai_session_sidebar_live_test.exs`
- [x] `mix test test/destila/sessions/session_process_test.exs test/destila_web/live/ai_session_detail_live_test.exs`
- [ ] Manually open a workflow runner with multiple AI sessions and confirm oldest appears first and the timestamp matches the local clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)