### PR TITLE
Use danger color for workflow runner delete button

### DIFF
--- a/lib/destila_web/live/workflow_runner_live.ex
+++ b/lib/destila_web/live/workflow_runner_live.ex
@@ -787,7 +787,7 @@ defmodule DestilaWeb.WorkflowRunnerLive do
                 <button
                   phx-click="delete_session"
                   id="delete-btn"
-                  class="btn btn-soft btn-sm"
+                  class="btn btn-soft btn-error btn-sm"
                   data-confirm="Permanently delete this session? This cannot be undone in the app."
                 >
                   <.icon name="hero-trash-micro" class="size-4" /> Delete


### PR DESCRIPTION
## Summary
- Adds `btn-error` modifier to the delete button on the workflow runner page so it visually communicates the destructive action while keeping the soft button style consistent with neighboring controls.

## Test plan
- [x] Visit a workflow session page and confirm the Delete button renders with the danger (red) color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)