### PR TITLE
feat(ai): re-inject phase prompt after context compaction

### DIFF
--- a/docs/plans/2026-04-21-001-feat-reinject-phase-prompt-on-compact-plan.md
+++ b/docs/plans/2026-04-21-001-feat-reinject-phase-prompt-on-compact-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Re-inject phase prompt around compaction via Claude Code hook"
 type: feat
-status: active
+status: completed
 date: 2026-04-21
 ---
 
@@ -182,7 +182,7 @@ This plan restores that context around the compaction boundary by:
 
 ## Implementation Units
 
-- [ ] **Unit 1: Wrap phase prompt in `<initial-prompt>` tag at phase start**
+- [x] **Unit 1: Wrap phase prompt in `<initial-prompt>` tag at phase start**
 
 **Goal:** The `# Prompt` section sent to Claude at phase start contains the
 phase prompt wrapped in `<initial-prompt>...</initial-prompt>` tags.
@@ -225,7 +225,7 @@ phase prompt wrapped in `<initial-prompt>...</initial-prompt>` tags.
 
 ---
 
-- [ ] **Unit 2: Persist wrapped phase prompt to per-worktree file**
+- [x] **Unit 2: Persist wrapped phase prompt to per-worktree file**
 
 **Goal:** On phase start, write the wrapped phase prompt to
 `<worktree_path>/.claude/destila/initial_prompt.txt` so a hook can read it.
@@ -279,7 +279,7 @@ phase prompt wrapped in `<initial-prompt>...</initial-prompt>` tags.
 
 ---
 
-- [ ] **Unit 3: Ship the hook shell script and install it into worktrees**
+- [x] **Unit 3: Ship the hook shell script and install it into worktrees**
 
 **Goal:** A small POSIX shell script exists in `priv/hooks/` and is copied
 into each worktree's `.claude/hooks/` directory. The script reads the
@@ -332,7 +332,7 @@ initial-prompt file and prints it followed by the reference sentence.
 
 ---
 
-- [ ] **Unit 4: Write `.claude/settings.json` declaring the SessionStart(compact) hook**
+- [x] **Unit 4: Write `.claude/settings.json` declaring the SessionStart(compact) hook**
 
 **Goal:** Each worktree contains a `.claude/settings.json` that registers
 the shipped script as a `SessionStart` hook for matcher `compact`.
@@ -398,7 +398,7 @@ the shipped script as a `SessionStart` hook for matcher `compact`.
 
 ---
 
-- [ ] **Unit 5: End-to-end integration wiring and existing-test audit**
+- [x] **Unit 5: End-to-end integration wiring and existing-test audit**
 
 **Goal:** `Conversation.phase_start/1` calls `CompactHookSetup.install/2`
 with the worktree path and wrapped phase prompt. Existing tests continue

--- a/docs/plans/2026-04-21-001-feat-reinject-phase-prompt-on-compact-plan.md
+++ b/docs/plans/2026-04-21-001-feat-reinject-phase-prompt-on-compact-plan.md
@@ -1,0 +1,505 @@
+---
+title: "feat: Re-inject phase prompt around compaction via Claude Code hook"
+type: feat
+status: active
+date: 2026-04-21
+---
+
+# feat: Re-inject phase prompt around compaction via Claude Code hook
+
+## Overview
+
+When Claude Code compacts a long conversation, the summary often loses the
+original phase prompt that describes the task boundaries, how to signal
+completion (e.g. `mcp__destila__session` with `phase_complete`), and
+exported-metadata conventions. Symptoms already referenced in-code:
+`handle_ai_result/2` auto-advances non-interactive phases "to avoid getting
+stuck when context compaction hides the original phase prompt."
+
+This plan restores that context around the compaction boundary by:
+
+1. Wrapping the initial phase prompt inside an `<initial-prompt>` tag so it is
+   visually and structurally recognizable in the transcript.
+2. Persisting the wrapped prompt to a known file inside the worktree at each
+   phase start.
+3. Installing a Claude Code hook in the worktree that fires when compaction
+   occurs, reads that file, and re-injects the prompt plus a short reference
+   note ("In the `<initial-prompt>` tag above you can find the initial user
+   prompt for reference.").
+
+## Problem Frame
+
+- Destila orchestrates long-running phases. When a phase generates enough
+  tokens to trigger auto-compact (or if the user issues `/compact`), the
+  compacted summary can drop phase-specific instructions, breaking
+  autonomous progression and structured tool usage.
+- The existing workaround in `lib/destila/ai/conversation.ex` is defensive
+  (auto-advance non-interactive phases), not corrective. The root problem is
+  that the phase prompt is not re-presented to the model post-compact.
+- Claude Code supports per-project `.claude/settings.json` hooks. Destila
+  already sets `setting_sources: ["user", "project"]` in
+  `lib/destila/ai/claude_session.ex`, so hooks written into the worktree
+  are honored automatically.
+
+## Requirements Trace
+
+- R1. Each phase start wraps the phase prompt inside `<initial-prompt>` tags
+  within the `# Prompt` section delivered to Claude.
+- R2. After compaction, the phase prompt is re-delivered to Claude as
+  conversation context, followed by a short reference sentence naming the
+  `<initial-prompt>` tag.
+- R3. The mechanism must be per-worktree (each workflow session has its own
+  worktree, so prompts do not leak between sessions).
+- R4. When a phase advances (same worktree, next phase), subsequent
+  compactions re-inject the *current* phase's prompt, not the previous one.
+- R5. The feature must not regress existing tests or require changing the
+  Claude session lifecycle (no new GenServers, no changes to
+  `SessionProcess` state machine).
+
+## Scope Boundaries
+
+- Only the Claude Code hook surface is used. No MCP changes, no changes to
+  `lib/destila/ai/tools.ex`.
+- Only `SessionStart` with matcher `compact` is configured. `startup`,
+  `resume`, and `clear` matchers are explicitly out of scope (the initial
+  phase prompt is already sent as the first user message at phase start, and
+  `:resume` sessions continue the same conversation).
+- Blocking compaction is out of scope. We do not use `PreCompact` for
+  blocking; we only re-supply context after compaction.
+- Changes to how `current_scope` / auth work are out of scope.
+- Removing or rewriting the existing non-interactive auto-advance safeguard
+  in `handle_ai_result/2` is out of scope. Leave it in as a belt-and-braces
+  layer.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `lib/destila/ai/conversation.ex` — `phase_start/1` assembles the `# Prompt`
+  section from `prompt_fn.(ws)`. This is the single place where phase prompts
+  are constructed and where the `<initial-prompt>` wrapping belongs.
+- `lib/destila/ai/claude_session.ex` — Initializes `ClaudeCode.start_link/1`
+  with `setting_sources: ["user", "project"]`, `cwd` is taken from
+  `ai_session.worktree_path`. Confirms `.claude/settings.json` inside the
+  worktree is loaded.
+- `lib/destila/ai/session_config.ex` — Passes `:cwd` through from
+  `ai_session.worktree_path`.
+- `lib/destila/workflows/phase.ex` — Phase struct (`system_prompt`,
+  `session_strategy`, `allowed_tools`, etc.).
+- `lib/destila/workflows/brainstorm_idea_workflow.ex`,
+  `lib/destila/workflows/code_chat_workflow.ex` — Examples where phase
+  prompts reference `workflow_session.user_prompt`; those prompts are what
+  we want preserved.
+- `test/destila/ai/conversation_test.exs` — Pattern for testing conversation
+  mechanics; uses `DestilaWeb.ConnCase, async: false` and factories for
+  workflow sessions / AI sessions.
+
+### Institutional Learnings
+
+- `lib/destila/ai/conversation.ex` already documents the compaction blind
+  spot: "This avoids getting stuck when context compaction hides the
+  original phase prompt (which describes how to signal completion) from the
+  agent." This plan directly addresses that symptom.
+- Destila workflow sessions each run in an isolated worktree (see
+  `AI.create_ai_session` flow). Writing files under the worktree is the
+  established way to expose per-session state to Claude.
+
+### External References
+
+- Claude Code hooks reference: https://code.claude.com/docs/en/hooks
+  - `PreCompact` hook fires before compaction but **cannot** inject
+    additional context — it only supports `decision: "block"` / exit 2.
+    The hook's stdout is discarded.
+  - `SessionStart` hook supports `additionalContext` (via JSON output) and
+    plain stdout is appended as context. Its matcher `compact` fires
+    immediately after auto or manual compaction completes.
+- This is the driver for the key decision below: we use `SessionStart` with
+  matcher `compact`, not `PreCompact`, because only that surface can
+  actually re-inject text after compaction.
+
+## Key Technical Decisions
+
+- **Use `SessionStart` matcher `compact`, not `PreCompact`**: `PreCompact`
+  cannot add context (confirmed against Claude Code docs). The semantic
+  intent of the user request ("re-add the phase prompt around compaction")
+  is satisfied by `SessionStart(compact)`, which fires right after
+  compaction and supports `additionalContext`/stdout. The plan acknowledges
+  the user framing while selecting the correct hook.
+- **Per-worktree settings file**: Write `.claude/settings.json` inside the
+  worktree (matches Destila's existing `setting_sources: ["user",
+  "project"]`). No global hook installation, no leakage between workflow
+  sessions.
+- **Separate command script from data file**: The hook entry in
+  `settings.json` points at a small shell script shipped from `priv/hooks/`
+  and copied into `<worktree>/.claude/hooks/reinject_initial_prompt.sh` at
+  setup time. The script reads the current phase prompt from
+  `<worktree>/.claude/destila/initial_prompt.txt` and prints it with the
+  wrapper tag and reference sentence. This keeps settings.json static and
+  makes per-phase updates a simple file write.
+- **Single source of truth for wrapping**: Wrapping with
+  `<initial-prompt>` happens once, in `phase_start/1`, before the prompt is
+  both (a) sent to Claude and (b) persisted to the worktree file. Both the
+  first-turn prompt and the hook re-injection use the same wrapped form.
+- **Idempotent setup**: Settings and hook script are written on every phase
+  start (cheap, covers worktrees that existed before this feature shipped).
+  The prompt file is overwritten each phase start so the *current* phase's
+  prompt is always what the hook re-injects.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Which hook event?** `SessionStart` with matcher `compact`. `PreCompact`
+  cannot inject context (docs confirm: no `additionalContext` field, stdout
+  discarded).
+- **Where do hook files live?** Inside the worktree — Destila already
+  configures `setting_sources: ["user", "project"]`, so the worktree's
+  `.claude/settings.json` is honored.
+- **Does the hook need access to DB state?** No. The phase prompt is
+  already fully rendered at phase start; persisting the rendered text to a
+  worktree file is sufficient. The hook is a pure file read + echo.
+- **Should we wrap only the phase prompt or the whole first query
+  (tools + skills + service + prompt)?** Only the phase prompt portion.
+  Tool descriptions and skills reload via their own mechanisms; re-injecting
+  them on every compaction would balloon context. Re-injecting just the
+  phase prompt matches the user's intent ("the initial user prompt for
+  reference").
+
+### Deferred to Implementation
+
+- **Exact shell-script formatting of the reference sentence**: the sentence
+  shape is specified ("In the `<initial-prompt>` tag above you can find
+  the initial user prompt for reference."), but trailing newlines and quote
+  escaping are best finalized when the script is written.
+- **Whether to also fire on matcher `resume`**: deferred. Destila resumes
+  Claude sessions via `:resume` option in
+  `session_config.ex`. Observing whether resumed sessions need re-injection
+  is better learned at execution time; the plan scopes to `compact` only
+  and can be extended later.
+- **Cleanup of `.claude/destila/` on session archive**: deferred. The
+  existing worktree cleanup path will remove these files along with the
+  worktree. If worktrees ever outlive sessions, revisit.
+
+## Implementation Units
+
+- [ ] **Unit 1: Wrap phase prompt in `<initial-prompt>` tag at phase start**
+
+**Goal:** The `# Prompt` section sent to Claude at phase start contains the
+phase prompt wrapped in `<initial-prompt>...</initial-prompt>` tags.
+
+**Requirements:** R1, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `lib/destila/ai/conversation.ex`
+- Test: `test/destila/ai/conversation_test.exs`
+
+**Approach:**
+- In `phase_start/1`, after `phase_prompt = prompt_fn.(ws)`, build a wrapped
+  string `"<initial-prompt>\n#{phase_prompt}\n</initial-prompt>"` and use
+  that in the `# Prompt\n\n...` section.
+- Keep the wrapping local to `phase_start/1` — do not propagate it through
+  `send_message/2` or other call sites (user messages are not phase prompts).
+
+**Patterns to follow:**
+- Existing `sections = [...] |> Enum.reject(&is_nil/1) |> Enum.join("\n\n")`
+  composition style in `phase_start/1`.
+
+**Test scenarios:**
+- Happy path — phase_start with a workflow session sending a phase prompt
+  containing "Describe your idea" produces a query whose `# Prompt` section
+  contains `<initial-prompt>` before "Describe your idea" and
+  `</initial-prompt>` after it.
+- Edge case — phase_prompt with embedded angle brackets (e.g. a prompt that
+  contains the literal string "<example>") is wrapped without corruption —
+  the outer `<initial-prompt>` tag is still the first and last tag in the
+  wrapped block.
+- Edge case — user messages routed through `send_message/2` are **not**
+  wrapped (verifies scope of change).
+
+**Verification:**
+- Enqueued Oban job payload for `AiQueryWorker` contains a `"query"` field
+  whose text includes `<initial-prompt>` and `</initial-prompt>` around the
+  phase prompt.
+
+---
+
+- [ ] **Unit 2: Persist wrapped phase prompt to per-worktree file**
+
+**Goal:** On phase start, write the wrapped phase prompt to
+`<worktree_path>/.claude/destila/initial_prompt.txt` so a hook can read it.
+
+**Requirements:** R2, R3, R4
+
+**Dependencies:** Unit 1 (wrapping logic reused), AI session must have a
+`worktree_path` at phase start (already required by existing flows).
+
+**Files:**
+- Create: `lib/destila/ai/compact_hook_setup.ex` (new, small module
+  encapsulating file-write concerns)
+- Modify: `lib/destila/ai/conversation.ex` (call the new module from
+  `phase_start/1`)
+- Test: `test/destila/ai/compact_hook_setup_test.exs` (new)
+
+**Approach:**
+- Introduce `Destila.AI.CompactHookSetup` with a single public function
+  `install/2` that accepts `worktree_path` and `phase_prompt` (already
+  wrapped or to-be-wrapped — see below) and writes the prompt file.
+- Keep wrapping logic in `conversation.ex` so both the Claude query and the
+  persisted file use the same wrapped string.
+- If `worktree_path` is `nil` (shouldn't happen in practice, but defend at
+  the boundary since it is I/O), return `:ok` without writing — this keeps
+  `phase_start/1` resilient for test setups that skip worktree creation.
+- Ensure the target directory exists via `File.mkdir_p!/1`.
+
+**Patterns to follow:**
+- Module layout mirrors existing small AI helper modules like
+  `lib/destila/ai/session_config.ex` (pure function, no GenServer).
+
+**Test scenarios:**
+- Happy path — given a tmp dir as worktree and a prompt string, after
+  `install/2` the file at
+  `<tmp>/.claude/destila/initial_prompt.txt` exists and contains the exact
+  prompt string (including `<initial-prompt>` wrapping).
+- Happy path — calling `install/2` twice with different prompts overwrites
+  the file with the second prompt (guarantees R4: the current phase's
+  prompt is what the hook reads).
+- Edge case — `worktree_path` is `nil` → function returns `:ok` and writes
+  nothing (no crash).
+- Edge case — the target directory does not yet exist → `install/2` creates
+  `.claude/destila/` and succeeds.
+- Integration — `Conversation.phase_start/1` writes the file with the
+  wrapped prompt for the current phase. Assert file contents equal the
+  same wrapped string that appears in the Oban job payload.
+
+**Verification:**
+- After `phase_start/1` runs in a workflow session with a tmp worktree, the
+  file exists, is readable, and matches the prompt sent to Claude.
+
+---
+
+- [ ] **Unit 3: Ship the hook shell script and install it into worktrees**
+
+**Goal:** A small POSIX shell script exists in `priv/hooks/` and is copied
+into each worktree's `.claude/hooks/` directory. The script reads the
+initial-prompt file and prints it followed by the reference sentence.
+
+**Requirements:** R2, R3
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Create: `priv/hooks/reinject_initial_prompt.sh`
+- Modify: `lib/destila/ai/compact_hook_setup.ex` (copy script into worktree
+  during `install/2`)
+- Test: `test/destila/ai/compact_hook_setup_test.exs` (extend)
+
+**Approach:**
+- The shipped script lives in `priv/hooks/reinject_initial_prompt.sh` and
+  is looked up at runtime via `:code.priv_dir(:destila)`.
+- The script reads
+  `$CLAUDE_PROJECT_DIR/.claude/destila/initial_prompt.txt` (Claude Code
+  exposes `CLAUDE_PROJECT_DIR` as the worktree root for hooks; fall back to
+  `./.claude/destila/initial_prompt.txt` relative to `cwd` if unset).
+- If the file is missing, the script exits 0 with empty stdout (no-op — do
+  not block compaction).
+- If the file exists, the script prints its contents followed by a blank
+  line and the reference sentence:
+  `"In the <initial-prompt> tag above you can find the initial user prompt for reference."`
+- `install/2` copies the script to `<worktree>/.claude/hooks/` and sets
+  mode `0755`. Overwrite on every call (idempotent, cheap).
+
+**Patterns to follow:**
+- Other Destila files under `priv/` (e.g. `priv/skills/`) are shipped with
+  the app and accessed via `:code.priv_dir(:destila)`.
+
+**Test scenarios:**
+- Happy path — after `install/2`, the script exists at
+  `<worktree>/.claude/hooks/reinject_initial_prompt.sh` and has executable
+  mode (`File.stat!` mode check).
+- Happy path — running the script in a shell with the prompt file present
+  (use `System.cmd("sh", [path])` in the test) prints the file contents
+  followed by the reference sentence.
+- Edge case — running the script when the prompt file is absent exits 0
+  with empty stdout.
+- Edge case — calling `install/2` twice overwrites the script (simulates
+  Destila upgrade where the shipped script changes between releases).
+
+**Verification:**
+- Script passes `shellcheck` (if available in CI) and behaves correctly in
+  both "file present" and "file absent" scenarios.
+
+---
+
+- [ ] **Unit 4: Write `.claude/settings.json` declaring the SessionStart(compact) hook**
+
+**Goal:** Each worktree contains a `.claude/settings.json` that registers
+the shipped script as a `SessionStart` hook for matcher `compact`.
+
+**Requirements:** R2, R3
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `lib/destila/ai/compact_hook_setup.ex` (add settings.json write)
+- Test: `test/destila/ai/compact_hook_setup_test.exs` (extend)
+
+**Approach:**
+- `install/2` writes `<worktree>/.claude/settings.json` with the following
+  shape (values to be serialized via `Jason.encode!`):
+
+  ```
+  {
+    "hooks": {
+      "SessionStart": [
+        {
+          "matcher": "compact",
+          "hooks": [
+            { "type": "command",
+              "command": ".claude/hooks/reinject_initial_prompt.sh" }
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+- If a `settings.json` already exists in the worktree (unlikely today, but
+  possible once Destila grows more hook features), merge the `SessionStart`
+  array by appending our entry if one with the same command is not present.
+  Leave all other keys untouched.
+- Keep merge logic inside `CompactHookSetup.merge_settings/2` so it is
+  unit-testable without touching disk.
+
+**Patterns to follow:**
+- JSON handling via `Jason` (standard in Phoenix apps).
+- Pure functional merge + I/O boundary separation (e.g.
+  `session_config.ex` keeps logic pure and I/O thin).
+
+**Test scenarios:**
+- Happy path — after `install/2`, `settings.json` exists, parses as JSON,
+  and contains exactly one `SessionStart` entry with matcher `compact` and
+  command pointing at `.claude/hooks/reinject_initial_prompt.sh`.
+- Edge case — merging into a pre-existing settings.json that has other
+  `hooks` (e.g. `PreToolUse`) preserves them and only appends the new
+  `SessionStart` compact entry.
+- Edge case — merging into a settings.json that *already* has our compact
+  entry (same command) does not duplicate it.
+- Edge case — a pre-existing settings.json that is not valid JSON is
+  handled without crashing the phase. Decision: log a warning and overwrite
+  the file (Destila owns the worktree's `.claude/` directory; this is a
+  safe default). Test that invalid input triggers the overwrite path.
+
+**Verification:**
+- Destila starts a phase → worktree contains a well-formed `settings.json`
+  and executable hook script → running Claude Code in that worktree would
+  load the hook via its standard `setting_sources` mechanism.
+
+---
+
+- [ ] **Unit 5: End-to-end integration wiring and existing-test audit**
+
+**Goal:** `Conversation.phase_start/1` calls `CompactHookSetup.install/2`
+with the worktree path and wrapped phase prompt. Existing tests continue
+to pass; new happy-path integration test covers the full flow.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** Units 1–4
+
+**Files:**
+- Modify: `lib/destila/ai/conversation.ex` (call `CompactHookSetup.install/2`
+  from `phase_start/1`, after `phase_prompt` is wrapped and before the
+  Oban worker is enqueued)
+- Test: `test/destila/ai/conversation_test.exs` (extend with an integration
+  scenario that stubs a tmp worktree path and asserts file presence)
+
+**Approach:**
+- Thread the `ai_session.worktree_path` into `phase_start/1` via the
+  already-returned `session = ensure_ai_session(ws)`.
+- If `session.worktree_path` is `nil` (legacy sessions, test setups),
+  skip the install cleanly (Unit 2 already handles this branch).
+- Do not call `install/2` from `send_message/2` — prompts only change at
+  phase start, so there is no reason to rewrite the file per user message.
+
+**Patterns to follow:**
+- Compose with existing helpers inside `phase_start/1`; do not introduce
+  new Oban jobs or GenServers.
+
+**Test scenarios:**
+- Integration — full `phase_start/1` call against a workflow session whose
+  AI session has a `worktree_path` pointing at a tmp dir. Asserts:
+  1. Oban job enqueued with a `# Prompt` section containing
+     `<initial-prompt>` wrapping.
+  2. `<tmp>/.claude/destila/initial_prompt.txt` contains the same wrapped
+     prompt.
+  3. `<tmp>/.claude/hooks/reinject_initial_prompt.sh` exists and is
+     executable.
+  4. `<tmp>/.claude/settings.json` parses as JSON and declares the
+     SessionStart compact hook.
+- Edge case — AI session has no `worktree_path`: phase_start still
+  succeeds, Oban job still enqueued, no files created in a tmp dir.
+- Regression — existing `conversation_test.exs` cases (`handle_ai_error`,
+  etc.) continue to pass unchanged.
+
+**Verification:**
+- `mix test test/destila/ai/conversation_test.exs` passes.
+- `mix test test/destila/ai/compact_hook_setup_test.exs` passes.
+- `mix precommit` reports no new issues.
+
+## System-Wide Impact
+
+- **Interaction graph:** `Conversation.phase_start/1` gains a call edge to
+  the new `CompactHookSetup.install/2` which in turn writes three files
+  into the worktree. No other call sites are affected.
+- **Error propagation:** File-write failures in `install/2` should not
+  abort the phase. Wrap I/O at the boundary and log on failure; the phase
+  query still gets enqueued. This preserves existing "phase always starts"
+  semantics.
+- **State lifecycle risks:** The prompt file is overwritten per phase
+  start, so stale content from a prior phase cannot leak into a later
+  compaction. Worktree deletion (on session archive) removes all three
+  files alongside everything else under the worktree — no extra cleanup
+  needed.
+- **API surface parity:** No MCP tools, no HTTP endpoints, no public
+  Phoenix routes changed. Internal Elixir API gains `CompactHookSetup`.
+- **Integration coverage:** Unit 5 provides a single integration test that
+  exercises the full wrap-persist-install sequence.
+- **Unchanged invariants:** `Phase` struct, `SessionProcess` state machine,
+  `ClaudeSession` GenServer lifecycle, Oban worker shape, and
+  `handle_ai_result/2` non-interactive auto-advance safeguard are all
+  preserved. No DB schema changes.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Claude Code docs change the `SessionStart(compact)` behavior or remove stdout-as-context support. | Hook stdout is an established Claude Code feature; if it regresses we can migrate to JSON `additionalContext`. The shell script is trivial to change. |
+| User installs a conflicting `.claude/settings.json` via their own tooling. | `CompactHookSetup.merge_settings/2` appends non-destructively when the file is valid JSON; invalid JSON triggers overwrite with a logged warning. |
+| Hook fails to execute (e.g. non-POSIX environment, missing `sh`). | A failing hook cannot block compaction (only an explicit `decision: "block"` can). Claude Code continues normally; worst case the re-injection is skipped. |
+| Prompt file contains secrets the user would not want re-broadcast. | The prompt file only contains data already sent to Claude at phase start, so there is no new exposure. |
+| Worktree-local settings.json confuses a developer debugging locally with `claude` CLI. | Keep the file narrowly scoped to the `SessionStart(compact)` hook. Document in the hook script header that it is managed by Destila. |
+
+## Documentation / Operational Notes
+
+- No user-facing docs change. The behavior is transparent to end users:
+  phases simply become more resilient to long conversations.
+- Developers running `claude` directly in a Destila worktree will now see a
+  post-compact context injection. Add a one-line header comment at the top
+  of `reinject_initial_prompt.sh` noting it is managed by Destila.
+
+## Sources & References
+
+- Claude Code hooks documentation — https://code.claude.com/docs/en/hooks
+  (consulted 2026-04-21; confirms `PreCompact` cannot add context and
+  `SessionStart` matcher `compact` supports `additionalContext` / stdout).
+- Related code:
+  - `lib/destila/ai/conversation.ex` — phase_start prompt assembly and
+    existing comment about compaction hiding the phase prompt.
+  - `lib/destila/ai/claude_session.ex` — `setting_sources: ["user",
+    "project"]` confirms worktree settings.json is loaded.
+  - `lib/destila/ai/session_config.ex` — `:cwd` wiring from
+    `ai_session.worktree_path`.
+  - `lib/destila/workflows/phase.ex` — Phase struct.
+- Related PRs/issues: none yet.

--- a/lib/destila/ai/compact_hook_setup.ex
+++ b/lib/destila/ai/compact_hook_setup.ex
@@ -19,9 +19,8 @@ defmodule Destila.AI.CompactHookSetup do
   require Logger
 
   @prompt_subpath ".claude/destila/initial_prompt.txt"
-  @hook_subpath ".claude/hooks/reinject_initial_prompt.sh"
+  @hook_path ".claude/hooks/reinject_initial_prompt.sh"
   @settings_subpath ".claude/settings.json"
-  @hook_command ".claude/hooks/reinject_initial_prompt.sh"
   @hook_script_name "reinject_initial_prompt.sh"
 
   @doc """
@@ -60,8 +59,17 @@ defmodule Destila.AI.CompactHookSetup do
   def merge_settings(existing, hook_entry \\ default_hook_entry())
 
   def merge_settings(existing, hook_entry) when is_map(existing) do
-    hooks = Map.get(existing, "hooks", %{})
-    session_start = Map.get(hooks, "SessionStart", [])
+    hooks =
+      case Map.get(existing, "hooks", %{}) do
+        map when is_map(map) -> map
+        _ -> %{}
+      end
+
+    session_start =
+      case Map.get(hooks, "SessionStart", []) do
+        list when is_list(list) -> list
+        _ -> []
+      end
 
     session_start =
       if contains_hook_entry?(session_start, hook_entry) do
@@ -88,7 +96,7 @@ defmodule Destila.AI.CompactHookSetup do
   def default_hook_entry do
     %{
       "matcher" => "compact",
-      "hooks" => [%{"type" => "command", "command" => @hook_command}]
+      "hooks" => [%{"type" => "command", "command" => @hook_path}]
     }
   end
 
@@ -101,9 +109,9 @@ defmodule Destila.AI.CompactHookSetup do
   end
 
   defp install_hook_script!(worktree_path) do
-    dest = Path.join(worktree_path, @hook_subpath)
+    dest = Path.join(worktree_path, @hook_path)
     File.mkdir_p!(Path.dirname(dest))
-    File.cp!(source_script_path(), dest)
+    File.cp!(source_script_path!(), dest)
     File.chmod!(dest, 0o755)
   end
 
@@ -151,7 +159,13 @@ defmodule Destila.AI.CompactHookSetup do
     end)
   end
 
-  defp source_script_path do
-    Path.join([:code.priv_dir(:destila), "hooks", @hook_script_name])
+  defp source_script_path! do
+    case :code.priv_dir(:destila) do
+      {:error, :bad_name} ->
+        raise "CompactHookSetup: :destila application priv directory not found"
+
+      priv_dir ->
+        Path.join([priv_dir, "hooks", @hook_script_name])
+    end
   end
 end

--- a/lib/destila/ai/compact_hook_setup.ex
+++ b/lib/destila/ai/compact_hook_setup.ex
@@ -1,0 +1,157 @@
+defmodule Destila.AI.CompactHookSetup do
+  @moduledoc """
+  Installs a Claude Code `SessionStart(compact)` hook inside a workflow
+  session's worktree so the current phase prompt is re-injected after
+  context compaction.
+
+  On each phase start, `install/2` writes three files under the worktree:
+
+    * `.claude/destila/initial_prompt.txt` — the wrapped phase prompt
+    * `.claude/hooks/reinject_initial_prompt.sh` — the shipped hook script
+    * `.claude/settings.json` — a SessionStart(compact) hook registration
+
+  The hook script reads the prompt file and prints it followed by a short
+  reference sentence. Claude Code appends the script's stdout to the
+  post-compact context, restoring the phase instructions that the summary
+  may have dropped.
+  """
+
+  require Logger
+
+  @prompt_subpath ".claude/destila/initial_prompt.txt"
+  @hook_subpath ".claude/hooks/reinject_initial_prompt.sh"
+  @settings_subpath ".claude/settings.json"
+  @hook_command ".claude/hooks/reinject_initial_prompt.sh"
+  @hook_script_name "reinject_initial_prompt.sh"
+
+  @doc """
+  Writes the wrapped phase prompt, hook script, and `.claude/settings.json`
+  into the given worktree. Safe to call repeatedly — each call overwrites
+  the prompt file and re-installs the hook script; settings.json is merged.
+
+  Returns `:ok`. I/O failures are logged but do not raise so a phase start
+  is never blocked by hook-setup problems.
+  """
+  def install(nil, _wrapped_prompt), do: :ok
+
+  def install(worktree_path, wrapped_prompt)
+      when is_binary(worktree_path) and is_binary(wrapped_prompt) do
+    try do
+      write_prompt_file!(worktree_path, wrapped_prompt)
+      install_hook_script!(worktree_path)
+      install_settings!(worktree_path)
+      :ok
+    rescue
+      error ->
+        Logger.warning(
+          "CompactHookSetup.install/2 failed for #{inspect(worktree_path)}: " <>
+            Exception.message(error)
+        )
+
+        :ok
+    end
+  end
+
+  @doc """
+  Pure merge of our `SessionStart(compact)` hook entry into a pre-existing
+  settings map. Preserves all other keys and hook events. If our entry is
+  already present (same command) it is not duplicated.
+  """
+  def merge_settings(existing, hook_entry \\ default_hook_entry())
+
+  def merge_settings(existing, hook_entry) when is_map(existing) do
+    hooks = Map.get(existing, "hooks", %{})
+    session_start = Map.get(hooks, "SessionStart", [])
+
+    session_start =
+      if contains_hook_entry?(session_start, hook_entry) do
+        session_start
+      else
+        session_start ++ [hook_entry]
+      end
+
+    Map.put(existing, "hooks", Map.put(hooks, "SessionStart", session_start))
+  end
+
+  def merge_settings(_non_map, hook_entry), do: default_settings(hook_entry)
+
+  @doc """
+  The default settings payload when no prior `settings.json` exists.
+  """
+  def default_settings(hook_entry \\ default_hook_entry()) do
+    %{"hooks" => %{"SessionStart" => [hook_entry]}}
+  end
+
+  @doc """
+  The `SessionStart(compact)` hook entry registering our shipped script.
+  """
+  def default_hook_entry do
+    %{
+      "matcher" => "compact",
+      "hooks" => [%{"type" => "command", "command" => @hook_command}]
+    }
+  end
+
+  # --- Private ---
+
+  defp write_prompt_file!(worktree_path, wrapped_prompt) do
+    path = Path.join(worktree_path, @prompt_subpath)
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, wrapped_prompt)
+  end
+
+  defp install_hook_script!(worktree_path) do
+    dest = Path.join(worktree_path, @hook_subpath)
+    File.mkdir_p!(Path.dirname(dest))
+    File.cp!(source_script_path(), dest)
+    File.chmod!(dest, 0o755)
+  end
+
+  defp install_settings!(worktree_path) do
+    path = Path.join(worktree_path, @settings_subpath)
+    File.mkdir_p!(Path.dirname(path))
+
+    merged =
+      case File.read(path) do
+        {:ok, contents} ->
+          case Jason.decode(contents) do
+            {:ok, existing} ->
+              merge_settings(existing)
+
+            {:error, _} ->
+              Logger.warning("CompactHookSetup: overwriting invalid JSON at #{path}")
+
+              default_settings()
+          end
+
+        {:error, :enoent} ->
+          default_settings()
+
+        {:error, reason} ->
+          Logger.warning(
+            "CompactHookSetup: failed to read #{path} (#{inspect(reason)}); overwriting"
+          )
+
+          default_settings()
+      end
+
+    File.write!(path, Jason.encode!(merged, pretty: true))
+  end
+
+  defp contains_hook_entry?(session_start, %{"hooks" => [%{"command" => cmd}]}) do
+    Enum.any?(session_start, fn
+      %{"hooks" => hooks} when is_list(hooks) ->
+        Enum.any?(hooks, fn
+          %{"command" => ^cmd} -> true
+          _ -> false
+        end)
+
+      _ ->
+        false
+    end)
+  end
+
+  defp source_script_path do
+    Path.join([:code.priv_dir(:destila), "hooks", @hook_script_name])
+  end
+end

--- a/lib/destila/ai/conversation.ex
+++ b/lib/destila/ai/conversation.ex
@@ -30,6 +30,9 @@ defmodule Destila.AI.Conversation do
     handle_session_strategy(ws, phase_number)
     session = ensure_ai_session(ws)
     phase_prompt = prompt_fn.(ws)
+    wrapped_prompt = "<initial-prompt>\n#{phase_prompt}\n</initial-prompt>"
+
+    AI.CompactHookSetup.install(session.worktree_path, wrapped_prompt)
 
     # Auto-add non_interactive skill for autonomous phases
     all_skills =
@@ -58,7 +61,7 @@ defmodule Destila.AI.Conversation do
         if(tool_section != "", do: "# Tools\n\n#{tool_section}"),
         if(skill_section != "", do: "# Skills\n\n#{skill_section}"),
         service_section,
-        "# Prompt\n\n#{phase_prompt}"
+        "# Prompt\n\n#{wrapped_prompt}"
       ]
 
     query = sections |> Enum.reject(&is_nil/1) |> Enum.join("\n\n")

--- a/priv/hooks/reinject_initial_prompt.sh
+++ b/priv/hooks/reinject_initial_prompt.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Managed by Destila. Do not edit by hand.
+#
+# SessionStart(compact) hook: re-inject the wrapped initial phase prompt so the
+# model retains task context after context compaction.
+
+set -eu
+
+prompt_file="${CLAUDE_PROJECT_DIR:-.}/.claude/destila/initial_prompt.txt"
+
+if [ ! -f "$prompt_file" ]; then
+  exit 0
+fi
+
+cat "$prompt_file"
+printf '\n\nIn the `<initial-prompt>` tag above you can find the initial user prompt for reference.\n'

--- a/test/destila/ai/compact_hook_setup_test.exs
+++ b/test/destila/ai/compact_hook_setup_test.exs
@@ -1,0 +1,198 @@
+defmodule Destila.AI.CompactHookSetupTest do
+  use ExUnit.Case, async: true
+
+  alias Destila.AI.CompactHookSetup
+
+  setup do
+    tmp =
+      Path.join(
+        System.tmp_dir!(),
+        "compact_hook_setup_#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp)
+    on_exit(fn -> File.rm_rf!(tmp) end)
+
+    %{worktree: tmp}
+  end
+
+  describe "install/2" do
+    test "writes wrapped prompt to .claude/destila/initial_prompt.txt", %{worktree: tmp} do
+      wrapped = "<initial-prompt>\nDescribe your idea\n</initial-prompt>"
+
+      assert :ok = CompactHookSetup.install(tmp, wrapped)
+
+      path = Path.join(tmp, ".claude/destila/initial_prompt.txt")
+      assert File.exists?(path)
+      assert File.read!(path) == wrapped
+    end
+
+    test "second call overwrites prompt file with latest phase prompt", %{worktree: tmp} do
+      first = "<initial-prompt>\nphase 1\n</initial-prompt>"
+      second = "<initial-prompt>\nphase 2\n</initial-prompt>"
+
+      :ok = CompactHookSetup.install(tmp, first)
+      :ok = CompactHookSetup.install(tmp, second)
+
+      path = Path.join(tmp, ".claude/destila/initial_prompt.txt")
+      assert File.read!(path) == second
+    end
+
+    test "returns :ok and writes nothing when worktree_path is nil" do
+      assert :ok = CompactHookSetup.install(nil, "<initial-prompt>x</initial-prompt>")
+    end
+
+    test "creates .claude/destila directory when missing", %{worktree: tmp} do
+      refute File.exists?(Path.join(tmp, ".claude"))
+
+      :ok = CompactHookSetup.install(tmp, "<initial-prompt>x</initial-prompt>")
+
+      assert File.dir?(Path.join(tmp, ".claude/destila"))
+    end
+
+    test "installs hook script as executable", %{worktree: tmp} do
+      :ok = CompactHookSetup.install(tmp, "<initial-prompt>x</initial-prompt>")
+
+      path = Path.join(tmp, ".claude/hooks/reinject_initial_prompt.sh")
+      assert File.exists?(path)
+
+      %File.Stat{mode: mode} = File.stat!(path)
+      # Check the owner-executable bit is set (0o100 in the mode)
+      assert Bitwise.band(mode, 0o100) == 0o100
+    end
+
+    test "hook script prints prompt contents followed by reference sentence when file present",
+         %{worktree: tmp} do
+      wrapped = "<initial-prompt>\nhello phase\n</initial-prompt>"
+
+      :ok = CompactHookSetup.install(tmp, wrapped)
+
+      script = Path.join(tmp, ".claude/hooks/reinject_initial_prompt.sh")
+
+      {output, 0} =
+        System.cmd("sh", [script], env: [{"CLAUDE_PROJECT_DIR", tmp}])
+
+      assert output =~ "<initial-prompt>"
+      assert output =~ "hello phase"
+      assert output =~ "</initial-prompt>"
+      assert output =~ "In the `<initial-prompt>` tag above"
+    end
+
+    test "hook script exits 0 with empty output when prompt file is absent", %{worktree: tmp} do
+      :ok = CompactHookSetup.install(tmp, "<initial-prompt>x</initial-prompt>")
+
+      File.rm!(Path.join(tmp, ".claude/destila/initial_prompt.txt"))
+
+      script = Path.join(tmp, ".claude/hooks/reinject_initial_prompt.sh")
+
+      {output, status} =
+        System.cmd("sh", [script], env: [{"CLAUDE_PROJECT_DIR", tmp}])
+
+      assert status == 0
+      assert output == ""
+    end
+
+    test "second install overwrites the hook script", %{worktree: tmp} do
+      :ok = CompactHookSetup.install(tmp, "<initial-prompt>x</initial-prompt>")
+
+      script = Path.join(tmp, ".claude/hooks/reinject_initial_prompt.sh")
+      File.write!(script, "#!/bin/sh\necho mutated\n")
+
+      :ok = CompactHookSetup.install(tmp, "<initial-prompt>x</initial-prompt>")
+
+      contents = File.read!(script)
+      refute contents =~ "mutated"
+      assert contents =~ "CLAUDE_PROJECT_DIR"
+    end
+
+    test "writes a valid settings.json declaring SessionStart compact hook", %{worktree: tmp} do
+      :ok = CompactHookSetup.install(tmp, "<initial-prompt>x</initial-prompt>")
+
+      settings = read_settings(tmp)
+
+      assert %{"hooks" => %{"SessionStart" => [entry]}} = settings
+      assert entry["matcher"] == "compact"
+      assert [%{"type" => "command", "command" => command}] = entry["hooks"]
+      assert command == ".claude/hooks/reinject_initial_prompt.sh"
+    end
+
+    test "merging preserves pre-existing unrelated hook events", %{worktree: tmp} do
+      settings_path = Path.join(tmp, ".claude/settings.json")
+      File.mkdir_p!(Path.dirname(settings_path))
+
+      existing = %{
+        "hooks" => %{
+          "PreToolUse" => [
+            %{
+              "matcher" => "Bash",
+              "hooks" => [%{"type" => "command", "command" => "echo before"}]
+            }
+          ]
+        }
+      }
+
+      File.write!(settings_path, Jason.encode!(existing))
+
+      :ok = CompactHookSetup.install(tmp, "<initial-prompt>x</initial-prompt>")
+
+      settings = read_settings(tmp)
+
+      assert settings["hooks"]["PreToolUse"] == existing["hooks"]["PreToolUse"]
+      assert [entry] = settings["hooks"]["SessionStart"]
+      assert entry["matcher"] == "compact"
+    end
+
+    test "does not duplicate the compact hook entry on repeated installs", %{worktree: tmp} do
+      :ok = CompactHookSetup.install(tmp, "<initial-prompt>x</initial-prompt>")
+      :ok = CompactHookSetup.install(tmp, "<initial-prompt>y</initial-prompt>")
+
+      settings = read_settings(tmp)
+
+      assert length(settings["hooks"]["SessionStart"]) == 1
+    end
+
+    test "overwrites invalid JSON settings without crashing", %{worktree: tmp} do
+      settings_path = Path.join(tmp, ".claude/settings.json")
+      File.mkdir_p!(Path.dirname(settings_path))
+      File.write!(settings_path, "{ not valid json")
+
+      :ok = CompactHookSetup.install(tmp, "<initial-prompt>x</initial-prompt>")
+
+      settings = read_settings(tmp)
+      assert [%{"matcher" => "compact"}] = settings["hooks"]["SessionStart"]
+    end
+  end
+
+  describe "merge_settings/2" do
+    test "returns default settings when existing is not a map" do
+      assert %{"hooks" => %{"SessionStart" => [_]}} =
+               CompactHookSetup.merge_settings(nil)
+    end
+
+    test "preserves sibling hook events" do
+      existing = %{
+        "hooks" => %{
+          "PreToolUse" => [%{"matcher" => "Bash"}]
+        }
+      }
+
+      merged = CompactHookSetup.merge_settings(existing)
+
+      assert merged["hooks"]["PreToolUse"] == existing["hooks"]["PreToolUse"]
+      assert [%{"matcher" => "compact"}] = merged["hooks"]["SessionStart"]
+    end
+
+    test "is idempotent when our entry already exists" do
+      existing = CompactHookSetup.default_settings()
+
+      assert CompactHookSetup.merge_settings(existing) == existing
+    end
+  end
+
+  defp read_settings(tmp) do
+    tmp
+    |> Path.join(".claude/settings.json")
+    |> File.read!()
+    |> Jason.decode!()
+  end
+end

--- a/test/destila/ai/conversation_test.exs
+++ b/test/destila/ai/conversation_test.exs
@@ -248,4 +248,121 @@ defmodule Destila.AI.ConversationTest do
       assert :awaiting_input == AI.Conversation.handle_ai_result(ws, ok_result())
     end
   end
+
+  describe "phase_start/1 initial-prompt wrapping and hook install" do
+    defp create_session_with_worktree(tmp, attrs \\ %{}) do
+      base = %{
+        title: "Wrap test",
+        workflow_type: :brainstorm_idea,
+        current_phase: 1,
+        total_phases: 4
+      }
+
+      {:ok, ws} = Workflows.insert_workflow_session(Map.merge(base, attrs))
+      {:ok, _ai_session} = AI.create_ai_session(%{workflow_session_id: ws.id, worktree_path: tmp})
+      ws
+    end
+
+    defp tmp_worktree do
+      path =
+        Path.join(
+          System.tmp_dir!(),
+          "conversation_phase_start_#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(path)
+      on_exit(fn -> File.rm_rf!(path) end)
+      path
+    end
+
+    test "enqueued Oban query wraps the phase prompt in <initial-prompt> tags" do
+      tmp = tmp_worktree()
+      ws = create_session_with_worktree(tmp)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :processing == AI.Conversation.phase_start(ws)
+
+        assert_enqueued(
+          worker: Destila.Workers.AiQueryWorker,
+          args: %{"workflow_session_id" => ws.id}
+        )
+
+        [job] = all_enqueued(worker: Destila.Workers.AiQueryWorker)
+        query = job.args["query"]
+
+        assert query =~ "# Prompt\n\n<initial-prompt>\n"
+        assert query =~ "\n</initial-prompt>"
+      end)
+    end
+
+    test "writes wrapped prompt, hook script, and settings.json into the worktree" do
+      tmp = tmp_worktree()
+      ws = create_session_with_worktree(tmp)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        AI.Conversation.phase_start(ws)
+
+        [job] = all_enqueued(worker: Destila.Workers.AiQueryWorker)
+        query = job.args["query"]
+
+        # 1. prompt file matches the wrapped block present in the query
+        prompt_path = Path.join(tmp, ".claude/destila/initial_prompt.txt")
+        assert File.exists?(prompt_path)
+        file_contents = File.read!(prompt_path)
+        assert String.contains?(query, file_contents)
+        assert file_contents =~ "<initial-prompt>"
+        assert file_contents =~ "</initial-prompt>"
+
+        # 2. hook script shipped and executable
+        hook_path = Path.join(tmp, ".claude/hooks/reinject_initial_prompt.sh")
+        assert File.exists?(hook_path)
+        %File.Stat{mode: mode} = File.stat!(hook_path)
+        assert Bitwise.band(mode, 0o100) == 0o100
+
+        # 3. settings.json parses and declares the SessionStart compact hook
+        settings = Jason.decode!(File.read!(Path.join(tmp, ".claude/settings.json")))
+        assert [entry] = settings["hooks"]["SessionStart"]
+        assert entry["matcher"] == "compact"
+        assert [%{"command" => ".claude/hooks/reinject_initial_prompt.sh"}] = entry["hooks"]
+      end)
+    end
+
+    test "works without a worktree_path (no files created, still enqueues)" do
+      base = %{
+        title: "No worktree",
+        workflow_type: :brainstorm_idea,
+        current_phase: 1,
+        total_phases: 4
+      }
+
+      {:ok, ws} = Workflows.insert_workflow_session(base)
+      {:ok, _ai_session} = AI.create_ai_session(%{workflow_session_id: ws.id})
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :processing == AI.Conversation.phase_start(ws)
+
+        assert_enqueued(
+          worker: Destila.Workers.AiQueryWorker,
+          args: %{"workflow_session_id" => ws.id}
+        )
+      end)
+    end
+
+    test "second phase_start overwrites the prompt file with the current phase's prompt" do
+      tmp = tmp_worktree()
+      ws1 = create_session_with_worktree(tmp, %{current_phase: 1})
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        AI.Conversation.phase_start(ws1)
+        first = File.read!(Path.join(tmp, ".claude/destila/initial_prompt.txt"))
+
+        ws2 = %{ws1 | current_phase: 2}
+        AI.Conversation.phase_start(ws2)
+        second = File.read!(Path.join(tmp, ".claude/destila/initial_prompt.txt"))
+
+        refute first == second
+        assert second =~ "<initial-prompt>"
+      end)
+    end
+  end
 end

--- a/test/destila/ai/conversation_test.exs
+++ b/test/destila/ai/conversation_test.exs
@@ -364,5 +364,84 @@ defmodule Destila.AI.ConversationTest do
         assert second =~ "<initial-prompt>"
       end)
     end
+
+    test "phase prompts containing literal angle-bracket tags are wrapped intact" do
+      tmp = tmp_worktree()
+
+      # Embed `<example>` tags via the brainstorm_idea phase-1 prompt,
+      # which interpolates `workflow_session.user_prompt` verbatim. The
+      # outer `<initial-prompt>` wrapping must appear exactly once around
+      # the full content and must not be disturbed by the inner tags.
+      user_prompt_with_tags =
+        "Build a todo app.\n<example>A task with title and due_date</example>\nBe concise."
+
+      ws =
+        create_session_with_worktree(tmp, %{
+          user_prompt: user_prompt_with_tags,
+          workflow_type: :brainstorm_idea,
+          current_phase: 1,
+          total_phases: 4
+        })
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :processing == AI.Conversation.phase_start(ws)
+
+        [job] = all_enqueued(worker: Destila.Workers.AiQueryWorker)
+        query = job.args["query"]
+
+        file_contents =
+          File.read!(Path.join(tmp, ".claude/destila/initial_prompt.txt"))
+
+        # Inner tags survive verbatim.
+        assert file_contents =~ "<example>A task with title and due_date</example>"
+        assert query =~ "<example>A task with title and due_date</example>"
+
+        # Outer wrapping appears exactly once in both query and file.
+        assert length(Regex.scan(~r/<initial-prompt>/, file_contents)) == 1
+        assert length(Regex.scan(~r|</initial-prompt>|, file_contents)) == 1
+        assert String.starts_with?(file_contents, "<initial-prompt>\n")
+        assert String.ends_with?(file_contents, "\n</initial-prompt>")
+      end)
+    end
+  end
+
+  describe "send_message/2 initial-prompt scope" do
+    test "does not wrap user messages in <initial-prompt> tags and does not write hook files" do
+      tmp =
+        Path.join(
+          System.tmp_dir!(),
+          "conversation_send_message_#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(tmp)
+      on_exit(fn -> File.rm_rf!(tmp) end)
+
+      base = %{
+        title: "Send message scope",
+        workflow_type: :brainstorm_idea,
+        current_phase: 1,
+        total_phases: 4
+      }
+
+      {:ok, ws} = Workflows.insert_workflow_session(base)
+      {:ok, _ai_session} = AI.create_ai_session(%{workflow_session_id: ws.id, worktree_path: tmp})
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :processing == AI.Conversation.send_message(ws, "hello from the user")
+
+        [job] = all_enqueued(worker: Destila.Workers.AiQueryWorker)
+        query = job.args["query"]
+
+        refute query =~ "<initial-prompt>"
+        refute query =~ "</initial-prompt>"
+        assert query == "hello from the user"
+
+        # send_message/2 must not touch the hook install side-effects —
+        # those are scoped to phase_start/1.
+        refute File.exists?(Path.join(tmp, ".claude/destila/initial_prompt.txt"))
+        refute File.exists?(Path.join(tmp, ".claude/hooks/reinject_initial_prompt.sh"))
+        refute File.exists?(Path.join(tmp, ".claude/settings.json"))
+      end)
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Wrap every phase prompt in `<initial-prompt>…</initial-prompt>` tags inside `AI.Conversation.phase_start/1`, and write the wrapped prompt into the worktree at `.claude/destila/initial_prompt.txt` on every phase start.
- Install a Claude Code `SessionStart(compact)` hook (`priv/hooks/reinject_initial_prompt.sh`, shipped + copied into `.claude/hooks/` per-worktree) that re-prints the wrapped prompt plus a short reference sentence after Claude Code compacts context — so the phase instructions survive the summary instead of being lost.
- Register the hook by merging `.claude/settings.json` (preserves unrelated hooks the user may already have) and keep the install idempotent across repeated phase starts.
- Install is nil-safe (no worktree = no-op) and I/O failures are logged but never block a phase from starting.

## Implementation notes

- New module `Destila.AI.CompactHookSetup` owns prompt-file / hook-script / settings.json writes; `Conversation.phase_start/1` calls `install/2` after resolving the phase prompt.
- `send_message/2` is intentionally unchanged — wrapping is scoped to phase starts (verified by test).
- `merge_settings/2` tolerates malformed user settings (non-map `hooks`, non-list `SessionStart`) and idempotently adds our entry.
- `source_script_path!/0` raises a clear error if `:code.priv_dir(:destila)` returns `{:error, :bad_name}` instead of crashing inside `Path.join`.

## Tests

- Unit coverage in `test/destila/ai/compact_hook_setup_test.exs` (15 tests): prompt file overwrite, nil worktree, executable bit, script output both with and without the prompt file, settings merge preserves sibling hooks, idempotence, invalid-JSON overwrite.
- Integration coverage in `test/destila/ai/conversation_test.exs` (5 new tests): wrapped prompt appears in the Oban query, three artifacts land on disk with the right shape, second phase start overwrites the prompt file, embedded `<example>` tags in the phase prompt are wrapped exactly once, and `send_message/2` does **not** wrap user messages or write hook artifacts.
- Full suite: **593 tests, 0 failures** (`mix precommit`).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — the change is entirely local to a workflow session's worktree and only runs inline during phase start. No new endpoints, background jobs, migrations, or external calls. If a worktree I/O error occurs, it is logged via `Logger.warning` with the failing path and phase starts continue as before.

## Test plan

- [x] `mix precommit` passes locally (format + full suite)
- [x] Hook script executes under `CLAUDE_PROJECT_DIR=<worktree> sh .claude/hooks/reinject_initial_prompt.sh` and prints the wrapped prompt plus reference sentence
- [x] Second phase start overwrites `initial_prompt.txt` with the new phase's prompt
- [x] Pre-existing `.claude/settings.json` with unrelated hooks is preserved when merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)