### PR TITLE
feat: surface Claude token usage and cost on AI sessions

### DIFF
--- a/features/ai_session_detail.feature
+++ b/features/ai_session_detail.feature
@@ -143,3 +143,33 @@ Feature: AI Session Debug Detail Page
     When I open the AI Session Debug Detail page
     Then the page should render the block through a pre element with inspect output
     And the page should not crash
+
+  Scenario: Assistant message renders a token usage chip
+    Given the history contains an assistant message whose inner message carries a usage map
+    When I open the AI Session Debug Detail page
+    Then the assistant bubble should render a usage chip with input and output token counts
+
+  Scenario: Assistant usage chip shows cache tokens when present
+    Given the history contains an assistant message whose usage includes cache tokens
+    When I open the AI Session Debug Detail page
+    Then the usage chip should include the cache read and cache creation token counts
+
+  Scenario: Assistant message without a usage map renders no chip
+    Given the history contains an assistant message whose inner message has no usage field
+    When I open the AI Session Debug Detail page
+    Then the assistant bubble should not render a usage chip
+
+  Scenario: Header shows aggregated token and cost totals across turns
+    Given the AI session has stored per-turn usage and cost in its messages
+    When I open the AI Session Debug Detail page
+    Then the header should render a totals strip summing input/output tokens and total cost across turns
+
+  Scenario: Totals strip hides when no turns have recorded usage yet
+    Given the AI session has no messages with recorded usage
+    When I open the AI Session Debug Detail page
+    Then the header should not render the totals strip
+
+  Scenario: Totals strip updates live when a new turn is recorded
+    Given I am on the AI Session Debug Detail page
+    When a new system message with usage is inserted for this AI session
+    Then the totals strip should refresh to include the new turn without a reload

--- a/features/ai_session_sidebar.feature
+++ b/features/ai_session_sidebar.feature
@@ -57,3 +57,18 @@ Feature: AI Sessions Sidebar
     Given I am on a workflow runner page
     When the AlivenessTracker broadcasts an AI-specific aliveness change
     Then the workflow-level header aliveness dot should remain unchanged
+
+  Scenario: AI session row shows a usage subtitle with turns, cost, and duration
+    Given the workflow session has one AI session whose messages carry recorded usage and cost
+    When I open the workflow runner page
+    Then the row should render a subtitle with the turn count, total cost, and total duration
+
+  Scenario: AI session row without recorded usage hides the subtitle
+    Given the workflow session has one AI session with no messages carrying usage
+    When I open the workflow runner page
+    Then the row should not render a usage subtitle
+
+  Scenario: Usage subtitle refreshes live when a new turn is recorded
+    Given I am on a workflow runner page showing an AI session with no recorded usage
+    When a new system message with usage is inserted for that AI session
+    Then the row's usage subtitle should appear without a reload

--- a/lib/destila/ai.ex
+++ b/lib/destila/ai.ex
@@ -79,6 +79,74 @@ defmodule Destila.AI do
     )
   end
 
+  def list_messages_for_ai_session(ai_session_id) do
+    Repo.all(
+      from(m in Message,
+        where: m.ai_session_id == ^ai_session_id,
+        order_by: m.inserted_at
+      )
+    )
+  end
+
+  @doc """
+  Sums per-turn usage and cost from the stored `raw_response` maps of all
+  system (assistant) messages for an AI session.
+
+  Returns a map with integer token counts, float `total_cost_usd`, float
+  `duration_ms`, and a `turns` count (number of turns that contributed usage).
+  Returns zeros when no usage has been recorded yet.
+  """
+  def aggregate_usage_for_ai_session(ai_session_id) do
+    ai_session_id
+    |> list_messages_for_ai_session()
+    |> Enum.reduce(empty_usage_totals(), &add_message_usage/2)
+  end
+
+  defp empty_usage_totals do
+    %{
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      total_cost_usd: 0.0,
+      duration_ms: 0.0,
+      turns: 0
+    }
+  end
+
+  defp add_message_usage(%Message{raw_response: raw}, acc) when is_map(raw) do
+    usage = Map.get(raw, "usage") || %{}
+
+    %{
+      input_tokens: acc.input_tokens + read_int(usage, "input_tokens"),
+      output_tokens: acc.output_tokens + read_int(usage, "output_tokens"),
+      cache_read_input_tokens:
+        acc.cache_read_input_tokens + read_int(usage, "cache_read_input_tokens"),
+      cache_creation_input_tokens:
+        acc.cache_creation_input_tokens + read_int(usage, "cache_creation_input_tokens"),
+      total_cost_usd: acc.total_cost_usd + read_float(raw, "total_cost_usd"),
+      duration_ms: acc.duration_ms + read_float(raw, "duration_ms"),
+      turns: acc.turns + if(usage == %{}, do: 0, else: 1)
+    }
+  end
+
+  defp add_message_usage(_msg, acc), do: acc
+
+  defp read_int(map, key) do
+    case Map.get(map, key) do
+      n when is_integer(n) -> n
+      _ -> 0
+    end
+  end
+
+  defp read_float(map, key) do
+    case Map.get(map, key) do
+      n when is_float(n) -> n
+      n when is_integer(n) -> n * 1.0
+      _ -> 0.0
+    end
+  end
+
   def create_message(ai_session_id, attrs) do
     attrs =
       attrs

--- a/lib/destila/ai/claude_session.ex
+++ b/lib/destila/ai/claude_session.ex
@@ -255,7 +255,14 @@ defmodule Destila.AI.ClaudeSession do
       session_id: nil,
       subtype: nil,
       errors: nil,
-      auth_error: nil
+      auth_error: nil,
+      usage: nil,
+      model_usage: nil,
+      total_cost_usd: nil,
+      duration_ms: nil,
+      duration_api_ms: nil,
+      num_turns: nil,
+      stop_reason: nil
     }
 
     acc =
@@ -279,7 +286,14 @@ defmodule Destila.AI.ClaudeSession do
                 is_error: msg.is_error,
                 session_id: msg.session_id,
                 subtype: msg.subtype,
-                errors: msg.errors
+                errors: msg.errors,
+                usage: msg.usage,
+                model_usage: msg.model_usage,
+                total_cost_usd: msg.total_cost_usd,
+                duration_ms: msg.duration_ms,
+                duration_api_ms: msg.duration_api_ms,
+                num_turns: msg.num_turns,
+                stop_reason: msg.stop_reason
             }
 
           %ClaudeCode.Message.AuthStatusMessage{error: error} when is_binary(error) ->
@@ -298,7 +312,14 @@ defmodule Destila.AI.ClaudeSession do
       subtype: acc.subtype,
       errors: acc.errors,
       auth_error: acc.auth_error,
-      mcp_tool_uses: Enum.reverse(acc.mcp_tool_uses)
+      mcp_tool_uses: Enum.reverse(acc.mcp_tool_uses),
+      usage: acc.usage,
+      model_usage: acc.model_usage,
+      total_cost_usd: acc.total_cost_usd,
+      duration_ms: acc.duration_ms,
+      duration_api_ms: acc.duration_api_ms,
+      num_turns: acc.num_turns,
+      stop_reason: acc.stop_reason
     }
   end
 

--- a/lib/destila_web/components/ai_session_debug_components.ex
+++ b/lib/destila_web/components/ai_session_debug_components.ex
@@ -72,6 +72,7 @@ defmodule DestilaWeb.AiSessionDebugComponents do
       assigns
       |> assign(:msg, msg)
       |> assign(:content, extract_content(msg.message))
+      |> assign(:usage, extract_usage(msg.message))
 
     ~H"""
     <div
@@ -80,7 +81,7 @@ defmodule DestilaWeb.AiSessionDebugComponents do
       data-message-uuid={@msg.uuid}
       class="rounded-lg border border-base-300 bg-base-100 px-4 py-3"
     >
-      <.role_header role="assistant" />
+      <.role_header role="assistant" usage={@usage} />
       <.content_list content={@content} tool_index={@tool_index} idx={@idx} />
     </div>
     """
@@ -248,6 +249,7 @@ defmodule DestilaWeb.AiSessionDebugComponents do
   end
 
   attr :role, :string, required: true
+  attr :usage, :any, default: nil
 
   defp role_header(assigns) do
     ~H"""
@@ -258,9 +260,50 @@ defmodule DestilaWeb.AiSessionDebugComponents do
       ]}>
         {@role}
       </span>
+      <.usage_chip :if={@usage} usage={@usage} />
     </div>
     """
   end
+
+  attr :usage, :map, required: true
+
+  defp usage_chip(assigns) do
+    ~H"""
+    <span
+      data-usage
+      class="ml-auto inline-flex items-center gap-1.5 rounded-full border border-base-300 bg-base-200/60 px-2 py-0.5 text-[10px] font-mono text-base-content/60"
+      title={usage_tooltip(@usage)}
+    >
+      <.icon name="hero-bolt-micro" class="size-3 text-base-content/40" />
+      <span data-usage-in>in {format_int(@usage.input_tokens)}</span>
+      <span class="text-base-content/30">·</span>
+      <span data-usage-out>out {format_int(@usage.output_tokens)}</span>
+      <%= if @usage.cache_read_input_tokens > 0 or @usage.cache_creation_input_tokens > 0 do %>
+        <span class="text-base-content/30">·</span>
+        <span data-usage-cache>
+          cache {format_int(@usage.cache_read_input_tokens)}/{format_int(
+            @usage.cache_creation_input_tokens
+          )}
+        </span>
+      <% end %>
+    </span>
+    """
+  end
+
+  defp usage_tooltip(usage) do
+    [
+      "input: #{usage.input_tokens}",
+      "output: #{usage.output_tokens}",
+      "cache read: #{usage.cache_read_input_tokens}",
+      "cache write: #{usage.cache_creation_input_tokens}",
+      usage.service_tier && "tier: #{usage.service_tier}"
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" · ")
+  end
+
+  defp format_int(n) when is_integer(n), do: Integer.to_string(n)
+  defp format_int(_), do: "0"
 
   defp role_color("user"), do: "text-primary"
   defp role_color("assistant"), do: "text-base-content/60"
@@ -664,6 +707,10 @@ defmodule DestilaWeb.AiSessionDebugComponents do
   defp extract_content(%{content: content}), do: content
   defp extract_content(%{"content" => content}), do: content
   defp extract_content(_), do: []
+
+  defp extract_usage(%{usage: %{input_tokens: _} = usage}), do: usage
+  defp extract_usage(%{"usage" => %{} = raw}), do: ClaudeCode.Usage.parse(raw)
+  defp extract_usage(_), do: nil
 
   defp render_tool_result_content(content) when is_binary(content), do: content
 

--- a/lib/destila_web/live/ai_session_detail_live.ex
+++ b/lib/destila_web/live/ai_session_detail_live.ex
@@ -57,6 +57,7 @@ defmodule DestilaWeb.AiSessionDetailLive do
     if connected?(socket) do
       Phoenix.PubSub.subscribe(Destila.PubSub, AlivenessTracker.topic())
       Phoenix.PubSub.subscribe(Destila.PubSub, PubSubHelper.ai_stream_topic(ws.id))
+      Phoenix.PubSub.subscribe(Destila.PubSub, "store:updates")
     end
 
     {history_state, loaded_count} = load_history(ai_session)
@@ -69,6 +70,7 @@ defmodule DestilaWeb.AiSessionDetailLive do
      |> assign(:history_state, history_state)
      |> assign(:loaded_count, loaded_count)
      |> assign(:reload_scheduled?, false)
+     |> assign(:usage_totals, AI.aggregate_usage_for_ai_session(ai_session.id))
      |> assign(:page_title, "AI Session — #{ws.title}")}
   end
 
@@ -87,6 +89,14 @@ defmodule DestilaWeb.AiSessionDetailLive do
 
   def handle_info(:reload_history, socket) do
     {:noreply, refresh_history(socket)}
+  end
+
+  def handle_info({:message_added, %Destila.AI.Message{ai_session_id: ai_id}}, socket) do
+    if socket.assigns.ai_session.id == ai_id do
+      {:noreply, assign(socket, :usage_totals, AI.aggregate_usage_for_ai_session(ai_id))}
+    else
+      {:noreply, socket}
+    end
   end
 
   def handle_info(_msg, socket), do: {:noreply, socket}
@@ -231,6 +241,7 @@ defmodule DestilaWeb.AiSessionDetailLive do
             >
               {@ai_session.claude_session_id}
             </code>
+            <.usage_totals_strip :if={@usage_totals.turns > 0} totals={@usage_totals} />
           </div>
         </div>
 
@@ -284,4 +295,51 @@ defmodule DestilaWeb.AiSessionDetailLive do
   end
 
   defp format_inserted_at(_), do: ""
+
+  attr :totals, :map, required: true
+
+  defp usage_totals_strip(assigns) do
+    ~H"""
+    <span
+      id="ai-session-usage-totals"
+      data-usage-totals
+      class="ml-auto inline-flex items-center gap-1.5 rounded-full border border-base-300 bg-base-200/60 px-2 py-0.5 text-[10px] font-mono text-base-content/60 shrink-0"
+      title={usage_totals_tooltip(@totals)}
+    >
+      <.icon name="hero-chart-bar-micro" class="size-3 text-base-content/40" />
+      <span data-totals-turns>{@totals.turns} {pluralize(@totals.turns, "turn", "turns")}</span>
+      <span class="text-base-content/30">·</span>
+      <span data-totals-in>in {@totals.input_tokens}</span>
+      <span class="text-base-content/30">·</span>
+      <span data-totals-out>out {@totals.output_tokens}</span>
+      <span :if={@totals.total_cost_usd > 0} class="text-base-content/30">·</span>
+      <span :if={@totals.total_cost_usd > 0} data-totals-cost>
+        {format_cost(@totals.total_cost_usd)}
+      </span>
+    </span>
+    """
+  end
+
+  defp usage_totals_tooltip(totals) do
+    [
+      "turns: #{totals.turns}",
+      "input: #{totals.input_tokens}",
+      "output: #{totals.output_tokens}",
+      "cache read: #{totals.cache_read_input_tokens}",
+      "cache write: #{totals.cache_creation_input_tokens}",
+      "cost: #{format_cost(totals.total_cost_usd)}",
+      "duration: #{Float.round(totals.duration_ms / 1000, 2)}s"
+    ]
+    |> Enum.join(" · ")
+  end
+
+  defp format_cost(usd) when is_float(usd) do
+    :erlang.float_to_binary(usd, decimals: 4)
+    |> then(&("$" <> &1))
+  end
+
+  defp format_cost(_), do: "$0.0000"
+
+  defp pluralize(1, singular, _plural), do: singular
+  defp pluralize(_, _singular, plural), do: plural
 end

--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -541,6 +541,26 @@ defmodule DestilaWeb.WorkflowRunnerLive do
     end
   end
 
+  def handle_info({:message_added, %Destila.AI.Message{ai_session_id: ai_id} = msg}, socket) do
+    ws = socket.assigns[:workflow_session]
+    totals = socket.assigns[:ai_sessions_totals] || %{}
+
+    cond do
+      is_nil(ws) ->
+        {:noreply, socket}
+
+      msg.workflow_session_id != ws.id ->
+        {:noreply, socket}
+
+      not Map.has_key?(totals, ai_id) ->
+        {:noreply, socket}
+
+      true ->
+        updated = Map.put(totals, ai_id, AI.aggregate_usage_for_ai_session(ai_id))
+        {:noreply, assign(socket, :ai_sessions_totals, updated)}
+    end
+  end
+
   def handle_info(_msg, socket), do: {:noreply, socket}
 
   defp extract_intermediate_text(%ClaudeCode.Message.AssistantMessage{message: message}) do
@@ -577,9 +597,13 @@ defmodule DestilaWeb.WorkflowRunnerLive do
     ai_sessions_alive =
       Map.new(ai_sessions, fn ai -> {ai.id, AlivenessTracker.alive_ai?(ai.id)} end)
 
+    ai_sessions_totals =
+      Map.new(ai_sessions, fn ai -> {ai.id, AI.aggregate_usage_for_ai_session(ai.id)} end)
+
     socket
     |> assign(:ai_sessions, ai_sessions)
     |> assign(:ai_sessions_alive, ai_sessions_alive)
+    |> assign(:ai_sessions_totals, ai_sessions_totals)
   end
 
   defp compute_current_step(ws, phase_status, messages) do
@@ -966,7 +990,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
                         :for={ai <- @ai_sessions}
                         id={"ai-session-row-#{ai.id}"}
                         navigate={~p"/sessions/#{@workflow_session.id}/ai/#{ai.id}"}
-                        class="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-md hover:bg-base-200/60 transition-colors duration-150 group"
+                        class="w-full flex items-start gap-2.5 px-2 py-1.5 rounded-md hover:bg-base-200/60 transition-colors duration-150 group"
                         aria-label={"Open AI session from #{format_ai_inserted_at(ai.inserted_at)}"}
                       >
                         <span class="size-5 rounded flex items-center justify-center shrink-0">
@@ -976,18 +1000,24 @@ defmodule DestilaWeb.WorkflowRunnerLive do
                             phase_status={:idle}
                           />
                         </span>
-                        <span
-                          id={"ai-session-time-#{ai.id}"}
-                          phx-hook="LocalTime"
-                          phx-update="ignore"
-                          data-ts={DateTime.to_iso8601(ai.inserted_at)}
-                          class="text-sm text-base-content/60 truncate flex-1 text-left"
-                        >
-                          {format_ai_inserted_at(ai.inserted_at)}
-                        </span>
+                        <div class="flex-1 min-w-0 text-left">
+                          <span
+                            id={"ai-session-time-#{ai.id}"}
+                            phx-hook="LocalTime"
+                            phx-update="ignore"
+                            data-ts={DateTime.to_iso8601(ai.inserted_at)}
+                            class="text-sm text-base-content/60 truncate block"
+                          >
+                            {format_ai_inserted_at(ai.inserted_at)}
+                          </span>
+                          <.ai_session_usage_subtitle
+                            ai_id={ai.id}
+                            totals={Map.get(@ai_sessions_totals, ai.id)}
+                          />
+                        </div>
                         <.icon
                           name="hero-chevron-right-micro"
-                          class="size-3.5 text-base-content/30 group-hover:text-primary transition-colors"
+                          class="size-3.5 text-base-content/30 group-hover:text-primary transition-colors mt-1"
                         />
                       </.link>
                     </div>
@@ -1353,6 +1383,49 @@ defmodule DestilaWeb.WorkflowRunnerLive do
   end
 
   defp format_ai_inserted_at(_), do: ""
+
+  attr :ai_id, :string, required: true
+  attr :totals, :map, default: nil
+
+  defp ai_session_usage_subtitle(assigns) do
+    ~H"""
+    <span
+      :if={@totals && @totals.turns > 0}
+      id={"ai-session-usage-#{@ai_id}"}
+      data-usage-subtitle
+      class="text-[11px] font-mono text-base-content/40 truncate block"
+    >
+      <span data-subtitle-turns>{@totals.turns} {pluralize_turns(@totals.turns)}</span>
+      <span class="text-base-content/25">·</span>
+      <span data-subtitle-cost>{format_cost(@totals.total_cost_usd)}</span>
+      <span class="text-base-content/25">·</span>
+      <span data-subtitle-duration>{format_duration(@totals.duration_ms)}</span>
+    </span>
+    """
+  end
+
+  defp pluralize_turns(1), do: "turn"
+  defp pluralize_turns(_), do: "turns"
+
+  defp format_cost(usd) when is_float(usd) do
+    :erlang.float_to_binary(usd, decimals: 4)
+    |> then(&("$" <> &1))
+  end
+
+  defp format_cost(_), do: "$0.0000"
+
+  defp format_duration(ms) when is_number(ms) and ms >= 0 do
+    seconds = ms / 1000
+
+    cond do
+      seconds < 10 -> "#{Float.round(seconds, 1)}s"
+      seconds < 60 -> "#{round(seconds)}s"
+      seconds < 3600 -> "#{div(round(seconds), 60)}m #{rem(round(seconds), 60)}s"
+      true -> "#{div(round(seconds), 3600)}h #{div(rem(round(seconds), 3600), 60)}m"
+    end
+  end
+
+  defp format_duration(_), do: "0s"
 
   defp post_delete_redirect(session, session_id) do
     case local_path(Map.get(session, "session_detail_referer")) do

--- a/test/destila_web/live/ai_session_detail_live_test.exs
+++ b/test/destila_web/live/ai_session_detail_live_test.exs
@@ -712,4 +712,160 @@ defmodule DestilaWeb.AiSessionDetailLiveTest do
       assert html =~ "NotARealBlock"
     end
   end
+
+  describe "assistant usage chip" do
+    defp assistant_message_with_usage(content_blocks, usage) do
+      %SessionMessage{
+        type: :assistant,
+        uuid: Ecto.UUID.generate(),
+        session_id: "test-session",
+        message: %{content: content_blocks, usage: usage},
+        parent_tool_use_id: nil
+      }
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Assistant message renders a token usage chip"
+    test "renders usage chip with input and output token counts", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      usage = ClaudeCode.Usage.parse(%{"input_tokens" => 123, "output_tokens" => 45})
+
+      messages = [
+        assistant_message_with_usage(
+          [%TextBlock{type: "text", text: "hello"}],
+          usage
+        )
+      ]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      assert has_element?(view, ~s|[data-message-role="assistant"] [data-usage]|)
+      assert has_element?(view, "[data-usage-in]", "in 123")
+      assert has_element?(view, "[data-usage-out]", "out 45")
+      refute has_element?(view, "[data-usage-cache]")
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Assistant usage chip shows cache tokens when present"
+    test "includes cache read and cache creation counts when non-zero", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      usage =
+        ClaudeCode.Usage.parse(%{
+          "input_tokens" => 10,
+          "output_tokens" => 20,
+          "cache_read_input_tokens" => 7,
+          "cache_creation_input_tokens" => 3
+        })
+
+      messages = [
+        assistant_message_with_usage(
+          [%TextBlock{type: "text", text: "hi"}],
+          usage
+        )
+      ]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      assert has_element?(view, "[data-usage-cache]", "cache 7/3")
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Assistant message without a usage map renders no chip"
+    test "renders no chip when usage is absent", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      messages = [assistant_message([%TextBlock{type: "text", text: "no usage"}])]
+
+      FakeHistory.stub(ai.claude_session_id, {:ok, messages})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      refute has_element?(view, ~s|[data-message-role="assistant"] [data-usage]|)
+    end
+  end
+
+  describe "usage totals strip" do
+    defp insert_system_message_with_usage(ai, ws, raw) do
+      {:ok, msg} =
+        AI.create_message(ai.id, %{
+          role: :system,
+          content: "ok",
+          workflow_session_id: ws.id,
+          raw_response: raw
+        })
+
+      msg
+    end
+
+    defp usage_raw(input, output, opts) do
+      %{
+        usage: %{
+          input_tokens: input,
+          output_tokens: output,
+          cache_read_input_tokens: Keyword.get(opts, :cache_read, 0),
+          cache_creation_input_tokens: Keyword.get(opts, :cache_creation, 0)
+        },
+        total_cost_usd: Keyword.get(opts, :cost, 0.0),
+        duration_ms: Keyword.get(opts, :duration, 0.0)
+      }
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Header shows aggregated token and cost totals across turns"
+    test "aggregates input/output tokens and cost from all system messages", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+      FakeHistory.stub(ai.claude_session_id, {:ok, []})
+
+      insert_system_message_with_usage(ai, ws, usage_raw(100, 50, cost: 0.002))
+      insert_system_message_with_usage(ai, ws, usage_raw(40, 10, cost: 0.001))
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      assert has_element?(view, "#ai-session-usage-totals")
+      assert has_element?(view, "[data-totals-turns]", "2 turns")
+      assert has_element?(view, "[data-totals-in]", "in 140")
+      assert has_element?(view, "[data-totals-out]", "out 60")
+      assert has_element?(view, "[data-totals-cost]", "$0.0030")
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Totals strip hides when no turns have recorded usage yet"
+    test "omits totals strip when no messages have recorded usage", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+      FakeHistory.stub(ai.claude_session_id, {:ok, []})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+
+      refute has_element?(view, "#ai-session-usage-totals")
+    end
+
+    @tag feature: "ai_session_detail",
+         scenario: "Totals strip updates live when a new turn is recorded"
+    test "refreshes totals when a new system message is broadcast", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+      FakeHistory.stub(ai.claude_session_id, {:ok, []})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}/ai/#{ai.id}")
+      refute has_element?(view, "#ai-session-usage-totals")
+
+      insert_system_message_with_usage(ai, ws, usage_raw(10, 5, cost: 0.0005))
+
+      assert has_element?(view, "#ai-session-usage-totals")
+      assert has_element?(view, "[data-totals-in]", "in 10")
+      assert has_element?(view, "[data-totals-out]", "out 5")
+      assert has_element?(view, "[data-totals-cost]", "$0.0005")
+    end
+  end
 end

--- a/test/destila_web/live/ai_session_sidebar_live_test.exs
+++ b/test/destila_web/live/ai_session_sidebar_live_test.exs
@@ -241,4 +241,78 @@ defmodule DestilaWeb.AiSessionSidebarLiveTest do
       assert render(view) =~ "ai-sessions-section"
     end
   end
+
+  describe "usage subtitle" do
+    defp create_usage_message(ws, ai, overrides \\ %{}) do
+      raw =
+        Map.merge(
+          %{
+            "usage" => %{
+              "input_tokens" => 120,
+              "output_tokens" => 80,
+              "cache_read_input_tokens" => 0,
+              "cache_creation_input_tokens" => 0
+            },
+            "total_cost_usd" => 0.0123,
+            "duration_ms" => 4200.0
+          },
+          overrides
+        )
+
+      {:ok, msg} =
+        AI.create_message(ai.id, %{
+          workflow_session_id: ws.id,
+          role: :system,
+          content: "",
+          raw_response: raw,
+          phase: 1
+        })
+
+      msg
+    end
+
+    @tag feature: "ai_session_sidebar",
+         scenario: "AI session row shows a usage subtitle with turns, cost, and duration"
+    test "row renders a subtitle with turn count, cost, and duration", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+      _ = create_usage_message(ws, ai)
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      assert has_element?(view, "#ai-session-usage-#{ai.id}")
+      assert has_element?(view, "#ai-session-usage-#{ai.id} [data-subtitle-turns]", "1 turn")
+      assert has_element?(view, "#ai-session-usage-#{ai.id} [data-subtitle-cost]", "$0.0123")
+      assert has_element?(view, "#ai-session-usage-#{ai.id} [data-subtitle-duration]", "4.2s")
+    end
+
+    @tag feature: "ai_session_sidebar",
+         scenario: "AI session row without recorded usage hides the subtitle"
+    test "row without usage does not render a subtitle", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      assert has_element?(view, "#ai-session-row-#{ai.id}")
+      refute has_element?(view, "#ai-session-usage-#{ai.id}")
+    end
+
+    @tag feature: "ai_session_sidebar",
+         scenario: "Usage subtitle refreshes live when a new turn is recorded"
+    test "subtitle appears live after a new system message is inserted", %{conn: conn} do
+      ws = create_session()
+      ai = create_ai_session(ws)
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{ws.id}")
+
+      refute has_element?(view, "#ai-session-usage-#{ai.id}")
+
+      _ = create_usage_message(ws, ai)
+      _ = render(view)
+
+      assert has_element?(view, "#ai-session-usage-#{ai.id}")
+      assert has_element?(view, "#ai-session-usage-#{ai.id} [data-subtitle-turns]", "1 turn")
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Extend `Destila.AI.ClaudeSession.collect_with_mcp_and_broadcast/2` to capture `usage`, `model_usage`, `total_cost_usd`, `duration_ms`, `duration_api_ms`, `num_turns`, and `stop_reason` from each stream's `%ClaudeCode.Message.ResultMessage{}`, so those stats now land in `messages.raw_response`.
- Add `Destila.AI.aggregate_usage_for_ai_session/1` that sums input/output/cache tokens, cost, and duration across an AI session's stored turns.
- Render per-assistant-message token chips (pulled from transcript `usage` entries) and a live-updating aggregate totals strip in the AI Session Debug Detail page header, refreshing via the existing `"store:updates"` PubSub when a new turn is inserted.
- Expand AI Sessions rows in the workflow runner right sidebar into a two-line card with a `{turns} turns · {cost} · {duration}` subtitle that updates live when new turns are recorded.

## Test plan
- [x] `mix test test/destila_web/live/ai_session_detail_live_test.exs` — passes with new scenarios for per-message chips and aggregate totals
- [x] `mix test test/destila_web/live/ai_session_sidebar_live_test.exs` — 14 tests, 0 failures (includes 3 new scenarios for usage subtitle rendering and live refresh)
- [x] `mix precommit` — 454 tests, 0 failures
- [x] Manual: open `/sessions/:ws_id/ai/:ai_id` for a session with recorded turns; confirm usage chip per assistant bubble and header totals strip showing `N turns · in X · out Y · $Z.ZZZZ`
- [x] Manual: open `/sessions/:ws_id` and confirm each AI Sessions row shows a `{turns} turns · {cost} · {duration}` subtitle, and that it refreshes without a reload as a new turn completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)