### PR TITLE
Skip Claude plugin setup in test env (36x suite speedup)

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -26,6 +26,10 @@ config :phoenix_live_view,
 # Use test adapter for ClaudeCode
 config :claude_code, adapter: {ClaudeCode.Test, ClaudeCode}
 
+# Skip Claude plugin registration in tests — each CLI call takes ~500ms and
+# contributes the majority of ClaudeSession test time.
+config :destila, :setup_claude_plugins, false
+
 # Stub the history reader in tests so we don't touch ~/.claude/projects.
 config :destila, :ai_history_module, Destila.AI.FakeHistory
 

--- a/lib/destila/ai/claude_session.ex
+++ b/lib/destila/ai/claude_session.ex
@@ -159,58 +159,71 @@ defmodule Destila.AI.ClaudeSession do
     claude_opts = Keyword.put_new(claude_opts, :setting_sources, ["user", "project"])
     claude_opts = Keyword.put_new(claude_opts, :max_turns, 200)
 
-    # Register marketplaces and install/enable plugins before starting the session.
-    # Treat "already" errors as success since these operations aren't fully idempotent.
-    with :ok <-
-           plugin_cmd(ClaudeCode.Plugin.Marketplace, :add, [
-             "EveryInc/compound-engineering-plugin"
-           ]),
-         :ok <- plugin_cmd(ClaudeCode.Plugin.Marketplace, :add, ["pbakaus/impeccable"]),
-         :ok <-
-           plugin_cmd(ClaudeCode.Plugin, :install, [
-             "compound-engineering@compound-engineering-plugin"
-           ]),
-         :ok <-
-           plugin_cmd(ClaudeCode.Plugin, :enable, [
-             "compound-engineering@compound-engineering-plugin"
-           ]),
-         :ok <- plugin_cmd(ClaudeCode.Plugin, :install, ["impeccable@impeccable"]),
-         :ok <- plugin_cmd(ClaudeCode.Plugin, :enable, ["impeccable@impeccable"]),
-         {:ok, installed} <- ClaudeCode.Plugin.list() do
-      # Pass enabled plugin install_paths so they are loaded into the session.
-      plugin_paths =
-        installed
-        |> Enum.filter(&(&1.enabled && &1.install_path))
-        |> Enum.map(& &1.install_path)
+    case setup_plugins() do
+      {:ok, plugin_paths} ->
+        claude_opts = Keyword.put(claude_opts, :plugins, plugin_paths)
 
-      claude_opts = Keyword.put(claude_opts, :plugins, plugin_paths)
+        case ClaudeCode.start_link(claude_opts) do
+          {:ok, claude_session} ->
+            timer_ref = schedule_timeout(timeout_ms)
 
-      case ClaudeCode.start_link(claude_opts) do
-        {:ok, claude_session} ->
-          timer_ref = schedule_timeout(timeout_ms)
+            if workflow_session_id do
+              Phoenix.PubSub.broadcast(
+                Destila.PubSub,
+                Destila.PubSubHelper.claude_session_topic(),
+                {:claude_session_started, workflow_session_id, ai_session_id}
+              )
+            end
 
-          if workflow_session_id do
-            Phoenix.PubSub.broadcast(
-              Destila.PubSub,
-              Destila.PubSubHelper.claude_session_topic(),
-              {:claude_session_started, workflow_session_id, ai_session_id}
-            )
-          end
+            {:ok,
+             %{
+               claude_session: claude_session,
+               timeout_ms: timeout_ms,
+               timer_ref: timer_ref,
+               workflow_session_id: workflow_session_id,
+               ai_session_id: ai_session_id
+             }}
 
-          {:ok,
-           %{
-             claude_session: claude_session,
-             timeout_ms: timeout_ms,
-             timer_ref: timer_ref,
-             workflow_session_id: workflow_session_id,
-             ai_session_id: ai_session_id
-           }}
+          {:error, reason} ->
+            {:stop, reason}
+        end
 
-        {:error, reason} ->
-          {:stop, reason}
+      {:error, reason} ->
+        {:stop, {:plugin_setup_failed, reason}}
+    end
+  end
+
+  # Registers marketplaces and installs/enables plugins, returning the list of
+  # enabled plugin install paths. Skipped when `:setup_claude_plugins` is false
+  # (e.g., in tests) — each CLI call takes hundreds of ms.
+  # Treats "already" errors as success since these operations aren't fully idempotent.
+  defp setup_plugins do
+    if Application.get_env(:destila, :setup_claude_plugins, true) do
+      with :ok <-
+             plugin_cmd(ClaudeCode.Plugin.Marketplace, :add, [
+               "EveryInc/compound-engineering-plugin"
+             ]),
+           :ok <- plugin_cmd(ClaudeCode.Plugin.Marketplace, :add, ["pbakaus/impeccable"]),
+           :ok <-
+             plugin_cmd(ClaudeCode.Plugin, :install, [
+               "compound-engineering@compound-engineering-plugin"
+             ]),
+           :ok <-
+             plugin_cmd(ClaudeCode.Plugin, :enable, [
+               "compound-engineering@compound-engineering-plugin"
+             ]),
+           :ok <- plugin_cmd(ClaudeCode.Plugin, :install, ["impeccable@impeccable"]),
+           :ok <- plugin_cmd(ClaudeCode.Plugin, :enable, ["impeccable@impeccable"]),
+           {:ok, installed} <- ClaudeCode.Plugin.list() do
+        plugin_paths =
+          installed
+          |> Enum.filter(&(&1.enabled && &1.install_path))
+          |> Enum.map(& &1.install_path)
+
+        {:ok, plugin_paths}
       end
     else
-      {:error, reason} -> {:stop, {:plugin_setup_failed, reason}}
+      {:ok, []}
     end
   end
 

--- a/lib/destila/ai/claude_session.ex
+++ b/lib/destila/ai/claude_session.ex
@@ -193,10 +193,8 @@ defmodule Destila.AI.ClaudeSession do
     end
   end
 
-  # Registers marketplaces and installs/enables plugins, returning the list of
-  # enabled plugin install paths. Skipped when `:setup_claude_plugins` is false
-  # (e.g., in tests) — each CLI call takes hundreds of ms.
-  # Treats "already" errors as success since these operations aren't fully idempotent.
+  # Skipped when `:setup_claude_plugins` is false — each CLI call takes
+  # hundreds of ms, which dominates test suite time.
   defp setup_plugins do
     if Application.get_env(:destila, :setup_claude_plugins, true) do
       with :ok <-


### PR DESCRIPTION
## Summary

- `Destila.AI.ClaudeSession.init/1` shells out to the real `claude` CLI six times (marketplace add / plugin install / plugin enable / plugin list), each taking ~200-500ms. Tests stub `ClaudeCode.query`, but nothing stubbed the plugin operations, so every test that started a session paid a ~3s tax.
- The seven tests in `test/destila/ai/session_test.exs` accounted for **~21.5s of a 21.9s full-suite run**.
- Extract the plugin registration into a private `setup_plugins/0` gated by `Application.get_env(:destila, :setup_claude_plugins, true)`, and set it to `false` in `config/test.exs`.

**Result:** full test suite now runs in 0.6s — a 36x speedup. Production behavior is unchanged (flag defaults to true).

## Test plan

- [x] `mix test test/destila/ai/session_test.exs --slowest 10` — 8 tests, 0 failures, 0.2s total. Previous ~3s-per-test entries are gone; remaining ~50-150ms are intentional `Process.sleep` calls in the inactivity-timeout tests.
- [x] `mix test --slowest 15` — pre-existing pass/fail counts unchanged. The only tests now in the slowest-15 are the inactivity-timeout tests (150ms) plus a terminal server test (40ms) — no other regressions.
- [ ] Manual verification in dev: start a workflow session and confirm plugins are still registered and enabled.

## Note on pre-existing failures

389 tests in `DestilaWeb.BrainstormIdeaWorkflowLiveTest` fail with `no such table: workflow_sessions` both before and after this change. That's an unrelated test-DB migration issue; `MIX_ENV=test mix ecto.reset` should fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)