### PR TITLE
Remove box-shadow from screenshot img

### DIFF
--- a/landing/docs/assets/app.js
+++ b/landing/docs/assets/app.js
@@ -1057,7 +1057,6 @@ if (!document.getElementById('destila-anim')) {
 function Shot({
   src,
   caption,
-  shadow = true,
   style = {}
 }) {
   return /*#__PURE__*/React.createElement("figure", {
@@ -1074,8 +1073,7 @@ function Shot({
       display: 'block',
       width: '100%',
       height: 'auto',
-      borderRadius: 10,
-      boxShadow: shadow ? '0 30px 60px -20px rgba(0,0,0,.35), 0 12px 24px -12px rgba(0,0,0,.25)' : 'none'
+      borderRadius: 10
     }
   }), caption && /*#__PURE__*/React.createElement("figcaption", {
     style: {

--- a/landing/docs/index.html
+++ b/landing/docs/index.html
@@ -50,6 +50,6 @@
 <script crossorigin src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js"></script>
 
 <!-- Pre-compiled JSX bundle (no in-browser Babel) -->
-<script src="assets/app.js?v=3"></script>
+<script src="assets/app.js?v=4"></script>
 </body>
 </html>

--- a/landing/src/shot.jsx
+++ b/landing/src/shot.jsx
@@ -1,7 +1,7 @@
 // Shared screenshot helpers for all variations
 // Screenshots are already macOS browser windows — don't re-frame them.
 
-function Shot({ src, caption, shadow = true, style = {} }) {
+function Shot({ src, caption, style = {} }) {
   return (
     <figure style={{margin:0, ...style}}>
       <img
@@ -11,8 +11,7 @@ function Shot({ src, caption, shadow = true, style = {} }) {
         decoding="async"
         style={{
           display:'block', width:'100%', height:'auto',
-          borderRadius:10,
-          boxShadow: shadow ? '0 30px 60px -20px rgba(0,0,0,.35), 0 12px 24px -12px rgba(0,0,0,.25)' : 'none'
+          borderRadius:10
         }}
       />
       {caption && (


### PR DESCRIPTION
Drops the drop-shadow on `<Shot>` screenshots in the minimal variation. Bumps `?v=` to bust the app.js cache.