### PR TITLE
chore(seeds): enable mise auto-trust for destila project

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -7,9 +7,10 @@ case Repo.get_by(Project, name: "destila") do
     case Projects.create_project(%{
            name: "destila",
            git_repo_url: "https://github.com/esnunes/destila",
-           setup_command: "mise trust -y && mix setup",
+           setup_command: "mix setup",
            run_command: "elixir --sname destila-{PORT} -S mix phx.server",
-           service_env_var: "PORT"
+           service_env_var: "PORT",
+           mise_auto_trust: true
          }) do
       {:ok, _project} ->
         IO.puts("seeded destila project")


### PR DESCRIPTION
## Summary
- Flip `mise_auto_trust: true` on the seeded destila project so new worktrees trust the mise config chain automatically.
- Drop the now-redundant `mise trust -y &&` prefix from `setup_command` — the worker handles trust before setup runs.

## Test plan
- [ ] Re-run seeds against a fresh DB and confirm the destila project is created with `mise_auto_trust = true`.
- [ ] Create a new workflow session and confirm no mise trust prompt appears in the setup tmux window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)