### PR TITLE
Point landing CTAs to the GitHub repo

### DIFF
--- a/landing/docs/assets/app.js
+++ b/landing/docs/assets/app.js
@@ -1232,7 +1232,7 @@ function VariationMinimal({
     }
   }, "v0.12.3"), /*#__PURE__*/React.createElement("a", {
     className: "min-btn min-btn-primary",
-    href: "#"
+    href: "https://github.com/esnunes/destila"
   }, /*#__PURE__*/React.createElement(GhIconM, null), " View on GitHub"))), /*#__PURE__*/React.createElement("div", {
     className: "min-wrap",
     style: {
@@ -1279,10 +1279,10 @@ function VariationMinimal({
     }
   }, /*#__PURE__*/React.createElement("a", {
     className: "min-btn min-btn-primary",
-    href: "#"
+    href: "https://github.com/esnunes/destila"
   }, /*#__PURE__*/React.createElement(GhIconM, null), " View on GitHub"), /*#__PURE__*/React.createElement("a", {
     className: "min-btn min-btn-ghost",
-    href: "#"
+    href: "https://github.com/esnunes/destila"
   }, "Read the docs \u2192"))), /*#__PURE__*/React.createElement("div", {
     className: "min-wrap",
     style: {
@@ -1703,10 +1703,10 @@ function VariationMinimal({
     }
   }, /*#__PURE__*/React.createElement("a", {
     className: "min-btn min-btn-primary",
-    href: "#"
+    href: "https://github.com/esnunes/destila"
   }, /*#__PURE__*/React.createElement(GhIconM, null), " View on GitHub"), /*#__PURE__*/React.createElement("a", {
     className: "min-btn min-btn-ghost",
-    href: "#"
+    href: "https://github.com/esnunes/destila"
   }, "Read the docs \u2192")), /*#__PURE__*/React.createElement("div", {
     style: {
       marginTop: 48,

--- a/landing/docs/index.html
+++ b/landing/docs/index.html
@@ -50,6 +50,6 @@
 <script crossorigin src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js"></script>
 
 <!-- Pre-compiled JSX bundle (no in-browser Babel) -->
-<script src="assets/app.js?v=2"></script>
+<script src="assets/app.js?v=3"></script>
 </body>
 </html>

--- a/landing/src/variation-minimal.jsx
+++ b/landing/src/variation-minimal.jsx
@@ -32,7 +32,7 @@ function VariationMinimal({ accent }) {
           </div>
           <div style={{marginLeft:'auto', display:'flex', gap:10, alignItems:'center'}}>
             <span style={{fontFamily:'JetBrains Mono,monospace', fontSize:11, color:'#888'}}>v0.12.3</span>
-            <a className="min-btn min-btn-primary" href="#"><GhIconM/> View on GitHub</a>
+            <a className="min-btn min-btn-primary" href="https://github.com/esnunes/destila"><GhIconM/> View on GitHub</a>
           </div>
         </nav>
 
@@ -48,8 +48,8 @@ function VariationMinimal({ accent }) {
             An agentic IDE that takes you from rough ideas to shipped code. Autonomous, multi-phase pipelines that plan, implement, review, and ship — pausing for human judgment only when it actually helps.
           </p>
           <div style={{display:'flex', gap:10, marginTop:30, flexWrap:'wrap', justifyContent:'center'}}>
-            <a className="min-btn min-btn-primary" href="#"><GhIconM/> View on GitHub</a>
-            <a className="min-btn min-btn-ghost" href="#">Read the docs →</a>
+            <a className="min-btn min-btn-primary" href="https://github.com/esnunes/destila"><GhIconM/> View on GitHub</a>
+            <a className="min-btn min-btn-ghost" href="https://github.com/esnunes/destila">Read the docs →</a>
           </div>
         </div>
 
@@ -304,8 +304,8 @@ function VariationMinimal({ accent }) {
             Ship without babysitting the robot.
           </h2>
           <div style={{display:'flex', gap:10, justifyContent:'center', marginTop:32, flexWrap:'wrap'}}>
-            <a className="min-btn min-btn-primary" href="#"><GhIconM/> View on GitHub</a>
-            <a className="min-btn min-btn-ghost" href="#">Read the docs →</a>
+            <a className="min-btn min-btn-primary" href="https://github.com/esnunes/destila"><GhIconM/> View on GitHub</a>
+            <a className="min-btn min-btn-ghost" href="https://github.com/esnunes/destila">Read the docs →</a>
           </div>
           <div style={{marginTop:48, paddingTop:28, borderTop:'1px solid rgba(255,255,255,.08)', display:'flex', justifyContent:'space-between', fontFamily:'JetBrains Mono,monospace', fontSize:11, color:'#666', flexWrap:'wrap', gap:12}}>
             <span>destila · elixir · phoenix liveview · claude code</span>


### PR DESCRIPTION
Updates "View on GitHub" and "Read the docs" links in the minimal variation (and built `app.js`) to https://github.com/esnunes/destila. Bumps `?v=` on the script tag to bust caches.