### PR TITLE
fix(ai): include default tool descriptions in system prompt

### DIFF
--- a/lib/destila/ai/claude_session.ex
+++ b/lib/destila/ai/claude_session.ex
@@ -8,25 +8,6 @@ defmodule Destila.AI.ClaudeSession do
   use GenServer
 
   @default_timeout_ms :timer.minutes(5)
-  @default_allowed_tools [
-    "Read",
-    "Grep",
-    "Glob",
-    "WebFetch",
-    "Skill",
-    "Bash(git log:*)",
-    "Bash(git show:*)",
-    "mcp__destila__ask_user_question",
-    "mcp__destila__session",
-    "mcp__destila__service"
-  ]
-
-  @doc """
-  Returns the default `allowed_tools` list used when a session starts without
-  an explicit list. Exposed so callers assembling the system prompt can reflect
-  the tools the agent will actually have access to.
-  """
-  def default_allowed_tools, do: @default_allowed_tools
 
   # Client API
 
@@ -153,7 +134,6 @@ defmodule Destila.AI.ClaudeSession do
     {timeout_ms, claude_opts} = Keyword.pop(opts, :timeout_ms, @default_timeout_ms)
     {workflow_session_id, claude_opts} = Keyword.pop(claude_opts, :workflow_session_id)
     {ai_session_id, claude_opts} = Keyword.pop(claude_opts, :ai_session_id)
-    claude_opts = Keyword.put_new(claude_opts, :allowed_tools, @default_allowed_tools)
 
     claude_opts =
       Keyword.put_new(claude_opts, :mcp_servers, %{

--- a/lib/destila/ai/claude_session.ex
+++ b/lib/destila/ai/claude_session.ex
@@ -21,6 +21,13 @@ defmodule Destila.AI.ClaudeSession do
     "mcp__destila__service"
   ]
 
+  @doc """
+  Returns the default `allowed_tools` list used when a session starts without
+  an explicit list. Exposed so callers assembling the system prompt can reflect
+  the tools the agent will actually have access to.
+  """
+  def default_allowed_tools, do: @default_allowed_tools
+
   # Client API
 
   @doc """

--- a/lib/destila/ai/session_config.ex
+++ b/lib/destila/ai/session_config.ex
@@ -69,10 +69,10 @@ defmodule Destila.AI.SessionConfig do
   defp put_append_system_prompt(opts, _), do: opts
 
   defp put_allowed_tools(opts, %{allowed_tools: [_ | _] = tools}),
-    do: Keyword.put(opts, :allowed_tools, tools)
+    do: Keyword.put_new(opts, :allowed_tools, tools)
 
   defp put_allowed_tools(opts, _),
-    do: Keyword.put(opts, :allowed_tools, @default_allowed_tools)
+    do: Keyword.put_new(opts, :allowed_tools, @default_allowed_tools)
 
   defp put_ai_session(opts, %{id: id}), do: Keyword.put(opts, :ai_session_id, id)
   defp put_ai_session(opts, _), do: opts

--- a/lib/destila/ai/session_config.ex
+++ b/lib/destila/ai/session_config.ex
@@ -5,16 +5,32 @@ defmodule Destila.AI.SessionConfig do
   The phase's `AISessionGroup` contributes its assembled `skills` and its
   `allowed_tools` descriptions as `:append_system_prompt` (appended to Claude
   Code's built-in system prompt), and its `allowed_tools` list as
-  `:allowed_tools`. The AI session record contributes `:resume` and `:cwd`.
+  `:allowed_tools`. When the group does not declare `allowed_tools`, the
+  module-level `@default_allowed_tools` list is used for both, so the
+  documented usage stays in sync with the tools the agent can actually call.
+  The AI session record contributes `:resume` and `:cwd`.
 
   Every session also registers `Destila.AI.Hooks.SessionStart` on the
   `SessionStart` event so the current phase's initial prompt is re-injected
   into the agent's context after a compaction (`source: "compact"`).
   """
 
-  alias Destila.AI.{ClaudeSession, Hooks, Tools}
+  alias Destila.AI.{Hooks, Tools}
   alias Destila.Workflows
   alias Destila.Workflows.Skills
+
+  @default_allowed_tools [
+    "Read",
+    "Grep",
+    "Glob",
+    "WebFetch",
+    "Skill",
+    "Bash(git log:*)",
+    "Bash(git show:*)",
+    "mcp__destila__ask_user_question",
+    "mcp__destila__session",
+    "mcp__destila__service"
+  ]
 
   @doc """
   Builds ClaudeCode session options for a workflow session and phase.
@@ -31,23 +47,17 @@ defmodule Destila.AI.SessionConfig do
     ai_session = Destila.AI.get_ai_session_for_workflow(workflow_session.id)
 
     base_opts
-    |> put_append_system_prompt(group)
     |> put_allowed_tools(group)
+    |> put_append_system_prompt(group)
     |> put_ai_session(ai_session)
     |> put_resume(ai_session)
     |> put_cwd(ai_session)
     |> put_hooks()
   end
 
-  defp put_append_system_prompt(opts, %{skills: skills, allowed_tools: tools}) do
-    effective_tools =
-      case tools do
-        [] -> ClaudeSession.default_allowed_tools()
-        list -> list
-      end
-
+  defp put_append_system_prompt(opts, %{skills: skills}) do
     sections =
-      [Skills.assemble_skills(skills), Tools.tool_descriptions(effective_tools)]
+      [Skills.assemble_skills(skills), Tools.tool_descriptions(opts[:allowed_tools] || [])]
       |> Enum.reject(&(&1 == ""))
 
     case sections do
@@ -61,7 +71,8 @@ defmodule Destila.AI.SessionConfig do
   defp put_allowed_tools(opts, %{allowed_tools: [_ | _] = tools}),
     do: Keyword.put(opts, :allowed_tools, tools)
 
-  defp put_allowed_tools(opts, _), do: opts
+  defp put_allowed_tools(opts, _),
+    do: Keyword.put(opts, :allowed_tools, @default_allowed_tools)
 
   defp put_ai_session(opts, %{id: id}), do: Keyword.put(opts, :ai_session_id, id)
   defp put_ai_session(opts, _), do: opts

--- a/lib/destila/ai/session_config.ex
+++ b/lib/destila/ai/session_config.ex
@@ -12,7 +12,7 @@ defmodule Destila.AI.SessionConfig do
   into the agent's context after a compaction (`source: "compact"`).
   """
 
-  alias Destila.AI.{Hooks, Tools}
+  alias Destila.AI.{ClaudeSession, Hooks, Tools}
   alias Destila.Workflows
   alias Destila.Workflows.Skills
 
@@ -40,8 +40,14 @@ defmodule Destila.AI.SessionConfig do
   end
 
   defp put_append_system_prompt(opts, %{skills: skills, allowed_tools: tools}) do
+    effective_tools =
+      case tools do
+        [] -> ClaudeSession.default_allowed_tools()
+        list -> list
+      end
+
     sections =
-      [Skills.assemble_skills(skills), Tools.tool_descriptions(tools)]
+      [Skills.assemble_skills(skills), Tools.tool_descriptions(effective_tools)]
       |> Enum.reject(&(&1 == ""))
 
     case sections do

--- a/test/destila/ai/session_config_test.exs
+++ b/test/destila/ai/session_config_test.exs
@@ -17,14 +17,15 @@ defmodule Destila.AI.SessionConfigTest do
   end
 
   describe "session_opts_for_workflow/3 for brainstorm_idea" do
-    test "omits :append_system_prompt and :allowed_tools (group has none)" do
+    test "omits :allowed_tools (group has none) and appends default-tool descriptions" do
       ws = create_session()
       {:ok, _} = AI.create_ai_session(%{workflow_session_id: ws.id})
 
       opts = SessionConfig.session_opts_for_workflow(ws, 1)
 
-      refute Keyword.has_key?(opts, :append_system_prompt)
       refute Keyword.has_key?(opts, :allowed_tools)
+      assert opts[:append_system_prompt] =~ "## Asking Questions"
+      assert opts[:append_system_prompt] =~ "## Phase Transitions"
     end
 
     test "forwards :ai_session_id when an AI session exists" do

--- a/test/destila/ai/session_config_test.exs
+++ b/test/destila/ai/session_config_test.exs
@@ -17,13 +17,14 @@ defmodule Destila.AI.SessionConfigTest do
   end
 
   describe "session_opts_for_workflow/3 for brainstorm_idea" do
-    test "omits :allowed_tools (group has none) and appends default-tool descriptions" do
+    test "uses default :allowed_tools (group has none) and appends matching tool descriptions" do
       ws = create_session()
       {:ok, _} = AI.create_ai_session(%{workflow_session_id: ws.id})
 
       opts = SessionConfig.session_opts_for_workflow(ws, 1)
 
-      refute Keyword.has_key?(opts, :allowed_tools)
+      assert "Read" in opts[:allowed_tools]
+      assert "mcp__destila__ask_user_question" in opts[:allowed_tools]
       assert opts[:append_system_prompt] =~ "## Asking Questions"
       assert opts[:append_system_prompt] =~ "## Phase Transitions"
     end


### PR DESCRIPTION
## Summary
- When a workflow's `AISessionGroup` declared no `allowed_tools`, `SessionConfig` built `:append_system_prompt` from the empty group list, so the agent got tools like `mcp__destila__ask_user_question` via `ClaudeSession.@default_allowed_tools` but no coaching about when to use them.
- Expose `ClaudeSession.default_allowed_tools/0` and fall back to it in `SessionConfig.put_append_system_prompt/2` so the documented usage stays in sync with the tools the agent can actually call.
- Observed on session `173efdfd-dad9-4dc0-8595-f82c00368dde` (brainstorm_idea, phase 1): the model answered with a plaintext markdown Q&A list (6 questions, most with clean discrete options) instead of calling `ask_user_question`.

## Test plan
- [x] `mix test test/destila/ai/session_config_test.exs`
- [x] `mix precommit` (644 tests, 0 failures)
- [ ] Start a new Brainstorm Idea session and confirm phase 1 uses the question tool for discrete-option questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)