### PR TITLE
feat: drafts board for capturing ideas before launch

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,6 +26,7 @@ import {hooks as colocatedHooks} from "phoenix-colocated/destila"
 import topbar from "../vendor/topbar"
 import TerminalPanel from "./hooks/terminal_panel"
 import LocalTime from "./hooks/local_time"
+import DraftsBoard from "./hooks/drafts_board"
 
 const ScrollBottomHook = {
   mounted() { this.el.scrollTop = this.el.scrollHeight },
@@ -62,6 +63,7 @@ const Hooks = {
   AutoDismiss: AutoDismissHook,
   TerminalPanel: TerminalPanel,
   LocalTime: LocalTime,
+  DraftsBoard: DraftsBoard,
 }
 
 const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")

--- a/assets/js/hooks/drafts_board.js
+++ b/assets/js/hooks/drafts_board.js
@@ -1,0 +1,99 @@
+// DraftsBoard hook — native HTML5 drag-and-drop across priority columns.
+//
+// Mounted on each column element (`#column-<priority>`). Uses `dragstart`,
+// `dragover`, `drop`, and `dragend` to reorder draft cards and push a
+// `reorder_draft` event to the server with the moved draft's id, its new
+// priority, and the ids of its new neighbors (before/after).
+
+const ITEM_SELECTOR = "[data-draft-id]"
+
+const DraftsBoard = {
+  mounted() {
+    this.priority = this.el.dataset.priority
+    this.onDragStart = this.handleDragStart.bind(this)
+    this.onDragOver = this.handleDragOver.bind(this)
+    this.onDragLeave = this.handleDragLeave.bind(this)
+    this.onDrop = this.handleDrop.bind(this)
+    this.onDragEnd = this.handleDragEnd.bind(this)
+
+    this.el.addEventListener("dragstart", this.onDragStart)
+    this.el.addEventListener("dragover", this.onDragOver)
+    this.el.addEventListener("dragleave", this.onDragLeave)
+    this.el.addEventListener("drop", this.onDrop)
+    this.el.addEventListener("dragend", this.onDragEnd)
+  },
+
+  destroyed() {
+    this.el.removeEventListener("dragstart", this.onDragStart)
+    this.el.removeEventListener("dragover", this.onDragOver)
+    this.el.removeEventListener("dragleave", this.onDragLeave)
+    this.el.removeEventListener("drop", this.onDrop)
+    this.el.removeEventListener("dragend", this.onDragEnd)
+  },
+
+  handleDragStart(event) {
+    const card = event.target.closest(ITEM_SELECTOR)
+    if (!card) return
+    event.dataTransfer.effectAllowed = "move"
+    event.dataTransfer.setData("text/plain", card.dataset.draftId)
+    card.classList.add("opacity-40")
+    window.__draftsBoardDraggingId = card.dataset.draftId
+  },
+
+  handleDragOver(event) {
+    event.preventDefault()
+    event.dataTransfer.dropEffect = "move"
+    this.el.classList.add("ring-2", "ring-primary/40")
+  },
+
+  handleDragLeave(event) {
+    if (event.target === this.el) {
+      this.el.classList.remove("ring-2", "ring-primary/40")
+    }
+  },
+
+  handleDrop(event) {
+    event.preventDefault()
+    this.el.classList.remove("ring-2", "ring-primary/40")
+
+    const draftId =
+      event.dataTransfer.getData("text/plain") ||
+      window.__draftsBoardDraggingId
+
+    if (!draftId) return
+
+    const cards = Array.from(this.el.querySelectorAll(ITEM_SELECTOR))
+      .filter((c) => c.dataset.draftId !== draftId)
+
+    const y = event.clientY
+    let beforeId = null
+    let afterId = null
+
+    for (const card of cards) {
+      const rect = card.getBoundingClientRect()
+      const midpoint = rect.top + rect.height / 2
+      if (y < midpoint) {
+        afterId = card.dataset.draftId
+        break
+      } else {
+        beforeId = card.dataset.draftId
+      }
+    }
+
+    this.pushEvent("reorder_draft", {
+      draft_id: draftId,
+      priority: this.priority,
+      before_id: beforeId,
+      after_id: afterId,
+    })
+  },
+
+  handleDragEnd() {
+    this.el.classList.remove("ring-2", "ring-primary/40")
+    const card = this.el.querySelector(".opacity-40")
+    if (card) card.classList.remove("opacity-40")
+    window.__draftsBoardDraggingId = null
+  },
+}
+
+export default DraftsBoard

--- a/assets/js/hooks/drafts_board.js
+++ b/assets/js/hooks/drafts_board.js
@@ -37,7 +37,7 @@ const DraftsBoard = {
     event.dataTransfer.effectAllowed = "move"
     event.dataTransfer.setData("text/plain", card.dataset.draftId)
     card.classList.add("opacity-40")
-    window.__draftsBoardDraggingId = card.dataset.draftId
+    DraftsBoard._draggingId = card.dataset.draftId
   },
 
   handleDragOver(event) {
@@ -58,7 +58,7 @@ const DraftsBoard = {
 
     const draftId =
       event.dataTransfer.getData("text/plain") ||
-      window.__draftsBoardDraggingId
+      DraftsBoard._draggingId
 
     if (!draftId) return
 
@@ -92,7 +92,7 @@ const DraftsBoard = {
     this.el.classList.remove("ring-2", "ring-primary/40")
     const card = this.el.querySelector(".opacity-40")
     if (card) card.classList.remove("opacity-40")
-    window.__draftsBoardDraggingId = null
+    DraftsBoard._draggingId = null
   },
 }
 

--- a/docs/plans/2026-04-18-001-feat-drafts-board-plan.md
+++ b/docs/plans/2026-04-18-001-feat-drafts-board-plan.md
@@ -1,0 +1,561 @@
+---
+title: "feat: Drafts Board"
+type: feat
+status: active
+date: 2026-04-18
+---
+
+# feat: Drafts Board
+
+## Overview
+
+Add a "Draft" concept to destila: a lightweight pairing of a prompt + project + priority that lives on a top-level kanban-style board at `/drafts` with three priority columns (High, Medium, Low). Drafts capture ideas before they become real workflow sessions. From a draft's detail page the user can edit it, drag-reorder within/across priority columns, discard (soft archive), or launch a workflow that bypasses the existing prompt + project selection form and navigates straight to the workflow runner, archiving the originating draft on success.
+
+This feature introduces a new domain context, two LiveViews, a drag-and-drop hook, and a bypass seam in `DestilaWeb.CreateSessionLive`. It mirrors the soft-archive pattern used by `Destila.Projects` and the stream-based list pattern used by `DestilaWeb.ProjectsLive`.
+
+## Problem Frame
+
+Today, the only way to capture an idea in destila is to start a full workflow session. That forces a user to commit to a prompt, pick a project, and pick a workflow type all at once — making the "collect loose ideas and sort them by priority later" workflow awkward. A drafts board lets users queue up thoughts, rank them by priority, and defer the commitment to a workflow type until they're ready to actually work on an idea.
+
+## Requirements Trace
+
+- **R1.** Board at `/drafts` renders three priority columns (High, Medium, Low), each listing its drafts; each card shows the (truncated) prompt only.
+- **R2.** Left navigation gets a "Drafts" entry peer to the "Crafting Board" entry.
+- **R3.** Users can create a draft from the board via "New Draft"; prompt, project, and priority are all required — priority has no default.
+- **R4.** Users can open a draft's detail/edit page to view and update prompt, project, and priority; saving persists changes and (if priority changed) moves the card to the matching column.
+- **R5.** Users can drag a card within a column to reorder it, or across columns to change its priority; order is preserved across reloads.
+- **R6.** "Discard" on the detail page soft-archives the draft, returns to the board, and hides the draft from every UI path (no archive view, no restore).
+- **R7.** "Start workflow" on the detail page navigates to the workflow type picker; selecting a type creates the workflow session using the draft's prompt + project, archives the draft, and navigates directly to the workflow runner — no flash of the prompt+project form.
+- **R8.** A draft may reference a project that was later archived; listing, cards, and detail pages must continue to render without crashing, surfacing the archived state.
+- **R9.** Archive only happens on successful workflow session creation; a failed launch must leave the draft intact.
+- **R10.** BDD coverage: add `features/drafts_board.feature` with the scenarios from the brief; every test carries `@tag feature: "drafts_board", scenario: "..."`.
+- **R11.** `mix precommit` passes before landing.
+
+## Scope Boundaries
+
+**In scope:**
+- New `Destila.Drafts` context + `Destila.Drafts.Draft` schema + `drafts` table migration.
+- `DestilaWeb.DraftsBoardLive` (board), `DestilaWeb.DraftFormLive` (new/edit/detail unified).
+- Drag-and-drop via a new external `phx-hook` using native HTML5 DnD; no new npm dependency.
+- Extending `DestilaWeb.CreateSessionLive` with a `draft_id` query-param bypass.
+- Sidebar navigation entry in `DestilaWeb.Layouts`.
+- Gherkin scenarios in `features/drafts_board.feature` and tests in `test/destila/` + `test/destila_web/live/`.
+
+**Explicit non-goals:**
+- No archived-drafts page, restore flow, or archive filter UI anywhere.
+- No back-link from a launched workflow session to its originating draft.
+- No default priority — the user must pick one.
+- No separate title/notes/description field — the card surface shows the prompt only.
+- No SortableJS or other DnD library dependency.
+- No workflow_type field on the draft itself — the workflow type is still chosen when launching.
+- No new permissions or access control layer (destila has no auth; see `docs/plans/2026-04-09-refactor-remove-user-auth-plan.md`).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Soft-archive pattern** — mirror `lib/destila/projects.ex` and `lib/destila/projects/project.ex`: `field :archived_at, :utc_datetime`; list queries filter `is_nil(archived_at)`; `archive_*` sets `DateTime.utc_now()`; every mutation ends with `|> broadcast(:event_name)` via `Destila.PubSubHelper`.
+- **Archive migration shape** — `priv/repo/migrations/20260415000000_add_archived_at_to_projects.exs` shows `add :archived_at, :utc_datetime` + `create index(:drafts, [:archived_at])`.
+- **Binary_id + FK conventions** — `lib/destila/projects/project.ex` (`@primary_key {:id, :binary_id, autogenerate: true}`, `@foreign_key_type :binary_id`) and `priv/repo/migrations/20260324111938_create_projects_workflow_sessions_messages.exs` (`references(:projects, type: :binary_id, on_delete: :restrict)`).
+- **Stream-based list LiveView** — `lib/destila_web/live/projects_live.ex` demonstrates `stream(:name, list)`, `assign(:empty?, list == [])`, PubSub subscription to `"store:updates"`, re-stream with `reset: true` on updates, inline edit via `stream_insert`, and the empty-state `hidden only:block` trick inside `phx-update="stream"`.
+- **Form LiveComponent + reuse of project selector** — `lib/destila_web/live/project_form_live.ex` and `lib/destila_web/components/project_components.ex` (`project_selector/1`). The project selector supports both inline-create and selection, emits `select_project`/`show_create_project`/`back_to_select` events, and `send(self(), {:project_saved, project})` back to the parent.
+- **Bypass seam in CreateSessionLive** — `lib/destila_web/live/create_session_live.ex:12-18` dispatches on `Map.has_key?(params, "workflow_type")`; line 167 (`~p"/workflows/#{wf.type}"`) is where `draft_id` must be propagated. `Destila.Workflows.create_workflow_session/1` at `lib/destila/workflows.ex:92` accepts `%{workflow_type, input_text, project_id}` — exactly the data a draft carries.
+- **Sidebar nav** — `lib/destila_web/components/layouts.ex:44-65`, using `<.sidebar_item navigate={} icon={} label={} active={@page_title == "..."} />`. Add the drafts entry between "Crafting Board" and "Projects".
+- **Router conventions** — `lib/destila_web/router.ex:37-50` scope `"/" , DestilaWeb`; `live "/drafts", DraftsBoardLive` (and siblings) slot in alongside `live "/crafting", CraftingBoardLive`.
+- **Colocated and external hook registration** — `assets/js/app.js:27-28` imports external hooks from `assets/js/hooks/`; `Hooks` object (lines 58-65) spreads them and registers with `LiveSocket`. Existing CSS classes `.sortable-ghost` and `.sortable-drag` at `assets/css/app.css:226-233` can be reused for drag styling even though no SortableJS is pulled in.
+- **PubSub broadcasting** — `Destila.PubSubHelper.broadcast/2` on `"store:updates"`, event atoms like `:draft_created`, `:draft_updated`, `:draft_deleted` received via `handle_info({event, data}, socket)`.
+- **BDD test linking** — module-level `@feature "name"` + per-test `@tag feature: @feature, scenario: "..."`; see `test/destila_web/live/project_archiving_live_test.exs:1-55` for the canonical shape. Feature files live in `features/`.
+- **Ecto.Enum precedent** — `docs/plans/2026-04-06-refactor-ecto-enum-phase-execution-status-plan.md` is the in-repo template for `Ecto.Enum` field usage.
+- **Crafting board columns (reference only)** — `lib/destila_web/live/crafting_board_live.ex` shows a multi-section board but does *not* use streams per column; the drafts board should use one stream per priority column because per-column stream operations (`stream_delete` + `stream_insert(at: idx)`) map cleanly to drag-and-drop events.
+
+### Institutional Learnings
+
+`docs/solutions/` does not exist in this repo. Adjacent prior plans consulted:
+- `docs/plans/2026-04-15-002-feat-project-archiving-plan.md` — shape of a soft-archive feature on a new entity (field, index, UI hiding, tests).
+- `docs/plans/2026-03-23-feat-crafting-board-redesign-plan.md` — documents the removal of the older SortableJS hook, confirming the current codebase has no DnD dependency and no `assets/js/hooks/sortable.js`. The hook name `Sortable` remains unused and explicitly asserted-absent in `test/destila_web/live/crafting_board_live_test.exs:323`; the new drafts hook should use a distinct name (`DraftsBoard` or `DraftDrag`) to avoid colliding with those assertions.
+- `docs/plans/2026-04-04-refactor-extract-create-session-live-plan.md` — confirms `CreateSessionLive` is the canonical entry for workflow session creation and the right place to extend the bypass.
+
+### External References
+
+None consulted. The codebase has strong local patterns for every layer this plan touches (context + schema, list LiveView with streams, form LiveComponent, phx-hook, bypass flow); external research would not change the design.
+
+## Key Technical Decisions
+
+- **Single `Destila.Drafts.Draft` schema, no associations beyond `belongs_to :project`.** Drafts don't link to workflow sessions; the brief explicitly says "no link back from the resulting workflow session to its originating draft." Keeping the schema minimal avoids a pointless FK cycle.
+- **Soft archive via `archived_at :utc_datetime`, no `deleted_at`.** Discard is permanent from the UI but recoverable via DB for accidental-data-loss protection, matching the brief and the projects pattern.
+- **Per-priority `position :float` for ordering.** Storing a float scoped per priority column means a single drag only writes one row (the moved draft) using midpoint math. Alternatives considered: (a) integer positions requiring bulk renumbering on every move — rejected because every drag writes N rows; (b) gap-10 integers with periodic rebalance — rejected as more complex than float midpoints for the expected scale (dozens of drafts per column). Float precision eventually degrades after many hundreds of consecutive midpoint operations between the same neighbors; captured as a low-probability risk rather than a design constraint. No unique constraint on `(priority, position)` — ties are tolerated and broken by `inserted_at`.
+- **`priority` is an `Ecto.Enum` of `[:low, :medium, :high]`, required at creation.** No default. The form uses a `<select>` with a blank placeholder option whose submission fails the `validate_required(:priority)` check.
+- **Required fields at creation: `prompt`, `priority`, `project_id`.** Project must reference a non-archived project at create time; edits are validated against the same rule *for the new value* only — an existing draft whose project was later archived remains loadable and editable (the user can change the project via the form).
+- **Drag-and-drop event contract:** the hook pushes a single `"reorder_draft"` event with `%{"draft_id", "priority", "before_id", "after_id"}`; the LiveView resolves the three cases (empty column, top/bottom, between two cards) into a new `position` and persists it atomically with any `priority` change. This keeps all ordering math on the server and makes the contract testable without a browser via `render_hook/3`.
+- **`DraftFormLive` is a full `live_view` (not a `live_component`).** Unlike `ProjectFormLive`, the draft form owns routes (`/drafts/new`, `/drafts/:id`) and navigation (back to board, to the workflow type picker, to the workflow runner after launch). The project selector is still reused as a function component via `DestilaWeb.ProjectComponents.project_selector/1` with `target={nil}`.
+- **Launch bypass via a `draft_id` query param threaded through the type picker.** `CreateSessionLive` already branches on the presence of `"workflow_type"` in `mount`; adding `"draft_id"` requires: (1) propagating it in the `<.link navigate={~p"/workflows/#{wf.type}?draft_id=..."}>` at `lib/destila_web/live/create_session_live.ex:167`, and (2) a new `mount_launch_from_draft/3` branch that (a) loads the draft, (b) calls `Destila.Workflows.create_workflow_session/1` with the draft's prompt+project+chosen type, (c) archives the draft only on `{:ok, ws}`, and (d) `push_navigate`s to `~p"/sessions/#{ws.id}"`. The render for this branch is a minimal loading state so nothing flashes; the heavy lifting happens in `mount` so the form is never rendered. On error the user is redirected back to the draft detail with a flash.
+- **Three streams per priority column** (`:drafts_low`, `:drafts_medium`, `:drafts_high`) on the board. This keeps drag operations localized to the affected column(s) with `stream_delete` + `stream_insert(at: idx)` and avoids re-streaming the whole board on every reorder. PubSub-driven updates from other tabs/processes still re-stream all three with `reset: true`.
+- **Archived-project display on cards and detail page** — when a draft's `project.archived_at` is non-nil, render an "(archived)" label next to the project name rather than hiding the draft or erroring. Handled in the card/detail templates; no query-level filtering change.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should the draft store the workflow type?** No. The brief specifies the launch flow goes through the workflow type picker, and keeping the draft type-agnostic avoids having to show/validate types at create time. The draft carries only prompt + project + priority.
+- **Form LiveComponent vs full LiveView for the detail page?** Full LiveView. The detail page owns routes and navigation; see Key Technical Decisions.
+- **How to represent priority?** `Ecto.Enum` with atoms `[:low, :medium, :high]`. Display labels are handled in the template.
+- **How to drag?** Native HTML5 DnD in a new external `phx-hook`, no npm dependency. See Unit 6.
+- **What prevents the prompt+project form from flashing during launch?** The bypass branch runs entirely inside `mount/3` (synchronous session creation + `push_navigate`) before any render, and its `render` function renders a dedicated `:launching` loading view, not the form. See Unit 5.
+
+### Deferred to Implementation
+
+- **Exact midpoint helper naming and placement** inside `Destila.Drafts` (`compute_position/3`, `reposition/4`, etc.) — pick during implementation of Unit 2.
+- **Exact sidebar icon** — `hero-document-text`, `hero-bolt`, `hero-queue-list`, or similar. Implementer picks whichever reads best alongside the existing `hero-beaker` for Crafting Board and `hero-folder` for Projects.
+- **Card truncation style** — pick Tailwind `line-clamp-3` vs `line-clamp-2` during implementation based on visual density.
+- **Precise UX microcopy** for empty states, discard confirmation button label, and start-workflow button wording — refine during implementation.
+- **Float-rebalancing utility** — none planned for this feature. If float precision ever becomes an issue in practice, add a small rebalance function in a follow-up; not needed for v1.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+### Drag-and-drop event contract
+
+```
+Client (phx-hook)                          Server (DraftsBoardLive)
+-----------------                          ------------------------
+drop event on a column ─────────────────▶  handle_event("reorder_draft", %{
+  derive:                                     "draft_id"    => dragged_id,
+    - dragged_id                              "priority"    => "high" | "medium" | "low",
+    - target_priority                         "before_id"   => id | nil,
+    - before_id (card above drop)             "after_id"    => id | nil
+    - after_id  (card below drop)           }, socket)
+  pushEvent("reorder_draft", payload)          │
+                                               ├─▶ Drafts.reposition(draft, priority, before_id, after_id)
+                                               │     compute_position/3 picks midpoint or top/bottom:
+                                               │       empty column       -> 1.0
+                                               │       before nil, after a -> a.position - 1.0
+                                               │       before a, after nil -> a.position + 1.0
+                                               │       between a and b     -> (a.position + b.position) / 2
+                                               ├─▶ stream_delete from old column (if priority changed)
+                                               └─▶ stream_insert(at: new_index) into target column
+```
+
+### Launch bypass flow
+
+```
+User clicks "Start workflow" on /drafts/:id
+  │
+  └─▶ push_navigate to /workflows?draft_id=<id>
+        │
+        └─▶ CreateSessionLive.mount/3 (type selection)
+              renders type picker with each card navigating to
+              /workflows/<type>?draft_id=<id>
+              │
+              └─▶ CreateSessionLive.mount/3 (launch branch)
+                    guard: both "workflow_type" and "draft_id" present
+                    load draft (get_draft! from non-archived)
+                      ├─ not found / archived -> redirect to /drafts + flash
+                      └─ ok
+                          │
+                          ├─▶ Workflows.create_workflow_session(%{
+                          │     workflow_type:, input_text: draft.prompt,
+                          │     project_id: draft.project_id })
+                          │     ├─ {:ok, ws}  -> Drafts.archive_draft(draft)
+                          │     │               push_navigate to /sessions/<ws.id>
+                          │     └─ {:error, _} -> redirect to /drafts/<id>
+                          │                       with error flash, draft NOT archived
+                          └─▶ render :launching view (minimal spinner; never the form)
+```
+
+## Implementation Units
+
+### Unit dependency graph
+
+```mermaid
+flowchart TB
+  U1[Unit 1: Gherkin feature file]
+  U2[Unit 2: Drafts context + schema + migration]
+  U3[Unit 3: DraftFormLive new/edit]
+  U4[Unit 4: DraftsBoardLive + sidebar nav]
+  U5[Unit 5: Discard + launch bypass in CreateSessionLive]
+  U6[Unit 6: Drag-and-drop hook + reorder handler]
+
+  U1 --> U3
+  U1 --> U4
+  U2 --> U3
+  U2 --> U4
+  U3 --> U4
+  U3 --> U5
+  U4 --> U5
+  U4 --> U6
+  U2 --> U6
+```
+
+---
+
+- [ ] **Unit 1: Gherkin feature file**
+
+**Goal:** Land `features/drafts_board.feature` with the exact scenario set from the brief so subsequent units can reference them by `@tag scenario:`.
+
+**Requirements:** R10
+
+**Dependencies:** None
+
+**Files:**
+- Create: `features/drafts_board.feature`
+
+**Approach:**
+- Copy the scenarios from the brief verbatim into `features/drafts_board.feature`. Preserve the feature description paragraph at the top (archive semantics, launch semantics, no restore path).
+- No code changes beyond the feature file; this unit exists so every downstream test in Units 2-6 can carry `@tag feature: "drafts_board", scenario: "..."` without risk of mismatched scenario names.
+
+**Patterns to follow:**
+- `features/project_archiving.feature` — shape of a multi-section feature file with `# --- Section ---` comment headers.
+- `features/session_archiving.feature` — cross-page scenario style.
+
+**Test scenarios:**
+- Test expectation: none -- this unit adds no code, only a BDD spec. Scenario coverage is verified by Units 2-6 as they attach `@tag` references.
+
+**Verification:**
+- `features/drafts_board.feature` exists and contains every scenario from the brief, with exact scenario names suitable for `@tag scenario:` reference.
+- `grep -n "Scenario:" features/drafts_board.feature` lists the 13 scenarios from the brief.
+
+---
+
+- [ ] **Unit 2: Drafts context + `Draft` schema + migration**
+
+**Goal:** Create the `Destila.Drafts` domain context and `Destila.Drafts.Draft` schema with CRUD, soft archive, per-priority ordering, and midpoint position helper. No UI.
+
+**Requirements:** R3, R4, R5, R6, R8, R9, R11
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `lib/destila/drafts.ex`
+- Create: `lib/destila/drafts/draft.ex`
+- Create: `priv/repo/migrations/YYYYMMDDHHMMSS_create_drafts.exs`
+- Create: `test/destila/drafts/draft_test.exs`
+- Create: `test/destila/drafts_test.exs`
+
+**Approach:**
+- `drafts` table fields: `id :binary_id` PK, `prompt :text` (null: false), `priority :string` (null: false, cast from Ecto.Enum atom), `position :float` (null: false), `archived_at :utc_datetime`, `project_id :binary_id` FK `references(:projects, on_delete: :restrict)`, `timestamps(type: :utc_datetime)`.
+- Indexes: `create index(:drafts, [:priority, :position])` (covers the per-priority ordered list query), `create index(:drafts, [:archived_at])`, `create index(:drafts, [:project_id])`.
+- Schema: mirror `lib/destila/projects/project.ex` — `@primary_key {:id, :binary_id, autogenerate: true}`, `@foreign_key_type :binary_id`, `field :priority, Ecto.Enum, values: [:low, :medium, :high]`, `belongs_to :project, Destila.Projects.Project`. Changeset `cast` + `validate_required([:prompt, :priority, :project_id, :position])` and validate the referenced project is not archived *at create time* via `Ecto.Changeset.prepare_changes/2` or a foreign_key_constraint + explicit pre-check in the context; keep it in the context to avoid coupling the schema to the projects module.
+- Context functions:
+  - `list_drafts_by_priority/1` -> `[%Draft{}]` ordered `asc: position`, filtered `is_nil(archived_at)`, preload `:project`.
+  - `list_all_active/0` -> returns `%{low: [...], medium: [...], high: [...]}` for efficient board load (single query + group_by in Elixir, preload `:project`).
+  - `get_draft/1`, `get_draft!/1` filter `is_nil(archived_at)`.
+  - `create_draft/1` — accepts `%{prompt, priority, project_id}`, validates project exists and is non-archived, computes default position as `max_position_in_priority(priority) + 1.0` (or `1.0` if empty), inserts, broadcasts `:draft_created`.
+  - `update_draft/2` — accepts `%{prompt, priority, project_id}`; if `priority` changed, re-assign position to `max_position_in_priority(new_priority) + 1.0` unless caller supplies one; broadcasts `:draft_updated`.
+  - `archive_draft/1` — sets `archived_at: DateTime.utc_now()`; broadcasts `:draft_updated`.
+  - `reposition_draft/4` — `reposition_draft(draft, target_priority, before_id, after_id)`; loads neighbors by id, computes midpoint via a private `compute_position/3`, updates both `priority` and `position` in one changeset, broadcasts `:draft_updated`.
+  - `compute_position/3` (private) — implements the four cases in the Technical Design block.
+- PubSub: `defdelegate broadcast(result, event), to: Destila.PubSubHelper` — same shape as `Destila.Projects`.
+- Do **not** add a `list_archived_drafts/0` function; the brief forbids an archived-drafts page.
+
+**Patterns to follow:**
+- `lib/destila/projects.ex` (context shape, broadcast, archive).
+- `lib/destila/projects/project.ex` (schema, binary_id, changeset).
+- `priv/repo/migrations/20260324111938_create_projects_workflow_sessions_messages.exs` (table creation, FK, indexes).
+- `priv/repo/migrations/20260415000000_add_archived_at_to_projects.exs` (archived_at index).
+
+**Test scenarios:**
+- Happy path: `create_draft/1` with all required fields persists and broadcasts `:draft_created`; returned draft has a numeric position and preloaded project.
+- Happy path: `list_drafts_by_priority(:high)` returns only non-archived drafts in the given priority, ordered by ascending `position`.
+- Happy path: `list_all_active/0` returns a map with `:low/:medium/:high` keys, each sorted by `position`, excluding archived drafts.
+- Happy path: `update_draft/2` updates prompt/project/priority; changing priority moves the draft to the new column's tail.
+- Happy path: `archive_draft/1` sets `archived_at`, removes the draft from all `list_*` queries, and broadcasts `:draft_updated`.
+- Edge case: `compute_position/3` with an empty column returns a sensible default (e.g. `1.0`); with `before_id = nil, after_id = some_id` returns `some.position - 1.0`; with `before_id = some_id, after_id = nil` returns `some.position + 1.0`; with both set returns the midpoint.
+- Edge case: `reposition_draft/4` across priorities atomically updates both `priority` and `position`.
+- Edge case: creating a draft with no `priority` fails changeset validation (required).
+- Edge case: creating a draft with no `project_id` fails changeset validation (required).
+- Edge case: creating a draft whose referenced project is archived returns `{:error, changeset}` with an error on `:project_id`.
+- Edge case: loading a draft whose project was archived *after* creation succeeds and returns the draft with a `project` whose `archived_at` is non-nil (no crash).
+- Edge case: `get_draft/1` and `get_draft!/1` return nil / raise for archived drafts.
+- Error path: `create_draft/1` with a non-existent `project_id` returns `{:error, changeset}` (foreign_key_constraint).
+- Integration: `create_draft/1` actually writes to the DB and a subsequent `list_drafts_by_priority/1` in the same test returns it (round-trip via `Destila.Repo`).
+
+Each test is tagged `@tag feature: "drafts_board", scenario: "<matching scenario from the feature file>"` where applicable; pure unit-level invariants (e.g., midpoint math) may be tagged against the relevant scenario ("Reorder drafts within a priority column", "Move a draft to a different priority column via drag-and-drop") or left un-tagged if they assert implementation-level correctness beyond what the Gherkin describes.
+
+**Verification:**
+- `mix test test/destila/drafts_test.exs test/destila/drafts/draft_test.exs` passes.
+- `mix ecto.migrate && mix ecto.rollback` both succeed cleanly.
+- A manual `iex` round-trip (`Destila.Drafts.create_draft/1` -> `list_drafts_by_priority/1` -> `archive_draft/1` -> `get_draft/1` returns nil) works.
+
+---
+
+- [ ] **Unit 3: `DraftFormLive` for new / edit / detail**
+
+**Goal:** Land the LiveView that serves `/drafts/new` and `/drafts/:id`, handling create, edit, discard, and start-workflow navigation. Drag-and-drop and the full bypass integration come in later units; this unit wires `Start workflow` to navigate to `~p"/workflows?draft_id=<id>"` — the propagation through the type picker ships in Unit 5.
+
+**Requirements:** R3, R4, R6, R7 (navigation only), R8
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Create: `lib/destila_web/live/draft_form_live.ex`
+- Modify: `lib/destila_web/router.ex` (add `live "/drafts/new", DraftFormLive` and `live "/drafts/:id", DraftFormLive`)
+- Create: `test/destila_web/live/draft_form_live_test.exs`
+
+**Approach:**
+- Full `DestilaWeb, :live_view` module — not a live_component. Dispatches on params: no `:id` -> `:new` mode; `:id` present -> `:edit` mode (also the "detail" surface; the brief lets them be the same page).
+- `mount/3`:
+  - Loads active projects via `Destila.Projects.list_projects/0`.
+  - For `:edit`, loads the draft via `Destila.Drafts.get_draft!/1` (raises 404 on archived/missing, which router rescues as a redirect — consistent with other LiveViews in this repo).
+  - Assigns `:form` from `to_form/2` with string-keyed params matching the template fields (`"prompt"`, `"priority"`, `"project_id"`).
+  - Subscribes to `"store:updates"` if connected so new projects created inline appear in the selector.
+- Events:
+  - `"validate"` — `assign(:form, to_form(params))`.
+  - `"save"` — trims prompt, collects priority (string `"low"|"medium"|"high"` cast to atom before calling context), calls `create_draft/1` or `update_draft/2`, on success `push_navigate` to `/drafts`, on error re-renders with errors.
+  - `"discard"` — only for `:edit`; calls `Destila.Drafts.archive_draft/1`, flashes "Draft discarded", `push_navigate` to `/drafts`.
+  - `"start_workflow"` — only for `:edit`; `push_navigate(to: ~p"/workflows?draft_id=#{@draft.id}")`. Unit 5 handles the other side.
+  - `"select_project"`, `"show_create_project"`, `"back_to_select"` — reuse the existing project-selector contract (see `CreateSessionLive` lines 94-105).
+  - `{:project_saved, project}` info — same as `CreateSessionLive.handle_info` — refresh `:projects`, preselect the new project.
+- Template: `<Layouts.app flash={@flash} page_title={@page_title}>` wrapper with `@page_title = "New Draft"` or `"Edit Draft"`. Form has:
+  - `id="draft-form"` with `phx-submit="save"` and `phx-change="validate"`.
+  - Prompt textarea `id="draft-prompt"` with `name="prompt"`, `phx-debounce="300"`.
+  - Priority `<select id="draft-priority" name="priority">` with a blank placeholder option (`<option value="" disabled selected>Select priority…</option>`) plus High/Medium/Low — submission with the empty value triggers the required validation.
+  - Project selector via `<.project_selector projects={@projects} selected_id={@project_id} step={@project_step} errors={@errors} target={nil} />`.
+  - Submit button `id="save-draft-btn"`.
+  - In `:edit` mode, two additional buttons at the bottom of the form: `id="discard-draft-btn"` (phx-click `"discard"`) and `id="start-workflow-btn"` (phx-click `"start_workflow"`). A "Back to drafts" link is always present.
+  - If `@draft.project.archived_at` is non-nil, render an archived indicator next to the project field.
+- Use the inline-create pattern from `CreateSessionLive` so the project selector can create a project without leaving the page.
+
+**Patterns to follow:**
+- `lib/destila_web/live/create_session_live.ex` — particularly the project-selector wiring (select/create/back) and the `{:project_saved, project}` handler.
+- `lib/destila_web/live/project_form_live.ex` — `to_form/2` with a string-keyed map, `changeset_to_errors/1` shape for error assigns.
+- `lib/destila_web/live/session_deletion_live_test.exs` (if present in `test/destila_web/live/` — reference `test/destila_web/live/project_archiving_live_test.exs` otherwise) for the "confirm then act" interaction style in tests.
+
+**Test scenarios:**
+- Happy path / Scenario: "Create a new draft from the drafts board" — POST `save` with prompt + project + priority redirects to `/drafts`; draft exists with those attrs.
+- Edge case / Scenario: "Cannot create a draft without a project" — submitting with `project_id` unset renders a validation error on the project field; no draft is created.
+- Edge case / Scenario: "Cannot create a draft without a priority" — submitting without priority renders a validation error on the priority field; no draft is created.
+- Happy path / Scenario: "Open a draft detail page" — GET `/drafts/:id` renders a form populated with the draft's prompt, project, and priority.
+- Happy path / Scenario: "Edit the prompt, project, and priority of an existing draft" — submitting the form with new values persists; redirect lands back on the board; subsequent `/drafts/:id` load reflects the new values.
+- Happy path / Scenario: "Discard a draft from its detail page" — clicking `#discard-draft-btn` redirects to `/drafts`, flashes, and `Destila.Drafts.get_draft(id)` returns nil.
+- Happy path / Scenario: "Launch a workflow from a draft skips prompt and project selection" (navigation half only, remainder in Unit 5) — clicking `#start-workflow-btn` performs a LiveView navigate whose target matches `~p"/workflows?draft_id=#{draft.id}"`.
+- Edge case: opening `/drafts/:id` for an archived draft 404s or redirects (consistent with how the rest of the app handles `get_*!` on soft-archived resources).
+- Integration: the project selector's inline-create flow (click "Create New Project", submit project form, receive `{:project_saved, project}`) results in the new project being preselected for the draft.
+- Integration: editing an existing draft whose `project.archived_at` is non-nil loads without crashing and renders the archived indicator.
+
+All tests tagged `@feature "drafts_board"` + the matching scenario name.
+
+**Verification:**
+- `mix test test/destila_web/live/draft_form_live_test.exs` passes.
+- Manual `/drafts/new` flow creates a draft; `/drafts/:id` edits and discards it.
+
+---
+
+- [ ] **Unit 4: `DraftsBoardLive` (board + sidebar nav)**
+
+**Goal:** Land the board at `/drafts` with three priority columns, empty state, "New Draft" button, card click-to-edit navigation, and a sidebar entry. No drag-and-drop yet — priority changes happen via the edit form until Unit 6 ships.
+
+**Requirements:** R1, R2, R3 (button only), R4 (navigation), R8, R11
+
+**Dependencies:** Unit 1, Unit 2, Unit 3
+
+**Files:**
+- Create: `lib/destila_web/live/drafts_board_live.ex`
+- Modify: `lib/destila_web/router.ex` (add `live "/drafts", DraftsBoardLive` just before `live "/projects"`)
+- Modify: `lib/destila_web/components/layouts.ex` (add `<.sidebar_item navigate={~p"/drafts"} icon={...} label="Drafts" active={@page_title == "Drafts"} />` between Crafting Board and Projects)
+- Create: `test/destila_web/live/drafts_board_live_test.exs`
+
+**Approach:**
+- `mount/3`:
+  - Subscribes to `"store:updates"` when connected.
+  - Loads `Destila.Drafts.list_all_active/0` into three streams: `stream(:drafts_high, grouped.high)`, `stream(:drafts_medium, ...)`, `stream(:drafts_low, ...)`.
+  - Assigns `:any_drafts?` (single boolean for the global empty state) based on whether all three lists are empty.
+  - Assigns `:page_title, "Drafts"`.
+- `handle_info({:draft_created | :draft_updated | :draft_deleted, _}, socket)` — re-fetches `list_all_active/0` and re-streams all three columns with `reset: true`, re-computes `:any_drafts?`.
+- Template:
+  - `<Layouts.app flash={@flash} page_title={@page_title}>` wrapper.
+  - Header with an `#new-draft-btn` linking (`<.link navigate={~p"/drafts/new"}>`) to the new-draft form.
+  - Global empty state (`id="drafts-board-empty"`) rendered only when `@any_drafts?` is false, inviting "Create your first draft" with a CTA identical to `#new-draft-btn`.
+  - Three column containers, each `id={"column-#{priority}"}` with a header (`High | Medium | Low`) and a `phx-update="stream"` inner div bearing `id={"drafts-#{priority}"}`. Each column has a per-column empty-state hint using the `hidden only:block` pattern.
+  - Each card: `<.link navigate={~p"/drafts/#{draft.id}"} id={id} class="…">` where the link's anchor id is the stream DOM id; card body shows only the prompt, truncated with `line-clamp-3`. If `draft.project.archived_at` is non-nil, render an `(archived)` badge for the project name.
+- No drag-and-drop here; clicking a card opens detail/edit (Unit 3). Sidebar layout update uses a hero icon chosen during implementation.
+- Tests drive interactions purely via `live/2`, `element/2`, `render_click/1`, and `has_element?/2` against the DOM ids above.
+
+**Patterns to follow:**
+- `lib/destila_web/live/projects_live.ex` — stream + PubSub + empty-state shape.
+- `lib/destila_web/live/crafting_board_live.ex` — multi-column board layout (three-column flex/grid wrapper).
+- `lib/destila_web/components/layouts.ex:44-65` — sidebar item insertion.
+
+**Test scenarios:**
+- Happy path / Scenario: "View drafts grouped by priority columns" — three drafts, one per priority; each appears in its column container.
+- Happy path / Scenario: "Draft card shows the prompt" — a draft with prompt "Refactor session archiving" renders a card whose body contains that text.
+- Happy path / Scenario: "Empty board shows guidance to create the first draft" — no drafts exist; `#drafts-board-empty` is present with the CTA.
+- Happy path / Scenario: "Create a new draft from the drafts board" — clicking `#new-draft-btn` navigates to `/drafts/new` (covered end-to-end in conjunction with Unit 3's create test).
+- Happy path / Scenario: "Open a draft detail page" — clicking a card navigates to `/drafts/:id`.
+- Edge case: a draft whose project was archived still renders on the board with the archived indicator.
+- Edge case: the sidebar shows "Drafts" as active when `@page_title == "Drafts"` (verify `aria-current` or the active class on the link).
+- Integration: after an inline edit to a draft in another process (simulate by calling `Destila.Drafts.update_draft/2` directly then sending the PubSub message), the board re-streams and the draft shows up in the new priority column.
+
+**Verification:**
+- `mix test test/destila_web/live/drafts_board_live_test.exs` passes.
+- Manual: `/drafts` renders three columns, empty state fires when no drafts exist, clicking a card opens `/drafts/:id`, sidebar "Drafts" item highlights on the board.
+
+---
+
+- [ ] **Unit 5: Launch bypass in `CreateSessionLive` + Discard-on-launch semantics**
+
+**Goal:** Propagate the `draft_id` query param through the workflow type picker and implement the launch branch that bypasses the prompt+project form entirely. On successful session creation, archive the draft.
+
+**Requirements:** R7, R9
+
+**Dependencies:** Unit 2, Unit 3, Unit 4
+
+**Files:**
+- Modify: `lib/destila_web/live/create_session_live.ex`
+- Create: `test/destila_web/live/draft_launch_live_test.exs` *(or extend `draft_form_live_test.exs` — implementer decides; keep the "launch + archive" integration assertions in one module)*
+
+**Approach:**
+- `CreateSessionLive.mount/3` gains a third branch:
+  ```
+  cond do
+    Map.has_key?(params, "draft_id") and Map.has_key?(params, "workflow_type") ->
+      mount_launch_from_draft(params, socket)
+    Map.has_key?(params, "workflow_type") ->
+      mount_form(params["workflow_type"], maybe_assign_draft_id(socket, params))
+    true ->
+      mount_type_selection(maybe_assign_draft_id(socket, params))
+  end
+  ```
+- `mount_launch_from_draft/2`:
+  - Loads the draft via `Destila.Drafts.get_draft(params["draft_id"])`. If nil -> redirect to `/drafts` with an error flash.
+  - Parses `workflow_type` via `String.to_existing_atom/1`; on `ArgumentError` redirect to `/workflows` with a flash.
+  - Calls `Destila.Workflows.create_workflow_session(%{workflow_type:, input_text: draft.prompt, project_id: draft.project_id})`.
+  - On `{:ok, ws}`: calls `Destila.Drafts.archive_draft(draft)` then `push_navigate(to: ~p"/sessions/#{ws.id}")`.
+  - On `{:error, _}`: redirect to `~p"/drafts/#{draft.id}"` with an error flash; **does not archive**.
+  - Assigns `view: :launching`, `page_title: "Launching workflow…"` for the unlikely case that the socket is not yet connected and the mount runs twice (disconnected + connected). Because the create+navigate happens inside `mount/3`, the form is never rendered.
+- `render(%{view: :launching} = assigns)` — a minimal centered spinner with text; wrapped in `<Layouts.app flash={@flash} page_title={@page_title}>`.
+- `mount_type_selection` gets the optional `:draft_id` assign; the type-picker template at `lib/destila_web/live/create_session_live.ex:167` changes:
+  ```
+  navigate={
+    if @draft_id,
+      do: ~p"/workflows/#{wf.type}?draft_id=#{@draft_id}",
+      else: ~p"/workflows/#{wf.type}"
+  }
+  ```
+- `mount_form` also carries `@draft_id` through for rendering-time propagation in case the user lands on `/workflows/:type?draft_id=X` but the branch-guard in `mount/3` has already redirected them via launch — but the guard ensures that path only renders when both params are present. Defensively, if only `draft_id` is present in the form branch, it's fine to ignore it.
+- Archive-only-on-success is enforced by the explicit order: `create_workflow_session` first, then `archive_draft`. If the caller kills the LiveView between create and archive, the worst case is a created session whose draft is still visible — in that case the brief's guarantee holds because the check is "archive only on successful creation", not "the draft is archived before the user sees the runner." A subsequent visit to the board still shows the draft; discarding it manually is available. This trade-off is captured in Risks.
+
+**Patterns to follow:**
+- `lib/destila_web/live/create_session_live.ex:12-18` — the existing `cond`-style dispatch in `mount/3`.
+- `lib/destila/workflows.ex:92-134` — the session-creation entry point and its `{:ok, ws}` / `{:error, _}` shape.
+- `lib/destila_web/live/session_archiving_live_test.exs` — the canonical "LiveView causes a DB state change, verify via Repo" shape.
+
+**Test scenarios:**
+- Happy path / Scenario: "Launch a workflow from a draft skips prompt and project selection" — `live(conn, ~p"/workflows?draft_id=#{draft.id}")` renders the type picker with each card's navigate URL containing `?draft_id=<draft.id>`; following one of those links lands on `/sessions/<ws.id>` with a newly-created workflow session whose `user_prompt == draft.prompt` and `project_id == draft.project_id`.
+- Happy path / Scenario: "Launching a workflow auto-archives the draft" — after the launch succeeds, `Destila.Drafts.get_draft(draft.id)` returns nil and the draft is absent from `list_all_active/0`.
+- Edge case: `/workflows?draft_id=<nonexistent>` redirects to `/drafts` with an error flash; no workflow session is created.
+- Edge case: `/workflows/invalid_type?draft_id=<id>` redirects to `/workflows` with an error flash; no workflow session is created; draft remains active.
+- Error path: when `Destila.Workflows.create_workflow_session/1` returns `{:error, _}` (simulate by passing a project whose `:restrict` FK rejects — or by deleting the project mid-test), the LiveView redirects back to `/drafts/<id>`, the draft's `archived_at` remains nil, and no workflow session is persisted.
+- Integration: the form is never rendered in the launch flow — after the redirect through `/workflows?draft_id=…` -> `/workflows/:type?draft_id=…` -> `/sessions/:id`, no HTML with `id="manual-input-form"` or `id="project-list"` appears in any intermediate render.
+
+**Verification:**
+- `mix test test/destila_web/live/draft_launch_live_test.exs test/destila_web/live/create_session_live_test.exs` passes. (The existing `create_session_live_test.exs` must continue to pass — the bypass must not regress the non-draft path.)
+- Manual: clicking "Start workflow" on a draft lands directly on the runner with the draft's prompt preloaded, and the draft is gone from the board.
+
+---
+
+- [ ] **Unit 6: Drag-and-drop hook + `reorder_draft` handler**
+
+**Goal:** Add drag-and-drop for cards within and across priority columns. Moving a card persists the new priority + position via the midpoint helper from Unit 2.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 2, Unit 4
+
+**Files:**
+- Create: `assets/js/hooks/drafts_board.js`
+- Modify: `assets/js/app.js` (import and register as `DraftsBoard`)
+- Modify: `lib/destila_web/live/drafts_board_live.ex` (attach `phx-hook="DraftsBoard"` + `phx-update="ignore"` to the column containers; add `handle_event("reorder_draft", _, socket)`)
+- Modify: `test/destila_web/live/drafts_board_live_test.exs` (add reorder scenarios)
+
+**Approach:**
+- The hook is an external JS object following the same pattern as `assets/js/hooks/terminal_panel.js` and `assets/js/hooks/local_time.js` — export default, `mounted`, `destroyed`, with `this.pushEvent(...)`.
+- Attach the hook to each column wrapper (not the inner `phx-update="stream"` div) so LiveView's stream-patching is not interfered with. The column wrapper uses:
+  ```
+  <div
+    id={"column-#{priority}"}
+    phx-hook="DraftsBoard"
+    phx-update="ignore"
+    data-priority={priority}
+    class="…"
+  >
+    <header>...</header>
+    <div id={"drafts-#{priority}"} phx-update="stream">
+      …cards…
+    </div>
+  </div>
+  ```
+  *Note:* `phx-update="ignore"` on the outer column is required by CLAUDE.md whenever a hook manages its own DOM; because the inner stream div is a descendant, its `phx-update="stream"` still applies. Confirm during implementation that streams still update correctly through an ignored ancestor — if not, move the hook to a sibling that doesn't wrap the stream and coordinate via DOM IDs.
+- Card markup: `draggable="true"` on each card, `data-draft-id={draft.id}` so the hook can read identifiers without reparsing DOM ids.
+- JS contract (HTML5 native DnD):
+  - On `dragstart` on a card: set a class on the dragged element, stash `draft_id` in `dataTransfer`, `dataTransfer.effectAllowed = "move"`.
+  - On `dragover` on the column: `event.preventDefault()` + add `.sortable-drag` class.
+  - On `dragleave`: remove the class.
+  - On `drop`: compute `before_id` (the card immediately above the drop point) and `after_id` (the one immediately below). Heuristic: iterate card children of the stream container, compare each card's bounding-rect midpoint `y` with `event.clientY`; the last card whose midpoint is < `clientY` is `before_id`, the first whose midpoint is >= `clientY` is `after_id`. Empty column: both `nil`. Push `"reorder_draft"` with `{draft_id, priority: this.el.dataset.priority, before_id, after_id}`.
+  - Re-use CSS `.sortable-ghost` and `.sortable-drag` classes from `assets/css/app.css:226-233` for visual feedback.
+- LiveView handler:
+  - `handle_event("reorder_draft", %{"draft_id" => draft_id, "priority" => priority_str, "before_id" => before_id, "after_id" => after_id}, socket)`.
+  - Cast `priority_str` to atom via `String.to_existing_atom/1` (safe because the enum values are pre-registered as atoms in the schema; reject unexpected values with a no-op on invalid atom).
+  - Load the draft, call `Destila.Drafts.reposition_draft/4`; on success, the PubSub `:draft_updated` handler already re-streams all three columns — no explicit stream operations needed here. On error, ignore (the board's current state is still internally consistent; a follow-up PubSub can correct any drift).
+  - Alternative: for snappier UX, `stream_delete` the draft from the old column and `stream_insert(at: idx)` into the new column locally, suppressing the next PubSub refresh for that draft id. Treat this as an implementation-time optimization; Unit 6 ships the correct-but-simple version first.
+- Do **not** name the hook `Sortable` — `test/destila_web/live/crafting_board_live_test.exs:323` explicitly refutes that string.
+
+**Patterns to follow:**
+- `assets/js/hooks/terminal_panel.js` — external hook file layout.
+- `assets/js/app.js:27-65` — import + register.
+- `assets/css/app.css:226-233` — existing drag class styling.
+
+**Test scenarios:**
+- Happy path / Scenario: "Reorder drafts within a priority column" — create three drafts in `:high`; push `"reorder_draft"` with `before_id = nil, after_id = drafts[0].id` for `drafts[2]`; reload the board and verify the order is `[drafts[2], drafts[0], drafts[1]]`.
+- Happy path / Scenario: "Move a draft to a different priority column via drag-and-drop" — create a draft in `:low`; push `"reorder_draft"` with `priority: "high", before_id: nil, after_id: nil`; reload and verify the draft's `priority == :high`.
+- Edge case: drop into an empty column — `before_id` and `after_id` both nil, `reposition_draft/4` yields a sensible default position and the draft appears in the new column.
+- Edge case: drop at the top of a non-empty column — `before_id = nil, after_id = existing.id` — new position is `existing.position - 1.0`.
+- Edge case: drop at the bottom of a non-empty column — `before_id = existing.id, after_id = nil` — new position is `existing.position + 1.0`.
+- Edge case: drop between two cards — new position is strictly between neighbors' positions and the three cards list in the expected order on reload.
+- Edge case: pushing `"reorder_draft"` with an unknown `draft_id` is a no-op (no crash, no DB change).
+- Edge case: pushing `"reorder_draft"` with an invalid priority string is a no-op.
+- Integration: after a reorder event, the board view re-renders with the new order without a full page reload.
+- Integration: no regression in sidebar or create/edit flows from adding the hook (existing Unit 4 tests still pass).
+
+All interactive tests are driven by `render_hook(view, "reorder_draft", %{...})` or direct `Phoenix.LiveView.Socket` event pushes — the JS hook itself is not unit-tested in Elixir; its behavior is validated by the event payload contract the tests exercise.
+
+**Verification:**
+- `mix test test/destila_web/live/drafts_board_live_test.exs` passes (including new reorder scenarios).
+- `mix precommit` passes cleanly (formatter, compile warnings, tests).
+- Manual: dragging a card within `High` persists order across `/drafts` reloads; dragging from `Low` to `High` changes the priority and the card appears in the High column.
+
+## System-Wide Impact
+
+- **Interaction graph:** `DestilaWeb.CreateSessionLive` is the only existing LiveView modified. The sidebar item in `DestilaWeb.Layouts` is purely additive. The `"store:updates"` PubSub topic picks up three new event atoms (`:draft_created`, `:draft_updated`, `:draft_deleted`); existing subscribers fall through via the default `handle_info(_msg, socket), do: {:noreply, socket}` already present on every LiveView. No other subscribers should react to draft events.
+- **Error propagation:** `Destila.Drafts` returns `{:ok, draft} | {:error, changeset}` for all mutations, matching `Destila.Projects`. The launch bypass treats `{:error, _}` from `Workflows.create_workflow_session/1` as a redirect-with-flash, not a re-raise, to avoid crashing the LiveView process mid-launch.
+- **State lifecycle risks:** Archive-after-create ordering in Unit 5 is not transactional — a process crash between `create_workflow_session/1` success and `archive_draft/1` leaves the draft active alongside the new session. The brief's "archive only on successful creation" constraint is satisfied either way (we never archive on failure). The tradeoff is documented in Risks; the user can manually discard the stale draft.
+- **API surface parity:** No existing interfaces are renamed or changed. `CreateSessionLive.mount/3` gains a new branch; its existing two branches remain behaviorally identical. The router gains three new routes under `/drafts`; existing `/workflows`, `/sessions`, `/projects`, `/crafting` routes are untouched.
+- **Integration coverage:** Units 3 and 5 each include an integration-style assertion that spans LiveView + Repo (`Destila.Drafts.get_draft/1` after a discard; `Destila.Drafts.get_draft/1` + `Destila.Workflows.get_workflow_session/1` after a launch). Unit 4 includes a PubSub-driven cross-tab simulation.
+- **Unchanged invariants:** (a) `Destila.Workflows.create_workflow_session/1` signature is unchanged; (b) `Destila.Projects` is unchanged; (c) the crafting board's assertion that `phx-hook="Sortable"` is absent remains valid (this feature uses `phx-hook="DraftsBoard"`); (d) the authentication model (none) and the `"store:updates"` PubSub topic name are unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Float position precision degrades after many consecutive midpoints between the same two neighbors, eventually breaking tie order. | Accept for v1. At ~50 midpoints between the same pair, doubles still have ~4 bits of precision left; well beyond expected user interactions. If it becomes real, add a rebalance utility in a follow-up. |
+| `phx-update="ignore"` on the outer column wrapper could interfere with the inner stream's patching if LiveView's diffing walks through the ignored subtree. | During Unit 6 implementation, verify stream updates still propagate. If they don't, restructure so the hook lives on a sibling DOM node (e.g. the header) and reads column identity via a `data-priority` attribute elsewhere. The plan accommodates either layout. |
+| A process crash between `create_workflow_session/1` and `archive_draft/1` leaves a stale draft after launch. | Documented behavior; manual discard is available. The brief's archive-only-on-success guarantee holds (we never archive on failure). Not worth introducing a transaction boundary because the two operations live in different contexts and DB transactions don't span `Oban.insert/1` or `SessionProcess.ensure_started/1` anyway. |
+| `String.to_existing_atom/1` on `draft_id`/`priority`/`workflow_type` from query or event params could raise if a user crafts a malicious URL. | The `reorder_draft` handler wraps the cast in a `try/rescue` or pattern-match on a known set; the launch branch already uses `String.to_existing_atom/1` for `workflow_type` exactly as `CreateSessionLive` does today (line 29). Follow the existing pattern and add a rescue-to-redirect on the draft path. |
+| `phx-hook` without JS fallback means users without JS can't drag. | The brief explicitly accepts this: priority can still be changed via the edit form. The hook's behavior is purely additive; without JS, cards render as `draggable="true"` elements that do nothing. |
+| Flash-of-form during launch bypass if `mount/3` renders before the `push_navigate` fires. | `push_navigate` from inside `mount/3` happens before the first render; LiveView mounts the `:launching` view as its initial assigns. The test for "form is never rendered" in Unit 5 locks this in. |
+| Name collision if the implementer accidentally picks `Sortable` for the hook. | Plan explicitly forbids the name and cites the existing test assertion in `test/destila_web/live/crafting_board_live_test.exs:323`. Unit 6 uses `DraftsBoard`. |
+
+## Sources & References
+
+- Feature spec (this document's input) — embedded in the user prompt, not persisted as a separate requirements file.
+- Pattern: `lib/destila/projects.ex`, `lib/destila/projects/project.ex`
+- Pattern: `lib/destila_web/live/projects_live.ex`, `lib/destila_web/live/project_form_live.ex`
+- Pattern: `lib/destila_web/live/create_session_live.ex` (bypass seam)
+- Pattern: `lib/destila_web/live/crafting_board_live.ex` (multi-column board precedent)
+- Pattern: `lib/destila_web/components/project_components.ex` (reusable project selector)
+- Pattern: `lib/destila_web/components/layouts.ex` (sidebar_item insertion)
+- Migration shape: `priv/repo/migrations/20260324111938_create_projects_workflow_sessions_messages.exs`, `priv/repo/migrations/20260415000000_add_archived_at_to_projects.exs`
+- Hook pattern: `assets/js/hooks/terminal_panel.js`, `assets/js/hooks/local_time.js`, `assets/js/app.js`
+- Drag CSS: `assets/css/app.css:226-233`
+- Prior related plans: `docs/plans/2026-04-15-002-feat-project-archiving-plan.md`, `docs/plans/2026-03-23-feat-crafting-board-redesign-plan.md`, `docs/plans/2026-04-04-refactor-extract-create-session-live-plan.md`
+- BDD conventions: `CLAUDE.md` ("BDD feature / test linking" section), `features/project_archiving.feature`, `test/destila_web/live/project_archiving_live_test.exs`

--- a/features/drafts_board.feature
+++ b/features/drafts_board.feature
@@ -1,0 +1,104 @@
+Feature: Drafts Board
+  Users capture loose ideas as drafts on a priority-based kanban board at
+  /drafts. Each draft carries a prompt, a project, and a priority (High,
+  Medium, or Low). Drafts can be edited, reordered within a column, moved
+  across priority columns via drag-and-drop, discarded (soft-archived with
+  no restore path), or launched directly into a workflow — bypassing the
+  prompt + project selection step. Launching a workflow from a draft
+  archives the draft only after the workflow session is successfully
+  created.
+
+  # --- Board ---
+
+  Scenario: View drafts grouped by priority columns
+    Given I have drafts across all three priorities
+    When I navigate to the drafts board
+    Then I should see three columns labeled "High", "Medium", and "Low"
+    And each draft should appear in the column matching its priority
+
+  Scenario: Draft card shows the prompt
+    Given I have a draft with prompt "Refactor session archiving"
+    When I navigate to the drafts board
+    Then the draft card should display the prompt text
+
+  Scenario: Empty board shows guidance to create the first draft
+    Given I have no drafts
+    When I navigate to the drafts board
+    Then I should see an empty state inviting me to create the first draft
+
+  # --- Sidebar ---
+
+  Scenario: Sidebar has a Drafts entry next to Crafting Board
+    Given I am on any page with the sidebar visible
+    When I look at the navigation sidebar
+    Then I should see a "Drafts" entry peer to "Crafting Board"
+    And clicking it should navigate to the drafts board
+
+  # --- Create ---
+
+  Scenario: Create a new draft from the drafts board
+    Given I am on the drafts board
+    When I click "New Draft"
+    And I fill in the prompt, pick a project, and pick a priority
+    And I save the draft
+    Then the draft should appear in the matching priority column
+
+  Scenario: Cannot create a draft without a project
+    Given I am on the new draft page
+    When I submit the form without selecting a project
+    Then I should see a validation error about the project
+
+  Scenario: Cannot create a draft without a priority
+    Given I am on the new draft page
+    When I submit the form without picking a priority
+    Then I should see a validation error about the priority
+
+  # --- Detail / Edit ---
+
+  Scenario: Open a draft detail page
+    Given I have an existing draft
+    When I click the draft card on the board
+    Then I should be taken to the draft's detail page
+    And the form should be pre-populated with the draft's prompt, project, and priority
+
+  Scenario: Edit the prompt, project, and priority of an existing draft
+    Given I am on an existing draft's detail page
+    When I change the prompt, project, and priority and save
+    Then the changes should persist
+    And the draft should appear in the new priority column on the board
+
+  # --- Discard ---
+
+  Scenario: Discard a draft from its detail page
+    Given I am on an existing draft's detail page
+    When I click "Discard"
+    Then the draft should be soft-archived
+    And I should be returned to the drafts board
+    And the draft should no longer appear anywhere in the UI
+
+  # --- Launch ---
+
+  Scenario: Launch a workflow from a draft skips prompt and project selection
+    Given I am on an existing draft's detail page
+    When I click "Start workflow"
+    And I choose a workflow type
+    Then a workflow session should be created with the draft's prompt and project
+    And I should land directly on the workflow runner without seeing the prompt/project form
+
+  Scenario: Launching a workflow auto-archives the draft
+    Given I have launched a workflow from a draft successfully
+    When I return to the drafts board
+    Then the originating draft should no longer appear
+
+  # --- Reordering ---
+
+  Scenario: Reorder drafts within a priority column
+    Given I have multiple drafts in the High priority column
+    When I drag a draft to a new position within the same column
+    Then the new order should persist across reloads
+
+  Scenario: Move a draft to a different priority column via drag-and-drop
+    Given I have a draft in the Low priority column
+    When I drag it into the High priority column
+    Then the draft's priority should become High
+    And the draft should appear in the High column on reload

--- a/features/drafts_board.feature
+++ b/features/drafts_board.feature
@@ -26,6 +26,20 @@ Feature: Drafts Board
     When I navigate to the drafts board
     Then I should see an empty state inviting me to create the first draft
 
+  # --- Filter ---
+
+  Scenario: Filter drafts by project
+    Given I have drafts across multiple projects
+    When I pick a project in the filter dropdown
+    Then only drafts from that project should remain visible on the board
+    And clearing the filter should restore drafts from all projects
+
+  Scenario: Filter with no matching drafts shows a no-matches state
+    Given I have drafts for project A only
+    When I filter by project B
+    Then I should see a no-matches message
+    And the columns should not be rendered
+
   # --- Sidebar ---
 
   Scenario: Sidebar has a Drafts entry next to Crafting Board

--- a/lib/destila/drafts.ex
+++ b/lib/destila/drafts.ex
@@ -1,0 +1,217 @@
+defmodule Destila.Drafts do
+  @moduledoc """
+  Drafts context. Drafts are lightweight prompt + project + priority triples
+  that live on a kanban board before being promoted to a workflow session.
+  """
+
+  import Ecto.Query
+
+  alias Destila.Repo
+  alias Destila.Drafts.Draft
+  alias Destila.Projects.Project
+
+  @priorities [:low, :medium, :high]
+
+  @doc "Returns the list of supported priorities."
+  def priorities, do: @priorities
+
+  def list_drafts_by_priority(priority) do
+    Repo.all(
+      from(d in Draft,
+        where: d.priority == ^priority and is_nil(d.archived_at),
+        order_by: [asc: d.position, asc: d.inserted_at],
+        preload: :project
+      )
+    )
+  end
+
+  @doc """
+  Returns a map of `:low | :medium | :high` -> list of active drafts, each
+  ordered ascending by position then inserted_at.
+  """
+  def list_all_active do
+    drafts =
+      Repo.all(
+        from(d in Draft,
+          where: is_nil(d.archived_at),
+          order_by: [asc: d.position, asc: d.inserted_at],
+          preload: :project
+        )
+      )
+
+    grouped = Enum.group_by(drafts, & &1.priority)
+    Map.new(@priorities, fn p -> {p, Map.get(grouped, p, [])} end)
+  end
+
+  def get_draft(id) do
+    Repo.one(
+      from(d in Draft,
+        where: d.id == ^id and is_nil(d.archived_at),
+        preload: :project
+      )
+    )
+  end
+
+  def get_draft!(id) do
+    Repo.one!(
+      from(d in Draft,
+        where: d.id == ^id and is_nil(d.archived_at),
+        preload: :project
+      )
+    )
+  end
+
+  def create_draft(attrs) do
+    attrs = normalize_attrs(attrs)
+
+    with :ok <- validate_project(attrs[:project_id]),
+         :ok <- validate_priority(attrs[:priority]) do
+      attrs = Map.put(attrs, :position, next_position(attrs[:priority]))
+
+      %Draft{}
+      |> Draft.changeset(attrs)
+      |> Repo.insert()
+      |> preload_result()
+      |> broadcast(:draft_created)
+    else
+      {:error, {:project, reason}} ->
+        {:error, project_error_changeset(attrs, reason)}
+
+      {:error, :invalid_priority} ->
+        {:error,
+         %Draft{}
+         |> Draft.changeset(attrs)
+         |> Map.put(:action, :insert)}
+    end
+  end
+
+  defp validate_priority(priority) when priority in @priorities, do: :ok
+  defp validate_priority(_), do: {:error, :invalid_priority}
+
+  def update_draft(%Draft{} = draft, attrs) do
+    attrs = normalize_attrs(attrs)
+
+    with :ok <- maybe_validate_project(attrs) do
+      attrs =
+        if attrs[:priority] && attrs[:priority] != draft.priority do
+          Map.put(attrs, :position, next_position(attrs[:priority]))
+        else
+          attrs
+        end
+
+      draft
+      |> Draft.changeset(attrs)
+      |> Repo.update()
+      |> preload_result()
+      |> broadcast(:draft_updated)
+    else
+      {:error, {:project, reason}} ->
+        {:error,
+         draft
+         |> Draft.changeset(attrs)
+         |> Ecto.Changeset.add_error(:project_id, project_error_message(reason))
+         |> Map.put(:action, :update)}
+    end
+  end
+
+  defp maybe_validate_project(attrs) do
+    if Map.has_key?(attrs, :project_id) do
+      validate_project(attrs[:project_id])
+    else
+      :ok
+    end
+  end
+
+  def archive_draft(%Draft{} = draft) do
+    draft
+    |> Draft.changeset(%{archived_at: DateTime.utc_now()})
+    |> Repo.update()
+    |> preload_result()
+    |> broadcast(:draft_updated)
+  end
+
+  @doc """
+  Repositions a draft within a priority column or moves it to a new one.
+  `before_id` is the neighbor immediately above the drop point; `after_id`
+  is the neighbor immediately below. Either or both may be nil.
+  """
+  def reposition_draft(%Draft{} = draft, target_priority, before_id, after_id)
+      when target_priority in @priorities do
+    before_draft = before_id && Repo.get(Draft, before_id)
+    after_draft = after_id && Repo.get(Draft, after_id)
+
+    position = compute_position(target_priority, before_draft, after_draft)
+
+    draft
+    |> Draft.changeset(%{priority: target_priority, position: position})
+    |> Repo.update()
+    |> preload_result()
+    |> broadcast(:draft_updated)
+  end
+
+  defp compute_position(priority, nil, nil) do
+    next_position(priority)
+  end
+
+  defp compute_position(_priority, nil, %Draft{position: pos}), do: pos - 1.0
+  defp compute_position(_priority, %Draft{position: pos}, nil), do: pos + 1.0
+
+  defp compute_position(_priority, %Draft{position: before_pos}, %Draft{position: after_pos}) do
+    (before_pos + after_pos) / 2
+  end
+
+  defp next_position(priority) do
+    max =
+      Repo.one(
+        from(d in Draft,
+          where: d.priority == ^priority and is_nil(d.archived_at),
+          select: max(d.position)
+        )
+      )
+
+    case max do
+      nil -> 1.0
+      value -> value + 1.0
+    end
+  end
+
+  defp validate_project(nil), do: {:error, {:project, :missing}}
+
+  defp validate_project(project_id) do
+    case Repo.get(Project, project_id) do
+      nil -> {:error, {:project, :not_found}}
+      %Project{archived_at: nil} -> :ok
+      %Project{} -> {:error, {:project, :archived}}
+    end
+  end
+
+  defp project_error_changeset(attrs, reason) do
+    %Draft{}
+    |> Draft.changeset(attrs)
+    |> Ecto.Changeset.add_error(:project_id, project_error_message(reason))
+    |> Map.put(:action, :insert)
+  end
+
+  defp project_error_message(:missing), do: "can't be blank"
+  defp project_error_message(:not_found), do: "does not exist"
+  defp project_error_message(:archived), do: "is archived"
+
+  defp normalize_attrs(attrs) when is_map(attrs) do
+    Map.new(attrs, fn {k, v} ->
+      key = if is_binary(k), do: String.to_existing_atom(k), else: k
+      {key, normalize_value(key, v)}
+    end)
+  end
+
+  defp normalize_value(:priority, value) when is_binary(value) and value != "" do
+    String.to_existing_atom(value)
+  end
+
+  defp normalize_value(:priority, ""), do: nil
+  defp normalize_value(_key, value), do: value
+
+  defp preload_result({:ok, draft}), do: {:ok, Repo.preload(draft, :project)}
+  defp preload_result({:error, _} = error), do: error
+
+  defdelegate broadcast(result, event), to: Destila.PubSubHelper
+end

--- a/lib/destila/drafts/draft.ex
+++ b/lib/destila/drafts/draft.ex
@@ -1,0 +1,24 @@
+defmodule Destila.Drafts.Draft do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "drafts" do
+    field(:prompt, :string)
+    field(:priority, Ecto.Enum, values: [:low, :medium, :high])
+    field(:position, :float)
+    field(:archived_at, :utc_datetime)
+
+    belongs_to(:project, Destila.Projects.Project)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(draft, attrs) do
+    draft
+    |> cast(attrs, [:prompt, :priority, :position, :project_id, :archived_at])
+    |> validate_required([:prompt, :priority, :position, :project_id])
+    |> foreign_key_constraint(:project_id)
+  end
+end

--- a/lib/destila_web/components/layouts.ex
+++ b/lib/destila_web/components/layouts.ex
@@ -49,6 +49,12 @@ defmodule DestilaWeb.Layouts do
           active={@page_title == "Crafting Board"}
         />
         <.sidebar_item
+          navigate={~p"/drafts"}
+          icon="hero-document-text"
+          label="Drafts"
+          active={@page_title == "Drafts"}
+        />
+        <.sidebar_item
           navigate={~p"/projects"}
           icon="hero-folder"
           label="Projects"

--- a/lib/destila_web/components/layouts.ex
+++ b/lib/destila_web/components/layouts.ex
@@ -68,6 +68,11 @@ defmodule DestilaWeb.Layouts do
           icon="hero-plus-circle"
           label="New Session"
         />
+        <.sidebar_item
+          navigate={~p"/drafts/new"}
+          icon="hero-document-plus"
+          label="New Draft"
+        />
       </nav>
 
       <%!-- Bottom --%>

--- a/lib/destila_web/live/create_session_live.ex
+++ b/lib/destila_web/live/create_session_live.ex
@@ -10,20 +10,80 @@ defmodule DestilaWeb.CreateSessionLive do
   alias Destila.Workflows
 
   def mount(params, _session, socket) do
-    if Map.has_key?(params, "workflow_type") do
-      mount_form(params["workflow_type"], socket)
-    else
-      mount_type_selection(socket)
+    draft_id = params["draft_id"]
+
+    cond do
+      draft_id && Map.has_key?(params, "workflow_type") ->
+        mount_launch_from_draft(draft_id, params["workflow_type"], socket)
+
+      Map.has_key?(params, "workflow_type") ->
+        mount_form(params["workflow_type"], socket)
+
+      true ->
+        mount_type_selection(socket, draft_id)
     end
   end
 
-  defp mount_type_selection(socket) do
+  defp mount_type_selection(socket, draft_id) do
     {:ok,
      socket
      |> assign(:view, :selecting_type)
      |> assign(:workflow_metadata, Workflows.workflow_type_metadata())
+     |> assign(:draft_id, draft_id)
      |> assign(:page_title, "New Session")}
   end
+
+  defp mount_launch_from_draft(draft_id, workflow_type_str, socket) do
+    with {:ok, workflow_type} <- cast_workflow_type(workflow_type_str),
+         %Destila.Drafts.Draft{} = draft <- Destila.Drafts.get_draft(draft_id) do
+      case Workflows.create_workflow_session(%{
+             workflow_type: workflow_type,
+             input_text: draft.prompt,
+             project_id: draft.project_id
+           }) do
+        {:ok, ws} ->
+          {:ok, _} = Destila.Drafts.archive_draft(draft)
+
+          {:ok,
+           socket
+           |> assign(:view, :launching)
+           |> assign(:page_title, "Launching workflow…")
+           |> push_navigate(to: ~p"/sessions/#{ws.id}")}
+
+        {:error, _} ->
+          {:ok,
+           socket
+           |> put_flash(:error, "Could not launch workflow from this draft")
+           |> push_navigate(to: ~p"/drafts/#{draft.id}")}
+      end
+    else
+      :invalid_workflow_type ->
+        {:ok,
+         socket
+         |> put_flash(:error, "Unknown workflow type")
+         |> push_navigate(to: ~p"/workflows")}
+
+      nil ->
+        {:ok,
+         socket
+         |> put_flash(:error, "Draft not found")
+         |> push_navigate(to: ~p"/drafts")}
+    end
+  end
+
+  defp cast_workflow_type(str) when is_binary(str) do
+    atom = String.to_existing_atom(str)
+
+    if atom in Workflows.workflow_types() do
+      {:ok, atom}
+    else
+      :invalid_workflow_type
+    end
+  rescue
+    ArgumentError -> :invalid_workflow_type
+  end
+
+  defp cast_workflow_type(_), do: :invalid_workflow_type
 
   defp mount_form(workflow_type_str, socket) do
     workflow_type = String.to_existing_atom(workflow_type_str)
@@ -149,6 +209,24 @@ defmodule DestilaWeb.CreateSessionLive do
      |> assign(:errors, %{})}
   end
 
+  defp type_card_path(type, nil), do: ~p"/workflows/#{type}"
+  defp type_card_path(type, draft_id), do: ~p"/workflows/#{type}?draft_id=#{draft_id}"
+
+  # --- Render: launching from draft ---
+
+  def render(%{view: :launching} = assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} page_title={@page_title}>
+      <div class="flex items-center justify-center min-h-screen" id="launching-from-draft">
+        <div class="text-center">
+          <.icon name="hero-arrow-path" class="size-8 motion-safe:animate-spin mb-4" />
+          <p class="text-sm text-base-content/60">Launching workflow…</p>
+        </div>
+      </div>
+    </Layouts.app>
+    """
+  end
+
   # --- Render: type selection ---
 
   def render(%{view: :selecting_type} = assigns) do
@@ -164,7 +242,7 @@ defmodule DestilaWeb.CreateSessionLive do
           <div class="grid gap-4">
             <.link
               :for={wf <- @workflow_metadata}
-              navigate={~p"/workflows/#{wf.type}"}
+              navigate={type_card_path(wf.type, @draft_id)}
               class="card bg-base-100 border-2 border-base-300 hover:border-primary transition-colors cursor-pointer text-left"
               id={"type-#{wf.type}"}
             >

--- a/lib/destila_web/live/draft_form_live.ex
+++ b/lib/destila_web/live/draft_form_live.ex
@@ -1,0 +1,310 @@
+defmodule DestilaWeb.DraftFormLive do
+  @moduledoc """
+  LiveView for creating and editing drafts.
+
+  - `/drafts/new` — create a new draft
+  - `/drafts/:id` — edit/detail view for an existing draft (also the launch
+    entry point and the discard action)
+  """
+
+  use DestilaWeb, :live_view
+
+  import DestilaWeb.ProjectComponents
+
+  alias Destila.Drafts
+
+  def mount(%{"id" => id}, _session, socket) do
+    if connected?(socket), do: Phoenix.PubSub.subscribe(Destila.PubSub, "store:updates")
+
+    case Drafts.get_draft(id) do
+      nil ->
+        {:ok,
+         socket
+         |> put_flash(:error, "Draft not found")
+         |> push_navigate(to: ~p"/drafts")}
+
+      draft ->
+        {:ok, assign_form(socket, :edit, draft)}
+    end
+  end
+
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: Phoenix.PubSub.subscribe(Destila.PubSub, "store:updates")
+    {:ok, assign_form(socket, :new, nil)}
+  end
+
+  defp assign_form(socket, mode, draft) do
+    params =
+      case draft do
+        nil ->
+          %{"prompt" => "", "priority" => "", "project_id" => ""}
+
+        %Drafts.Draft{} = d ->
+          %{
+            "prompt" => d.prompt || "",
+            "priority" => if(d.priority, do: Atom.to_string(d.priority), else: ""),
+            "project_id" => d.project_id || ""
+          }
+      end
+
+    page_title = if mode == :edit, do: "Edit Draft", else: "New Draft"
+
+    socket
+    |> assign(:mode, mode)
+    |> assign(:draft, draft)
+    |> assign(:page_title, page_title)
+    |> assign(:projects, Destila.Projects.list_projects())
+    |> assign(:project_id, params["project_id"])
+    |> assign(:project_step, :select)
+    |> assign(:prompt, params["prompt"])
+    |> assign(:priority, params["priority"])
+    |> assign(:errors, %{})
+  end
+
+  # --- Form events ---
+
+  def handle_event("validate", params, socket) do
+    {:noreply,
+     socket
+     |> assign(:prompt, params["prompt"] || "")
+     |> assign(:priority, params["priority"] || "")}
+  end
+
+  def handle_event("save", params, socket) do
+    socket =
+      socket
+      |> assign(:prompt, params["prompt"] || socket.assigns.prompt)
+      |> assign(:priority, params["priority"] || socket.assigns.priority)
+
+    attrs = %{
+      prompt: String.trim(socket.assigns.prompt || ""),
+      priority: socket.assigns.priority,
+      project_id: socket.assigns.project_id
+    }
+
+    errors = validate(attrs)
+
+    cond do
+      errors != %{} ->
+        {:noreply, assign(socket, :errors, errors)}
+
+      socket.assigns.mode == :edit ->
+        handle_save_result(Drafts.update_draft(socket.assigns.draft, attrs), socket)
+
+      true ->
+        handle_save_result(Drafts.create_draft(attrs), socket)
+    end
+  end
+
+  # --- Detail-only events ---
+
+  def handle_event("discard", _params, %{assigns: %{mode: :edit, draft: draft}} = socket) do
+    {:ok, _} = Drafts.archive_draft(draft)
+
+    {:noreply,
+     socket
+     |> put_flash(:info, "Draft discarded")
+     |> push_navigate(to: ~p"/drafts")}
+  end
+
+  def handle_event("start_workflow", _params, %{assigns: %{mode: :edit, draft: draft}} = socket) do
+    {:noreply, push_navigate(socket, to: ~p"/workflows?draft_id=#{draft.id}")}
+  end
+
+  # --- Project selector events ---
+
+  def handle_event("select_project", %{"id" => id}, socket) do
+    {:noreply,
+     socket
+     |> assign(:project_id, id)
+     |> assign(:errors, Map.delete(socket.assigns.errors, :project))}
+  end
+
+  def handle_event("show_create_project", _params, socket) do
+    {:noreply, assign(socket, project_step: :create, errors: %{})}
+  end
+
+  def handle_event("back_to_select", _params, socket) do
+    {:noreply, assign(socket, :project_step, :select)}
+  end
+
+  defp handle_save_result({:ok, _draft}, socket) do
+    {:noreply, push_navigate(socket, to: ~p"/drafts")}
+  end
+
+  defp handle_save_result({:error, changeset}, socket) do
+    {:noreply, assign(socket, :errors, changeset_to_errors(changeset))}
+  end
+
+  # --- Callbacks ---
+
+  def handle_info({:project_saved, project}, socket) do
+    {:noreply,
+     socket
+     |> assign(:project_id, project.id)
+     |> assign(:projects, Destila.Projects.list_projects())
+     |> assign(:project_step, :select)
+     |> assign(:errors, %{})}
+  end
+
+  def handle_info({event, _data}, socket)
+      when event in [:project_created, :project_updated, :project_deleted] do
+    {:noreply, assign(socket, :projects, Destila.Projects.list_projects())}
+  end
+
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
+  # --- Helpers ---
+
+  defp validate(attrs) do
+    errors = %{}
+
+    errors =
+      if attrs.prompt == "",
+        do: Map.put(errors, :prompt, "Please write a prompt"),
+        else: errors
+
+    errors =
+      if attrs.priority in ["low", "medium", "high"],
+        do: errors,
+        else: Map.put(errors, :priority, "Please pick a priority")
+
+    errors =
+      if attrs.project_id in [nil, ""],
+        do: Map.put(errors, :project, "Please select a project"),
+        else: errors
+
+    errors
+  end
+
+  defp changeset_to_errors(%Ecto.Changeset{} = changeset) do
+    Enum.reduce(changeset.errors, %{}, fn
+      {:prompt, {msg, _}}, acc -> Map.put(acc, :prompt, msg)
+      {:priority, {msg, _}}, acc -> Map.put(acc, :priority, msg)
+      {:project_id, {msg, _}}, acc -> Map.put(acc, :project, msg)
+      _, acc -> acc
+    end)
+  end
+
+  # --- Render ---
+
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} page_title={@page_title}>
+      <div class="overflow-y-auto h-screen px-6 py-6">
+        <div class="max-w-2xl mx-auto space-y-6">
+          <div class="flex justify-between items-center">
+            <h1 class="text-2xl font-bold tracking-tight">{@page_title}</h1>
+            <.link
+              navigate={~p"/drafts"}
+              class="text-xs text-base-content/40 hover:text-base-content/60 flex items-center gap-1"
+              id="back-to-drafts"
+            >
+              <.icon name="hero-arrow-left-micro" class="size-3.5" /> Back to drafts
+            </.link>
+          </div>
+
+          <form
+            id="draft-form"
+            phx-submit="save"
+            phx-change="validate"
+            class="space-y-5"
+          >
+            <%!-- Prompt --%>
+            <div>
+              <label class="block text-sm font-medium mb-2" for="draft-prompt">
+                Prompt <span class="text-error">*</span>
+              </label>
+              <textarea
+                id="draft-prompt"
+                name="prompt"
+                rows="6"
+                phx-debounce="300"
+                placeholder="What's the idea?"
+                aria-invalid={@errors[:prompt] && "true"}
+                class={[
+                  "textarea textarea-bordered w-full",
+                  @errors[:prompt] && "textarea-error"
+                ]}
+              >{@prompt}</textarea>
+              <p :if={@errors[:prompt]} class="text-xs text-error mt-1">{@errors[:prompt]}</p>
+            </div>
+
+            <%!-- Priority --%>
+            <div>
+              <label class="block text-sm font-medium mb-2" for="draft-priority">
+                Priority <span class="text-error">*</span>
+              </label>
+              <select
+                id="draft-priority"
+                name="priority"
+                aria-invalid={@errors[:priority] && "true"}
+                class={[
+                  "select select-bordered w-full",
+                  @errors[:priority] && "select-error"
+                ]}
+              >
+                <option value="" disabled selected={@priority in [nil, ""]}>
+                  Select priority…
+                </option>
+                <option value="high" selected={@priority == "high"}>High</option>
+                <option value="medium" selected={@priority == "medium"}>Medium</option>
+                <option value="low" selected={@priority == "low"}>Low</option>
+              </select>
+              <p :if={@errors[:priority]} class="text-xs text-error mt-1">{@errors[:priority]}</p>
+            </div>
+          </form>
+
+          <%!-- Project section (its own <.live_component> form) --%>
+          <div class="border-t border-base-300 pt-6">
+            <.project_selector
+              projects={@projects}
+              selected_id={@project_id}
+              step={@project_step}
+              errors={@errors}
+              target={nil}
+            />
+            <%= if @mode == :edit && @draft.project && @draft.project.archived_at do %>
+              <p class="text-xs text-warning mt-2" id="archived-project-indicator">
+                <.icon name="hero-archive-box-micro" class="size-3.5 inline" />
+                The linked project is archived. Select another project or keep this one.
+              </p>
+            <% end %>
+          </div>
+
+          <%!-- Actions --%>
+          <div :if={@project_step == :select} class="flex flex-col gap-2">
+            <button
+              type="submit"
+              form="draft-form"
+              class="btn btn-primary w-full"
+              id="save-draft-btn"
+            >
+              <.icon name="hero-check-micro" class="size-4" /> Save draft
+            </button>
+
+            <%= if @mode == :edit do %>
+              <button
+                phx-click="start_workflow"
+                class="btn btn-secondary w-full"
+                id="start-workflow-btn"
+              >
+                <.icon name="hero-bolt-micro" class="size-4" /> Start workflow
+              </button>
+
+              <button
+                phx-click="discard"
+                data-confirm="Discard this draft? This cannot be undone."
+                class="btn btn-ghost btn-sm text-error/70 hover:text-error"
+                id="discard-draft-btn"
+              >
+                Discard
+              </button>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </Layouts.app>
+    """
+  end
+end

--- a/lib/destila_web/live/draft_form_live.ex
+++ b/lib/destila_web/live/draft_form_live.ex
@@ -99,12 +99,16 @@ defmodule DestilaWeb.DraftFormLive do
   # --- Detail-only events ---
 
   def handle_event("discard", _params, %{assigns: %{mode: :edit, draft: draft}} = socket) do
-    {:ok, _} = Drafts.archive_draft(draft)
+    case Drafts.archive_draft(draft) do
+      {:ok, _} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Draft discarded")
+         |> push_navigate(to: ~p"/drafts")}
 
-    {:noreply,
-     socket
-     |> put_flash(:info, "Draft discarded")
-     |> push_navigate(to: ~p"/drafts")}
+      {:error, _changeset} ->
+        {:noreply, put_flash(socket, :error, "Could not discard draft")}
+    end
   end
 
   def handle_event("start_workflow", _params, %{assigns: %{mode: :edit, draft: draft}} = socket) do

--- a/lib/destila_web/live/draft_form_live.ex
+++ b/lib/destila_web/live/draft_form_live.ex
@@ -71,6 +71,8 @@ defmodule DestilaWeb.DraftFormLive do
   end
 
   def handle_event("save", params, socket) do
+    action = params["action"] || "save"
+
     socket =
       socket
       |> assign(:prompt, params["prompt"] || socket.assigns.prompt)
@@ -89,10 +91,10 @@ defmodule DestilaWeb.DraftFormLive do
         {:noreply, assign(socket, :errors, errors)}
 
       socket.assigns.mode == :edit ->
-        handle_save_result(Drafts.update_draft(socket.assigns.draft, attrs), socket)
+        handle_save_result(Drafts.update_draft(socket.assigns.draft, attrs), action, socket)
 
       true ->
-        handle_save_result(Drafts.create_draft(attrs), socket)
+        handle_save_result(Drafts.create_draft(attrs), action, socket)
     end
   end
 
@@ -109,10 +111,6 @@ defmodule DestilaWeb.DraftFormLive do
       {:error, _changeset} ->
         {:noreply, put_flash(socket, :error, "Could not discard draft")}
     end
-  end
-
-  def handle_event("start_workflow", _params, %{assigns: %{mode: :edit, draft: draft}} = socket) do
-    {:noreply, push_navigate(socket, to: ~p"/workflows?draft_id=#{draft.id}")}
   end
 
   # --- Project selector events ---
@@ -132,11 +130,15 @@ defmodule DestilaWeb.DraftFormLive do
     {:noreply, assign(socket, :project_step, :select)}
   end
 
-  defp handle_save_result({:ok, _draft}, socket) do
+  defp handle_save_result({:ok, draft}, "start_workflow", socket) do
+    {:noreply, push_navigate(socket, to: ~p"/workflows?draft_id=#{draft.id}")}
+  end
+
+  defp handle_save_result({:ok, _draft}, _action, socket) do
     {:noreply, push_navigate(socket, to: ~p"/drafts")}
   end
 
-  defp handle_save_result({:error, changeset}, socket) do
+  defp handle_save_result({:error, changeset}, _action, socket) do
     {:noreply, assign(socket, :errors, changeset_to_errors(changeset))}
   end
 
@@ -281,6 +283,8 @@ defmodule DestilaWeb.DraftFormLive do
             <button
               type="submit"
               form="draft-form"
+              name="action"
+              value="save"
               class="btn btn-primary w-full"
               id="save-draft-btn"
             >
@@ -289,7 +293,10 @@ defmodule DestilaWeb.DraftFormLive do
 
             <%= if @mode == :edit do %>
               <button
-                phx-click="start_workflow"
+                type="submit"
+                form="draft-form"
+                name="action"
+                value="start_workflow"
                 class="btn btn-secondary w-full"
                 id="start-workflow-btn"
               >
@@ -297,6 +304,7 @@ defmodule DestilaWeb.DraftFormLive do
               </button>
 
               <button
+                type="button"
                 phx-click="discard"
                 data-confirm="Discard this draft? This cannot be undone."
                 class="btn btn-ghost btn-sm text-error/70 hover:text-error"

--- a/lib/destila_web/live/drafts_board_live.ex
+++ b/lib/destila_web/live/drafts_board_live.ex
@@ -18,27 +18,45 @@ defmodule DestilaWeb.DraftsBoardLive do
   def mount(_params, _session, socket) do
     if connected?(socket), do: Phoenix.PubSub.subscribe(Destila.PubSub, "store:updates")
 
-    grouped = Drafts.list_all_active()
+    all_grouped = Drafts.list_all_active()
 
     {:ok,
      socket
      |> assign(:page_title, "Drafts")
-     |> assign_board(grouped)}
+     |> assign(:all_grouped, all_grouped)
+     |> assign_projects(all_grouped)
+     |> init_streams()}
+  end
+
+  def handle_params(params, _uri, socket) do
+    project_filter = empty_to_nil(params["project"])
+    filtered = filter_by_project(socket.assigns.all_grouped, project_filter)
+
+    {:noreply,
+     socket
+     |> assign(:project_filter, project_filter)
+     |> reset_streams(filtered)
+     |> assign_board_flags(socket.assigns.all_grouped, filtered)}
   end
 
   def handle_info({event, _data}, socket)
       when event in [:draft_created, :draft_updated] do
-    grouped = Drafts.list_all_active()
+    all_grouped = Drafts.list_all_active()
+    filtered = filter_by_project(all_grouped, socket.assigns.project_filter)
 
-    socket =
-      socket
-      |> reset_streams(grouped)
-      |> assign_board_flags(grouped)
-
-    {:noreply, socket}
+    {:noreply,
+     socket
+     |> assign(:all_grouped, all_grouped)
+     |> assign_projects(all_grouped)
+     |> reset_streams(filtered)
+     |> assign_board_flags(all_grouped, filtered)}
   end
 
   def handle_info(_msg, socket), do: {:noreply, socket}
+
+  def handle_event("filter_project", %{"project" => project_id}, socket) do
+    {:noreply, push_patch(socket, to: build_path(empty_to_nil(project_id)))}
+  end
 
   def handle_event(
         "reorder_draft",
@@ -77,11 +95,31 @@ defmodule DestilaWeb.DraftsBoardLive do
   defp empty_to_nil(""), do: nil
   defp empty_to_nil(id), do: id
 
-  defp assign_board(socket, grouped) do
-    Enum.reduce(@priorities, socket, fn priority, acc ->
-      stream(acc, stream_key(priority), Map.get(grouped, priority, []))
+  defp filter_by_project(grouped, nil), do: grouped
+
+  defp filter_by_project(grouped, project_id) do
+    Map.new(grouped, fn {priority, drafts} ->
+      {priority, Enum.filter(drafts, &(&1.project_id == project_id))}
     end)
-    |> assign_board_flags(grouped)
+  end
+
+  defp assign_projects(socket, grouped) do
+    projects =
+      grouped
+      |> Map.values()
+      |> List.flatten()
+      |> Enum.map(& &1.project)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq_by(& &1.id)
+      |> Enum.sort_by(& &1.name)
+
+    assign(socket, :projects, projects)
+  end
+
+  defp init_streams(socket) do
+    Enum.reduce(@priorities, socket, fn priority, acc ->
+      stream(acc, stream_key(priority), [])
+    end)
   end
 
   defp reset_streams(socket, grouped) do
@@ -90,10 +128,17 @@ defmodule DestilaWeb.DraftsBoardLive do
     end)
   end
 
-  defp assign_board_flags(socket, grouped) do
-    any? = Enum.any?(@priorities, fn p -> Map.get(grouped, p, []) != [] end)
-    assign(socket, :any_drafts?, any?)
+  defp assign_board_flags(socket, all_grouped, filtered) do
+    any_drafts? = Enum.any?(@priorities, fn p -> Map.get(all_grouped, p, []) != [] end)
+    any_visible? = Enum.any?(@priorities, fn p -> Map.get(filtered, p, []) != [] end)
+
+    socket
+    |> assign(:any_drafts?, any_drafts?)
+    |> assign(:any_visible?, any_visible?)
   end
+
+  defp build_path(nil), do: ~p"/drafts"
+  defp build_path(project_id), do: ~p"/drafts?project=#{project_id}"
 
   defp stream_key(:high), do: :drafts_high
   defp stream_key(:medium), do: :drafts_medium
@@ -103,7 +148,7 @@ defmodule DestilaWeb.DraftsBoardLive do
     ~H"""
     <Layouts.app flash={@flash} page_title={@page_title}>
       <div class="p-6 lg:p-8">
-        <div class="flex items-center justify-between mb-6">
+        <div class="flex items-center justify-between mb-4">
           <h1 class="text-2xl font-bold tracking-tight">Drafts</h1>
           <.link navigate={~p"/drafts/new"} class="btn btn-primary btn-sm" id="new-draft-btn">
             <.icon name="hero-plus-micro" class="size-4" /> New Draft
@@ -111,26 +156,54 @@ defmodule DestilaWeb.DraftsBoardLive do
         </div>
 
         <%= if @any_drafts? do %>
-          <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <.column
-              priority={:high}
-              label="High"
-              stream={@streams.drafts_high}
-              accent="text-error"
-            />
-            <.column
-              priority={:medium}
-              label="Medium"
-              stream={@streams.drafts_medium}
-              accent="text-warning"
-            />
-            <.column
-              priority={:low}
-              label="Low"
-              stream={@streams.drafts_low}
-              accent="text-base-content/50"
-            />
+          <div class="flex items-center gap-3 mb-6">
+            <form phx-change="filter_project" id="project-filter-form">
+              <select
+                name="project"
+                id="project-filter"
+                class="select select-sm select-bordered"
+              >
+                <option value="">All projects</option>
+                <option
+                  :for={project <- @projects}
+                  value={project.id}
+                  selected={@project_filter == project.id}
+                >
+                  {project.name}
+                </option>
+              </select>
+            </form>
           </div>
+
+          <%= if @any_visible? do %>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <.column
+                priority={:high}
+                label="High"
+                stream={@streams.drafts_high}
+                accent="text-error"
+              />
+              <.column
+                priority={:medium}
+                label="Medium"
+                stream={@streams.drafts_medium}
+                accent="text-warning"
+              />
+              <.column
+                priority={:low}
+                label="Low"
+                stream={@streams.drafts_low}
+                accent="text-base-content/50"
+              />
+            </div>
+          <% else %>
+            <div
+              id="drafts-board-no-matches"
+              class="flex flex-col items-center justify-center h-32 gap-2 text-base-content/20 text-sm bg-base-200/20 rounded-xl border border-dashed border-base-300/50"
+            >
+              <.icon name="hero-funnel-micro" class="size-5" /> No drafts match this filter
+            </div>
+          <% end %>
         <% else %>
           <div class="text-center py-20" id="drafts-board-empty">
             <.icon name="hero-document-text" class="size-12 text-base-content/20 mx-auto mb-3" />

--- a/lib/destila_web/live/drafts_board_live.ex
+++ b/lib/destila_web/live/drafts_board_live.ex
@@ -9,6 +9,8 @@ defmodule DestilaWeb.DraftsBoardLive do
 
   use DestilaWeb, :live_view
 
+  require Logger
+
   alias Destila.Drafts
 
   @priorities [:high, :medium, :low]
@@ -25,7 +27,7 @@ defmodule DestilaWeb.DraftsBoardLive do
   end
 
   def handle_info({event, _data}, socket)
-      when event in [:draft_created, :draft_updated, :draft_deleted] do
+      when event in [:draft_created, :draft_updated] do
     grouped = Drafts.list_all_active()
 
     socket =
@@ -47,7 +49,14 @@ defmodule DestilaWeb.DraftsBoardLive do
          draft when not is_nil(draft) <- Drafts.get_draft(draft_id) do
       before_id = empty_to_nil(params["before_id"])
       after_id = empty_to_nil(params["after_id"])
-      Drafts.reposition_draft(draft, priority, before_id, after_id)
+
+      case Drafts.reposition_draft(draft, priority, before_id, after_id) do
+        {:ok, _} ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning("reposition_draft failed: #{inspect(reason)} draft_id=#{draft_id}")
+      end
     end
 
     {:noreply, socket}

--- a/lib/destila_web/live/drafts_board_live.ex
+++ b/lib/destila_web/live/drafts_board_live.ex
@@ -1,0 +1,183 @@
+defmodule DestilaWeb.DraftsBoardLive do
+  @moduledoc """
+  Priority-based kanban board of drafts at /drafts.
+
+  Three columns: High, Medium, Low. Cards are clickable and navigate to
+  the draft detail page. Drag-and-drop is handled by the `DraftsBoard`
+  JS hook which pushes a `reorder_draft` event.
+  """
+
+  use DestilaWeb, :live_view
+
+  alias Destila.Drafts
+
+  @priorities [:high, :medium, :low]
+
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: Phoenix.PubSub.subscribe(Destila.PubSub, "store:updates")
+
+    grouped = Drafts.list_all_active()
+
+    {:ok,
+     socket
+     |> assign(:page_title, "Drafts")
+     |> assign_board(grouped)}
+  end
+
+  def handle_info({event, _data}, socket)
+      when event in [:draft_created, :draft_updated, :draft_deleted] do
+    grouped = Drafts.list_all_active()
+
+    socket =
+      socket
+      |> reset_streams(grouped)
+      |> assign_board_flags(grouped)
+
+    {:noreply, socket}
+  end
+
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
+  def handle_event(
+        "reorder_draft",
+        %{"draft_id" => draft_id, "priority" => priority_str} = params,
+        socket
+      ) do
+    with {:ok, priority} <- cast_priority(priority_str),
+         draft when not is_nil(draft) <- Drafts.get_draft(draft_id) do
+      before_id = empty_to_nil(params["before_id"])
+      after_id = empty_to_nil(params["after_id"])
+      Drafts.reposition_draft(draft, priority, before_id, after_id)
+    end
+
+    {:noreply, socket}
+  end
+
+  defp cast_priority(str) when is_binary(str) do
+    case String.to_existing_atom(str) do
+      atom when atom in @priorities -> {:ok, atom}
+      _ -> :error
+    end
+  rescue
+    ArgumentError -> :error
+  end
+
+  defp cast_priority(_), do: :error
+
+  defp empty_to_nil(nil), do: nil
+  defp empty_to_nil(""), do: nil
+  defp empty_to_nil(id), do: id
+
+  defp assign_board(socket, grouped) do
+    Enum.reduce(@priorities, socket, fn priority, acc ->
+      stream(acc, stream_key(priority), Map.get(grouped, priority, []))
+    end)
+    |> assign_board_flags(grouped)
+  end
+
+  defp reset_streams(socket, grouped) do
+    Enum.reduce(@priorities, socket, fn priority, acc ->
+      stream(acc, stream_key(priority), Map.get(grouped, priority, []), reset: true)
+    end)
+  end
+
+  defp assign_board_flags(socket, grouped) do
+    any? = Enum.any?(@priorities, fn p -> Map.get(grouped, p, []) != [] end)
+    assign(socket, :any_drafts?, any?)
+  end
+
+  defp stream_key(:high), do: :drafts_high
+  defp stream_key(:medium), do: :drafts_medium
+  defp stream_key(:low), do: :drafts_low
+
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} page_title={@page_title}>
+      <div class="p-6 lg:p-8">
+        <div class="flex items-center justify-between mb-6">
+          <h1 class="text-2xl font-bold tracking-tight">Drafts</h1>
+          <.link navigate={~p"/drafts/new"} class="btn btn-primary btn-sm" id="new-draft-btn">
+            <.icon name="hero-plus-micro" class="size-4" /> New Draft
+          </.link>
+        </div>
+
+        <%= if @any_drafts? do %>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <.column
+              priority={:high}
+              label="High"
+              stream={@streams.drafts_high}
+              accent="text-error"
+            />
+            <.column
+              priority={:medium}
+              label="Medium"
+              stream={@streams.drafts_medium}
+              accent="text-warning"
+            />
+            <.column
+              priority={:low}
+              label="Low"
+              stream={@streams.drafts_low}
+              accent="text-base-content/50"
+            />
+          </div>
+        <% else %>
+          <div class="text-center py-20" id="drafts-board-empty">
+            <.icon name="hero-document-text" class="size-12 text-base-content/20 mx-auto mb-3" />
+            <p class="text-sm text-base-content/40 mb-4">
+              No drafts yet — capture your first idea.
+            </p>
+            <.link
+              navigate={~p"/drafts/new"}
+              class="btn btn-primary"
+              id="create-first-draft-btn"
+            >
+              <.icon name="hero-plus-micro" class="size-4" /> Create your first draft
+            </.link>
+          </div>
+        <% end %>
+      </div>
+    </Layouts.app>
+    """
+  end
+
+  attr :priority, :atom, required: true
+  attr :label, :string, required: true
+  attr :stream, :any, required: true
+  attr :accent, :string, default: ""
+
+  defp column(assigns) do
+    ~H"""
+    <div
+      id={"column-#{@priority}"}
+      phx-hook="DraftsBoard"
+      data-priority={@priority}
+      class="bg-base-200/40 rounded-lg p-3 flex flex-col gap-2 min-h-[12rem]"
+    >
+      <header class="flex items-center gap-2 px-1 pb-2 border-b border-base-300/50">
+        <span class={["text-sm font-semibold tracking-tight", @accent]}>{@label}</span>
+      </header>
+
+      <div id={"drafts-#{@priority}"} phx-update="stream" class="space-y-2 min-h-[2rem]">
+        <div :for={{id, draft} <- @stream} id={id} data-draft-id={draft.id}>
+          <.link
+            navigate={~p"/drafts/#{draft.id}"}
+            draggable="true"
+            class="block p-3 rounded-lg bg-base-100 shadow-sm hover:shadow-md transition-shadow cursor-pointer"
+          >
+            <p class="text-sm line-clamp-3 whitespace-pre-wrap">{draft.prompt}</p>
+            <div class="flex items-center gap-1 mt-2 text-xs text-base-content/40">
+              <.icon name="hero-folder-micro" class="size-3.5" />
+              <span class="truncate">{draft.project.name}</span>
+              <span :if={draft.project.archived_at} class="ml-1 text-warning">
+                (archived)
+              </span>
+            </div>
+          </.link>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/destila_web/router.ex
+++ b/lib/destila_web/router.ex
@@ -41,6 +41,9 @@ defmodule DestilaWeb.Router do
     live "/crafting", CraftingBoardLive
     live "/projects/archived", ArchivedProjectsLive
     live "/projects", ProjectsLive
+    live "/drafts", DraftsBoardLive
+    live "/drafts/new", DraftFormLive
+    live "/drafts/:id", DraftFormLive
     live "/workflows", CreateSessionLive
     live "/workflows/:workflow_type", CreateSessionLive
     live "/sessions/archived", ArchivedSessionsLive

--- a/priv/repo/migrations/20260418000000_create_drafts.exs
+++ b/priv/repo/migrations/20260418000000_create_drafts.exs
@@ -1,0 +1,20 @@
+defmodule Destila.Repo.Migrations.CreateDrafts do
+  use Ecto.Migration
+
+  def change do
+    create table(:drafts, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :prompt, :text, null: false
+      add :priority, :string, null: false
+      add :position, :float, null: false
+      add :archived_at, :utc_datetime
+      add :project_id, references(:projects, type: :binary_id, on_delete: :restrict), null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:drafts, [:priority, :position])
+    create index(:drafts, [:archived_at])
+    create index(:drafts, [:project_id])
+  end
+end

--- a/test/destila/drafts/draft_test.exs
+++ b/test/destila/drafts/draft_test.exs
@@ -1,0 +1,41 @@
+defmodule Destila.Drafts.DraftTest do
+  use DestilaWeb.ConnCase, async: false
+
+  alias Destila.Drafts.Draft
+
+  describe "changeset/2" do
+    test "requires prompt, priority, position, and project_id" do
+      changeset = Draft.changeset(%Draft{}, %{})
+      refute changeset.valid?
+      assert changeset.errors[:prompt]
+      assert changeset.errors[:priority]
+      assert changeset.errors[:position]
+      assert changeset.errors[:project_id]
+    end
+
+    test "accepts a valid set of attributes" do
+      attrs = %{
+        prompt: "Refactor the thing",
+        priority: :high,
+        position: 1.0,
+        project_id: Ecto.UUID.generate()
+      }
+
+      changeset = Draft.changeset(%Draft{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "rejects unknown priority values" do
+      attrs = %{
+        prompt: "p",
+        priority: "banana",
+        position: 1.0,
+        project_id: Ecto.UUID.generate()
+      }
+
+      changeset = Draft.changeset(%Draft{}, attrs)
+      refute changeset.valid?
+      assert changeset.errors[:priority]
+    end
+  end
+end

--- a/test/destila/drafts_test.exs
+++ b/test/destila/drafts_test.exs
@@ -1,0 +1,312 @@
+defmodule Destila.DraftsTest do
+  use DestilaWeb.ConnCase, async: false
+
+  alias Destila.Drafts
+  alias Destila.Drafts.Draft
+  alias Destila.Projects
+
+  @feature "drafts_board"
+
+  defp create_project!(attrs \\ %{}) do
+    defaults = %{
+      name: "Proj #{System.unique_integer([:positive])}",
+      git_repo_url: "https://github.com/test/repo"
+    }
+
+    {:ok, project} = Projects.create_project(Map.merge(defaults, attrs))
+    project
+  end
+
+  describe "create_draft/1" do
+    @tag feature: @feature, scenario: "Create a new draft from the drafts board"
+    test "persists a draft with all required fields" do
+      project = create_project!()
+
+      {:ok, draft} =
+        Drafts.create_draft(%{
+          prompt: "Try this idea",
+          priority: :high,
+          project_id: project.id
+        })
+
+      assert draft.id
+      assert draft.prompt == "Try this idea"
+      assert draft.priority == :high
+      assert is_float(draft.position)
+      assert draft.project.id == project.id
+    end
+
+    test "broadcasts :draft_created" do
+      project = create_project!()
+      Phoenix.PubSub.subscribe(Destila.PubSub, "store:updates")
+
+      {:ok, draft} =
+        Drafts.create_draft(%{
+          prompt: "Hi",
+          priority: :medium,
+          project_id: project.id
+        })
+
+      id = draft.id
+      assert_receive {:draft_created, %Draft{id: ^id}}
+    end
+
+    @tag feature: @feature, scenario: "Cannot create a draft without a priority"
+    test "fails without a priority" do
+      project = create_project!()
+
+      assert {:error, changeset} =
+               Drafts.create_draft(%{
+                 prompt: "Hi",
+                 priority: nil,
+                 project_id: project.id
+               })
+
+      assert changeset.errors[:priority]
+    end
+
+    @tag feature: @feature, scenario: "Cannot create a draft without a project"
+    test "fails without a project_id" do
+      assert {:error, changeset} =
+               Drafts.create_draft(%{
+                 prompt: "Hi",
+                 priority: :low,
+                 project_id: nil
+               })
+
+      assert changeset.errors[:project_id]
+    end
+
+    test "fails for an archived project" do
+      project = create_project!()
+      {:ok, _} = Projects.archive_project(project)
+
+      assert {:error, changeset} =
+               Drafts.create_draft(%{
+                 prompt: "Hi",
+                 priority: :low,
+                 project_id: project.id
+               })
+
+      assert changeset.errors[:project_id]
+    end
+
+    test "fails for a non-existent project" do
+      assert {:error, changeset} =
+               Drafts.create_draft(%{
+                 prompt: "Hi",
+                 priority: :low,
+                 project_id: Ecto.UUID.generate()
+               })
+
+      assert changeset.errors[:project_id]
+    end
+
+    test "places new drafts at the tail of their priority column" do
+      project = create_project!()
+
+      {:ok, a} = Drafts.create_draft(%{prompt: "a", priority: :low, project_id: project.id})
+      {:ok, b} = Drafts.create_draft(%{prompt: "b", priority: :low, project_id: project.id})
+
+      assert b.position > a.position
+    end
+  end
+
+  describe "list_drafts_by_priority/1" do
+    @tag feature: @feature, scenario: "View drafts grouped by priority columns"
+    test "returns only non-archived drafts in the given priority ordered by position" do
+      project = create_project!()
+
+      {:ok, a} = Drafts.create_draft(%{prompt: "a", priority: :high, project_id: project.id})
+      {:ok, b} = Drafts.create_draft(%{prompt: "b", priority: :high, project_id: project.id})
+
+      {:ok, _} = Drafts.create_draft(%{prompt: "low", priority: :low, project_id: project.id})
+
+      result = Drafts.list_drafts_by_priority(:high)
+      assert Enum.map(result, & &1.id) == [a.id, b.id]
+    end
+
+    test "excludes archived drafts" do
+      project = create_project!()
+
+      {:ok, draft} =
+        Drafts.create_draft(%{prompt: "a", priority: :high, project_id: project.id})
+
+      {:ok, _} = Drafts.archive_draft(draft)
+
+      assert Drafts.list_drafts_by_priority(:high) == []
+    end
+  end
+
+  describe "list_all_active/0" do
+    @tag feature: @feature, scenario: "View drafts grouped by priority columns"
+    test "groups active drafts by priority" do
+      project = create_project!()
+
+      {:ok, _} = Drafts.create_draft(%{prompt: "a", priority: :high, project_id: project.id})
+      {:ok, _} = Drafts.create_draft(%{prompt: "b", priority: :medium, project_id: project.id})
+      {:ok, _} = Drafts.create_draft(%{prompt: "c", priority: :low, project_id: project.id})
+
+      result = Drafts.list_all_active()
+
+      assert Map.keys(result) |> Enum.sort() == [:high, :low, :medium]
+      assert length(result.high) == 1
+      assert length(result.medium) == 1
+      assert length(result.low) == 1
+    end
+
+    test "each column is ordered by ascending position" do
+      project = create_project!()
+
+      {:ok, a} = Drafts.create_draft(%{prompt: "a", priority: :high, project_id: project.id})
+      {:ok, b} = Drafts.create_draft(%{prompt: "b", priority: :high, project_id: project.id})
+      {:ok, c} = Drafts.create_draft(%{prompt: "c", priority: :high, project_id: project.id})
+
+      ids = Drafts.list_all_active().high |> Enum.map(& &1.id)
+      assert ids == [a.id, b.id, c.id]
+    end
+  end
+
+  describe "get_draft/1 and get_draft!/1" do
+    test "returns nil / raises for archived drafts" do
+      project = create_project!()
+
+      {:ok, draft} =
+        Drafts.create_draft(%{prompt: "a", priority: :high, project_id: project.id})
+
+      assert Drafts.get_draft(draft.id)
+      assert Drafts.get_draft!(draft.id)
+
+      {:ok, _} = Drafts.archive_draft(draft)
+
+      assert Drafts.get_draft(draft.id) == nil
+      assert_raise Ecto.NoResultsError, fn -> Drafts.get_draft!(draft.id) end
+    end
+
+    test "preloads project even when the project is archived" do
+      project = create_project!()
+
+      {:ok, draft} =
+        Drafts.create_draft(%{prompt: "a", priority: :high, project_id: project.id})
+
+      {:ok, _} = Projects.archive_project(project)
+
+      loaded = Drafts.get_draft(draft.id)
+      assert loaded.project.id == project.id
+      assert loaded.project.archived_at
+    end
+  end
+
+  describe "update_draft/2" do
+    @tag feature: @feature,
+         scenario: "Edit the prompt, project, and priority of an existing draft"
+    test "updates prompt, project, and priority" do
+      project1 = create_project!()
+      project2 = create_project!()
+
+      {:ok, draft} =
+        Drafts.create_draft(%{prompt: "a", priority: :low, project_id: project1.id})
+
+      {:ok, updated} =
+        Drafts.update_draft(draft, %{
+          prompt: "b",
+          priority: :high,
+          project_id: project2.id
+        })
+
+      assert updated.prompt == "b"
+      assert updated.priority == :high
+      assert updated.project_id == project2.id
+    end
+
+    test "moves draft to the tail of the new priority column when priority changes" do
+      project = create_project!()
+
+      {:ok, a} = Drafts.create_draft(%{prompt: "a", priority: :high, project_id: project.id})
+      {:ok, _b} = Drafts.create_draft(%{prompt: "b", priority: :high, project_id: project.id})
+
+      {:ok, c_initial} =
+        Drafts.create_draft(%{prompt: "c", priority: :low, project_id: project.id})
+
+      {:ok, c_updated} = Drafts.update_draft(c_initial, %{priority: :high})
+
+      assert c_updated.priority == :high
+      assert c_updated.position > a.position
+    end
+  end
+
+  describe "archive_draft/1" do
+    @tag feature: @feature, scenario: "Discard a draft from its detail page"
+    test "sets archived_at and removes the draft from list queries" do
+      project = create_project!()
+
+      {:ok, draft} =
+        Drafts.create_draft(%{prompt: "a", priority: :high, project_id: project.id})
+
+      {:ok, archived} = Drafts.archive_draft(draft)
+
+      assert archived.archived_at
+      assert Drafts.list_drafts_by_priority(:high) == []
+      assert Drafts.list_all_active().high == []
+    end
+  end
+
+  describe "reposition_draft/4" do
+    @tag feature: @feature, scenario: "Reorder drafts within a priority column"
+    test "empty column yields a default position" do
+      project = create_project!()
+
+      {:ok, a} = Drafts.create_draft(%{prompt: "a", priority: :low, project_id: project.id})
+
+      {:ok, repositioned} = Drafts.reposition_draft(a, :high, nil, nil)
+      assert repositioned.priority == :high
+      assert is_float(repositioned.position)
+    end
+
+    @tag feature: @feature, scenario: "Reorder drafts within a priority column"
+    test "dropping at the top gives a lower position than the top neighbor" do
+      project = create_project!()
+
+      {:ok, a} = Drafts.create_draft(%{prompt: "a", priority: :high, project_id: project.id})
+
+      {:ok, b_initial} =
+        Drafts.create_draft(%{prompt: "b", priority: :low, project_id: project.id})
+
+      {:ok, b} = Drafts.reposition_draft(b_initial, :high, nil, a.id)
+      assert b.position < a.position
+    end
+
+    test "dropping at the bottom gives a higher position than the last neighbor" do
+      project = create_project!()
+
+      {:ok, a} = Drafts.create_draft(%{prompt: "a", priority: :high, project_id: project.id})
+
+      {:ok, b_initial} =
+        Drafts.create_draft(%{prompt: "b", priority: :low, project_id: project.id})
+
+      {:ok, b} = Drafts.reposition_draft(b_initial, :high, a.id, nil)
+      assert b.position > a.position
+    end
+
+    @tag feature: @feature,
+         scenario: "Move a draft to a different priority column via drag-and-drop"
+    test "dropping between two cards yields a midpoint position" do
+      project = create_project!()
+
+      {:ok, a} = Drafts.create_draft(%{prompt: "a", priority: :high, project_id: project.id})
+      {:ok, b} = Drafts.create_draft(%{prompt: "b", priority: :high, project_id: project.id})
+
+      {:ok, c_initial} =
+        Drafts.create_draft(%{prompt: "c", priority: :low, project_id: project.id})
+
+      {:ok, c} = Drafts.reposition_draft(c_initial, :high, a.id, b.id)
+
+      assert c.priority == :high
+      assert c.position > a.position
+      assert c.position < b.position
+
+      ordered = Drafts.list_drafts_by_priority(:high) |> Enum.map(& &1.id)
+      assert ordered == [a.id, c.id, b.id]
+    end
+  end
+end

--- a/test/destila_web/live/draft_form_live_test.exs
+++ b/test/destila_web/live/draft_form_live_test.exs
@@ -1,0 +1,172 @@
+defmodule DestilaWeb.DraftFormLiveTest do
+  @moduledoc """
+  Tests for DraftFormLive (new/edit/detail).
+  Feature: features/drafts_board.feature
+  """
+
+  use DestilaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Destila.Drafts
+  alias Destila.Projects
+
+  @feature "drafts_board"
+
+  defp create_project!(attrs \\ %{}) do
+    defaults = %{
+      name: "Proj #{System.unique_integer([:positive])}",
+      git_repo_url: "https://github.com/test/repo"
+    }
+
+    {:ok, project} = Projects.create_project(Map.merge(defaults, attrs))
+    project
+  end
+
+  defp create_draft!(attrs) do
+    project = attrs[:project] || create_project!()
+    priority = attrs[:priority] || :low
+    prompt = attrs[:prompt] || "prompt"
+
+    {:ok, draft} =
+      Drafts.create_draft(%{
+        prompt: prompt,
+        priority: priority,
+        project_id: project.id
+      })
+
+    draft
+  end
+
+  describe "new draft" do
+    @tag feature: @feature, scenario: "Create a new draft from the drafts board"
+    test "creates a draft with prompt + priority + project", %{conn: conn} do
+      project = create_project!()
+
+      {:ok, view, _html} = live(conn, ~p"/drafts/new")
+
+      view |> element("#project-#{project.id}") |> render_click()
+
+      view
+      |> form("#draft-form", %{prompt: "Hello draft", priority: "high"})
+      |> render_submit()
+
+      assert [draft] = Drafts.list_drafts_by_priority(:high)
+      assert draft.prompt == "Hello draft"
+      assert draft.project_id == project.id
+    end
+
+    @tag feature: @feature, scenario: "Cannot create a draft without a project"
+    test "surfaces project validation error when none is picked", %{conn: conn} do
+      _project = create_project!()
+
+      {:ok, view, _html} = live(conn, ~p"/drafts/new")
+
+      html =
+        view
+        |> form("#draft-form", %{prompt: "Hi", priority: "low"})
+        |> render_submit()
+
+      assert html =~ "Please select a project"
+      assert Drafts.list_drafts_by_priority(:low) == []
+    end
+
+    @tag feature: @feature, scenario: "Cannot create a draft without a priority"
+    test "surfaces priority validation error when none is picked", %{conn: conn} do
+      project = create_project!()
+
+      {:ok, view, _html} = live(conn, ~p"/drafts/new")
+
+      view |> element("#project-#{project.id}") |> render_click()
+
+      html =
+        view
+        |> form("#draft-form", %{prompt: "Hi", priority: ""})
+        |> render_submit()
+
+      assert html =~ "Please pick a priority"
+      assert Drafts.list_drafts_by_priority(:low) == []
+    end
+  end
+
+  describe "edit draft" do
+    @tag feature: @feature, scenario: "Open a draft detail page"
+    test "loads existing draft values into the form", %{conn: conn} do
+      project = create_project!(%{name: "Edit Proj"})
+      draft = create_draft!(project: project, prompt: "Original prompt", priority: :medium)
+
+      {:ok, view, html} = live(conn, ~p"/drafts/#{draft.id}")
+
+      assert html =~ "Original prompt"
+      assert html =~ "Edit Proj"
+      assert has_element?(view, "#start-workflow-btn")
+      assert has_element?(view, "#discard-draft-btn")
+    end
+
+    @tag feature: @feature,
+         scenario: "Edit the prompt, project, and priority of an existing draft"
+    test "saves changes to an existing draft", %{conn: conn} do
+      project1 = create_project!()
+      project2 = create_project!(%{name: "Target Proj"})
+      draft = create_draft!(project: project1, prompt: "A", priority: :low)
+
+      {:ok, view, _html} = live(conn, ~p"/drafts/#{draft.id}")
+
+      view |> element("#project-#{project2.id}") |> render_click()
+
+      view
+      |> form("#draft-form", %{prompt: "Updated", priority: "high"})
+      |> render_submit()
+
+      updated = Drafts.get_draft(draft.id)
+      assert updated.prompt == "Updated"
+      assert updated.priority == :high
+      assert updated.project_id == project2.id
+    end
+
+    @tag feature: @feature, scenario: "Discard a draft from its detail page"
+    test "discard archives the draft and redirects to the board", %{conn: conn} do
+      draft = create_draft!(%{})
+
+      {:ok, view, _html} = live(conn, ~p"/drafts/#{draft.id}")
+
+      assert {:error, {:live_redirect, %{to: "/drafts"}}} =
+               view |> element("#discard-draft-btn") |> render_click()
+
+      assert Drafts.get_draft(draft.id) == nil
+    end
+
+    @tag feature: @feature,
+         scenario: "Launch a workflow from a draft skips prompt and project selection"
+    test "start workflow navigates to /workflows with draft_id", %{conn: conn} do
+      draft = create_draft!(%{})
+
+      {:ok, view, _html} = live(conn, ~p"/drafts/#{draft.id}")
+
+      expected_path = "/workflows?draft_id=#{draft.id}"
+
+      assert {:error, {:live_redirect, %{to: ^expected_path}}} =
+               view |> element("#start-workflow-btn") |> render_click()
+    end
+
+    test "loading an archived draft redirects with an error flash", %{conn: conn} do
+      draft = create_draft!(%{})
+      {:ok, _} = Drafts.archive_draft(draft)
+
+      assert {:error, {:live_redirect, %{to: "/drafts", flash: flash}}} =
+               live(conn, ~p"/drafts/#{draft.id}")
+
+      assert flash["error"] == "Draft not found"
+    end
+
+    test "renders archived-project indicator when the linked project is archived", %{conn: conn} do
+      project = create_project!()
+      draft = create_draft!(project: project)
+
+      {:ok, _} = Projects.archive_project(project)
+
+      {:ok, view, _html} = live(conn, ~p"/drafts/#{draft.id}")
+      assert has_element?(view, "#archived-project-indicator")
+    end
+  end
+end

--- a/test/destila_web/live/draft_form_live_test.exs
+++ b/test/destila_web/live/draft_form_live_test.exs
@@ -146,7 +146,40 @@ defmodule DestilaWeb.DraftFormLiveTest do
       expected_path = "/workflows?draft_id=#{draft.id}"
 
       assert {:error, {:live_redirect, %{to: ^expected_path}}} =
-               view |> element("#start-workflow-btn") |> render_click()
+               view
+               |> form("#draft-form")
+               |> render_submit(%{action: "start_workflow"})
+    end
+
+    test "start workflow persists pending edits before navigating", %{conn: conn} do
+      draft = create_draft!(prompt: "Original", priority: :low)
+
+      {:ok, view, _html} = live(conn, ~p"/drafts/#{draft.id}")
+
+      expected_path = "/workflows?draft_id=#{draft.id}"
+
+      assert {:error, {:live_redirect, %{to: ^expected_path}}} =
+               view
+               |> form("#draft-form", %{prompt: "Edited before launch", priority: "high"})
+               |> render_submit(%{action: "start_workflow"})
+
+      reloaded = Drafts.get_draft(draft.id)
+      assert reloaded.prompt == "Edited before launch"
+      assert reloaded.priority == :high
+    end
+
+    test "start workflow with invalid form does not navigate or mutate draft", %{conn: conn} do
+      draft = create_draft!(prompt: "Original", priority: :low)
+
+      {:ok, view, _html} = live(conn, ~p"/drafts/#{draft.id}")
+
+      html =
+        view
+        |> form("#draft-form", %{prompt: "", priority: "high"})
+        |> render_submit(%{action: "start_workflow"})
+
+      assert html =~ "Please write a prompt"
+      assert Drafts.get_draft(draft.id).prompt == "Original"
     end
 
     test "loading an archived draft redirects with an error flash", %{conn: conn} do

--- a/test/destila_web/live/draft_launch_live_test.exs
+++ b/test/destila_web/live/draft_launch_live_test.exs
@@ -1,0 +1,115 @@
+defmodule DestilaWeb.DraftLaunchLiveTest do
+  @moduledoc """
+  Tests for launching a workflow from a draft via CreateSessionLive.
+  Feature: features/drafts_board.feature
+  """
+
+  use DestilaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Destila.Drafts
+  alias Destila.Projects
+
+  @feature "drafts_board"
+
+  setup %{conn: conn} do
+    ClaudeCode.Test.set_mode_to_shared()
+
+    ClaudeCode.Test.stub(ClaudeCode, fn _query, _opts ->
+      [
+        ClaudeCode.Test.text("AI response"),
+        ClaudeCode.Test.result("AI response")
+      ]
+    end)
+
+    {:ok, conn: conn}
+  end
+
+  defp create_project! do
+    {:ok, project} =
+      Projects.create_project(%{
+        name: "Launch Proj #{System.unique_integer([:positive])}",
+        git_repo_url: "https://github.com/test/repo"
+      })
+
+    project
+  end
+
+  defp create_draft!(attrs \\ %{}) do
+    project = attrs[:project] || create_project!()
+
+    {:ok, draft} =
+      Drafts.create_draft(%{
+        prompt: attrs[:prompt] || "Draft prompt",
+        priority: attrs[:priority] || :low,
+        project_id: project.id
+      })
+
+    draft
+  end
+
+  describe "type picker threads draft_id" do
+    test "clicking a workflow type on /workflows?draft_id navigates to /workflows/<type>?draft_id",
+         %{conn: conn} do
+      draft = create_draft!()
+
+      {:ok, view, _html} = live(conn, ~p"/workflows?draft_id=#{draft.id}")
+
+      view |> element("#type-brainstorm_idea") |> render_click()
+
+      {path, _flash} = assert_redirect(view)
+      assert path == "/workflows/brainstorm_idea?draft_id=#{draft.id}"
+    end
+  end
+
+  describe "launch from draft" do
+    @tag feature: @feature,
+         scenario: "Launch a workflow from a draft skips prompt and project selection"
+    test "creates a session with the draft's prompt + project and redirects to the runner",
+         %{conn: conn} do
+      project = create_project!()
+      draft = create_draft!(project: project, prompt: "Launch me", priority: :high)
+
+      assert {:error, {:live_redirect, %{to: to}}} =
+               live(conn, ~p"/workflows/brainstorm_idea?draft_id=#{draft.id}")
+
+      assert String.starts_with?(to, "/sessions/")
+      session_id = String.replace_prefix(to, "/sessions/", "")
+
+      session = Destila.Workflows.get_workflow_session!(session_id)
+      assert session.user_prompt == "Launch me"
+      assert session.project_id == project.id
+      assert session.workflow_type == :brainstorm_idea
+    end
+
+    @tag feature: @feature, scenario: "Launching a workflow auto-archives the draft"
+    test "successful launch archives the draft so it no longer appears on the board",
+         %{conn: conn} do
+      draft = create_draft!(%{prompt: "Archive me"})
+
+      {:error, {:live_redirect, _}} =
+        live(conn, ~p"/workflows/brainstorm_idea?draft_id=#{draft.id}")
+
+      assert Drafts.get_draft(draft.id) == nil
+    end
+
+    test "unknown draft_id redirects to /drafts with an error flash", %{conn: conn} do
+      fake_id = Ecto.UUID.generate()
+
+      assert {:error, {:live_redirect, %{to: "/drafts", flash: flash}}} =
+               live(conn, ~p"/workflows/brainstorm_idea?draft_id=#{fake_id}")
+
+      assert flash["error"] == "Draft not found"
+    end
+
+    test "unknown workflow type redirects to /workflows with an error flash", %{conn: conn} do
+      draft = create_draft!()
+
+      assert {:error, {:live_redirect, %{to: "/workflows", flash: flash}}} =
+               live(conn, ~p"/workflows/not_a_real_type?draft_id=#{draft.id}")
+
+      assert flash["error"] == "Unknown workflow type"
+    end
+  end
+end

--- a/test/destila_web/live/drafts_board_live_test.exs
+++ b/test/destila_web/live/drafts_board_live_test.exs
@@ -119,6 +119,74 @@ defmodule DestilaWeb.DraftsBoardLiveTest do
     end
   end
 
+  describe "project filter" do
+    @tag feature: @feature, scenario: "Filter drafts by project"
+    test "selecting a project hides drafts from other projects", %{conn: conn} do
+      project_a = create_project!(%{name: "Project A"})
+      project_b = create_project!(%{name: "Project B"})
+
+      create_draft!(project: project_a, priority: :high, prompt: "Alpha idea")
+      create_draft!(project: project_b, priority: :high, prompt: "Bravo idea")
+
+      {:ok, view, _html} = live(conn, ~p"/drafts")
+
+      html =
+        view
+        |> form("#project-filter-form", %{project: project_a.id})
+        |> render_change()
+
+      assert html =~ "Alpha idea"
+      refute html =~ "Bravo idea"
+      assert_patched(view, ~p"/drafts?project=#{project_a.id}")
+    end
+
+    @tag feature: @feature, scenario: "Filter drafts by project"
+    test "clearing the filter restores drafts from all projects", %{conn: conn} do
+      project_a = create_project!(%{name: "Project A"})
+      project_b = create_project!(%{name: "Project B"})
+
+      create_draft!(project: project_a, priority: :high, prompt: "Alpha idea")
+      create_draft!(project: project_b, priority: :high, prompt: "Bravo idea")
+
+      {:ok, view, _html} = live(conn, ~p"/drafts?project=#{project_a.id}")
+
+      html =
+        view
+        |> form("#project-filter-form", %{project: ""})
+        |> render_change()
+
+      assert html =~ "Alpha idea"
+      assert html =~ "Bravo idea"
+      assert_patched(view, ~p"/drafts")
+    end
+
+    @tag feature: @feature, scenario: "Filter with no matching drafts shows a no-matches state"
+    test "no-matches state renders when filter yields nothing", %{conn: conn} do
+      project_a = create_project!(%{name: "Project A"})
+      project_b = create_project!(%{name: "Project B"})
+
+      create_draft!(project: project_a, priority: :high, prompt: "Alpha idea")
+
+      {:ok, view, _html} = live(conn, ~p"/drafts?project=#{project_b.id}")
+
+      assert has_element?(view, "#drafts-board-no-matches")
+      refute has_element?(view, "#column-high")
+    end
+
+    test "filter dropdown lists projects that have drafts", %{conn: conn} do
+      project_a = create_project!(%{name: "Visible Proj"})
+      _project_unused = create_project!(%{name: "Hidden Proj"})
+
+      create_draft!(project: project_a, priority: :low)
+
+      {:ok, view, _html} = live(conn, ~p"/drafts")
+      html = view |> element("#project-filter") |> render()
+
+      assert html =~ "Visible Proj"
+      refute html =~ "Hidden Proj"
+    end
+  end
+
   describe "reorder events" do
     @tag feature: @feature, scenario: "Reorder drafts within a priority column"
     test "reorder_draft within the same column updates position", %{conn: conn} do

--- a/test/destila_web/live/drafts_board_live_test.exs
+++ b/test/destila_web/live/drafts_board_live_test.exs
@@ -1,0 +1,190 @@
+defmodule DestilaWeb.DraftsBoardLiveTest do
+  @moduledoc """
+  Tests for DraftsBoardLive (the /drafts kanban board).
+  Feature: features/drafts_board.feature
+  """
+
+  use DestilaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Destila.Drafts
+  alias Destila.Projects
+
+  @feature "drafts_board"
+
+  defp create_project!(attrs \\ %{}) do
+    defaults = %{
+      name: "Proj #{System.unique_integer([:positive])}",
+      git_repo_url: "https://github.com/test/repo"
+    }
+
+    {:ok, project} = Projects.create_project(Map.merge(defaults, attrs))
+    project
+  end
+
+  defp create_draft!(attrs) do
+    project = attrs[:project] || create_project!()
+    priority = attrs[:priority] || :low
+    prompt = attrs[:prompt] || "prompt"
+
+    {:ok, draft} =
+      Drafts.create_draft(%{
+        prompt: prompt,
+        priority: priority,
+        project_id: project.id
+      })
+
+    draft
+  end
+
+  describe "board layout" do
+    @tag feature: @feature, scenario: "View drafts grouped by priority columns"
+    test "renders three priority columns, one per priority", %{conn: conn} do
+      project = create_project!()
+      create_draft!(project: project, priority: :high, prompt: "High idea")
+      create_draft!(project: project, priority: :medium, prompt: "Medium idea")
+      create_draft!(project: project, priority: :low, prompt: "Low idea")
+
+      {:ok, view, _html} = live(conn, ~p"/drafts")
+
+      assert has_element?(view, "#column-high")
+      assert has_element?(view, "#column-medium")
+      assert has_element?(view, "#column-low")
+
+      assert view |> element("#column-high") |> render() =~ "High idea"
+      assert view |> element("#column-medium") |> render() =~ "Medium idea"
+      assert view |> element("#column-low") |> render() =~ "Low idea"
+    end
+
+    @tag feature: @feature, scenario: "Draft card shows the prompt"
+    test "card surface shows the prompt", %{conn: conn} do
+      create_draft!(prompt: "Refactor session archiving", priority: :high)
+
+      {:ok, _view, html} = live(conn, ~p"/drafts")
+      assert html =~ "Refactor session archiving"
+    end
+
+    @tag feature: @feature, scenario: "Empty board shows guidance to create the first draft"
+    test "empty state is rendered when no drafts exist", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/drafts")
+      assert has_element?(view, "#drafts-board-empty")
+      assert has_element?(view, "#create-first-draft-btn")
+    end
+
+    test "new draft button links to /drafts/new", %{conn: conn} do
+      create_draft!(%{})
+      {:ok, view, _html} = live(conn, ~p"/drafts")
+      assert has_element?(view, "#new-draft-btn")
+    end
+
+    test "cards render with the archived indicator when the project is archived", %{conn: conn} do
+      project = create_project!()
+      _draft = create_draft!(project: project, priority: :high)
+      {:ok, _} = Projects.archive_project(project)
+
+      {:ok, _view, html} = live(conn, ~p"/drafts")
+      assert html =~ "(archived)"
+    end
+  end
+
+  describe "sidebar" do
+    @tag feature: @feature, scenario: "Sidebar has a Drafts entry next to Crafting Board"
+    test "sidebar exposes a Drafts entry", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/drafts")
+      assert view |> render() =~ "Drafts"
+      assert view |> has_element?("a[href=\"/drafts\"]")
+    end
+  end
+
+  describe "pubsub refresh" do
+    test "new draft appears after a :draft_created broadcast", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/drafts")
+
+      assert has_element?(view, "#drafts-board-empty")
+
+      project = create_project!()
+
+      {:ok, _draft} =
+        Drafts.create_draft(%{
+          prompt: "Fresh idea",
+          priority: :medium,
+          project_id: project.id
+        })
+
+      # Broadcast already sent by create_draft; allow LiveView to process it
+      _ = render(view)
+
+      assert view |> element("#column-medium") |> render() =~ "Fresh idea"
+    end
+  end
+
+  describe "reorder events" do
+    @tag feature: @feature, scenario: "Reorder drafts within a priority column"
+    test "reorder_draft within the same column updates position", %{conn: conn} do
+      project = create_project!()
+
+      a = create_draft!(project: project, priority: :high, prompt: "first")
+      b = create_draft!(project: project, priority: :high, prompt: "second")
+
+      {:ok, view, _html} = live(conn, ~p"/drafts")
+
+      # Move b to the top: before=nil, after=a
+      render_hook(view, "reorder_draft", %{
+        "draft_id" => b.id,
+        "priority" => "high",
+        "before_id" => nil,
+        "after_id" => a.id
+      })
+
+      ids = Drafts.list_drafts_by_priority(:high) |> Enum.map(& &1.id)
+      assert ids == [b.id, a.id]
+    end
+
+    @tag feature: @feature,
+         scenario: "Move a draft to a different priority column via drag-and-drop"
+    test "reorder_draft across priorities changes the priority", %{conn: conn} do
+      project = create_project!()
+      d = create_draft!(project: project, priority: :low)
+
+      {:ok, view, _html} = live(conn, ~p"/drafts")
+
+      render_hook(view, "reorder_draft", %{
+        "draft_id" => d.id,
+        "priority" => "high",
+        "before_id" => nil,
+        "after_id" => nil
+      })
+
+      reloaded = Drafts.get_draft(d.id)
+      assert reloaded.priority == :high
+    end
+
+    test "unknown draft_id is a no-op", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/drafts")
+
+      render_hook(view, "reorder_draft", %{
+        "draft_id" => Ecto.UUID.generate(),
+        "priority" => "high",
+        "before_id" => nil,
+        "after_id" => nil
+      })
+    end
+
+    test "invalid priority is a no-op", %{conn: conn} do
+      project = create_project!()
+      d = create_draft!(project: project, priority: :low)
+
+      {:ok, view, _html} = live(conn, ~p"/drafts")
+
+      render_hook(view, "reorder_draft", %{
+        "draft_id" => d.id,
+        "priority" => "banana",
+        "before_id" => nil,
+        "after_id" => nil
+      })
+
+      assert Drafts.get_draft(d.id).priority == :low
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `/drafts` kanban board where ideas are captured, triaged by priority (High/Medium/Low), and later launched into workflow sessions — preserving the prompt + project selection so users don't re-type them in the wizard.

- **`Destila.Drafts` context**: CRUD + soft-archive via `archived_at`; float-midpoint `position` for per-column ordering; broadcasts `:draft_created` / `:draft_updated` on `store:updates`.
- **`/drafts` board** (`DraftsBoardLive`): three priority columns over LiveView streams; empty state with "Create your first draft" CTA; native HTML5 drag-and-drop via a `DraftsBoard` JS hook that pushes a `reorder_draft` event with `before_id`/`after_id` neighbors.
- **Draft form** (`DraftFormLive`): new/edit/detail modes at `/drafts/new` and `/drafts/:id`; project selector with inline project creation; Save / Discard (archives) / Start workflow actions in edit mode.
- **Launch bypass** (`CreateSessionLive`): `/workflows?draft_id=<id>` threads the draft through the type picker; `/workflows/<type>?draft_id=<id>` creates a session with the draft's prompt + project and auto-archives the draft on success.
- **Sidebar**: new "Drafts" entry next to Crafting Board.
- **Plan**: `docs/plans/2026-04-18-001-feat-drafts-board-plan.md` carried through to completion with all 14 Gherkin scenarios linked to tests.

## Testing

- 47 new tests across `drafts_test.exs`, `drafts_board_live_test.exs`, `draft_form_live_test.exs`, `draft_launch_live_test.exs`, plus `Drafts.Draft` schema tests.
- Full suite: 501 / 502 passing (the 1 failure is a pre-existing SQLite `Database busy` flake on `implement_general_prompt_workflow_live_test.exs:132`, unrelated to this branch; passes on rerun).

## Review

`ce:review` ran 11 reviewer personas in autofix mode. P1/P2 safe-auto fixes applied on top of the feature commit:

- `drafts_board_live.ex`: log `reposition_draft` DB failures instead of silently discarding; dropped unused `:draft_deleted` pubsub pattern.
- `draft_form_live.ex`: graceful `{:error, _}` branch on `archive_draft` in the discard handler (was a hard match).
- `drafts_board.js`: replaced `window.__draftsBoardDraggingId` global with a module-scoped property.

Residual gated/advisory findings (duplicate-session risk on retry, `DraftFormLive` still using a raw HTML form instead of `to_form/2`, float precision collapse at 50+ same-pair reorders, concurrent reorder races) are documented in `.context/compound-engineering/ce-review/2026-04-18-drafts-board/run.md`.

## Post-Deploy Monitoring & Validation

- **Logs to watch**: `Logger.warning` lines matching `reposition_draft failed:` — a sudden spike indicates DB contention or a client sending bad neighbor IDs.
- **Validation**: after deploy, visit `/drafts`, create a draft, drag it between columns, and launch a workflow from it. Confirm the draft disappears from the board and a session appears under the session runner.
- **Rollback trigger**: drafts silently disappearing or reordering not persisting after a refresh.
- **Window**: first 24 hours after rollout.

## Test plan

- [x] Visit `/drafts`, confirm empty state + "Create your first draft" CTA
- [x] Create a draft at `/drafts/new` — select project, set priority, save
- [x] Confirm draft appears in the correct priority column
- [x] Drag the draft between columns — confirm the new priority persists after refresh
- [ ] Open the draft, click "Start workflow", pick a type — confirm the session opens with the draft's prompt, and the draft is gone from the board
- [ ] Visit `/drafts/<unknown-uuid>` — confirm redirect to `/drafts` with a "Draft not found" flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)