### PR TITLE
fix(ai): deny built-in AskUserQuestion tool

### DIFF
--- a/lib/destila/ai/session_config.ex
+++ b/lib/destila/ai/session_config.ex
@@ -32,6 +32,10 @@ defmodule Destila.AI.SessionConfig do
     "mcp__destila__service"
   ]
 
+  # Built-in AskUserQuestion duplicates `mcp__destila__ask_user_question`; denying
+  # it forces the agent to use the Destila tool, which is the one wired into the UI.
+  @default_disallowed_tools ["AskUserQuestion"]
+
   @doc """
   Builds ClaudeCode session options for a workflow session and phase.
 
@@ -48,12 +52,16 @@ defmodule Destila.AI.SessionConfig do
 
     base_opts
     |> put_allowed_tools(group)
+    |> put_disallowed_tools()
     |> put_append_system_prompt(group)
     |> put_ai_session(ai_session)
     |> put_resume(ai_session)
     |> put_cwd(ai_session)
     |> put_hooks()
   end
+
+  defp put_disallowed_tools(opts),
+    do: Keyword.put_new(opts, :disallowed_tools, @default_disallowed_tools)
 
   defp put_append_system_prompt(opts, %{skills: skills}) do
     sections =

--- a/lib/destila/ai/tools.ex
+++ b/lib/destila/ai/tools.ex
@@ -9,7 +9,7 @@ defmodule Destila.AI.Tools do
 
   tool :ask_user_question do
     description(
-      "Present one or more structured questions to the user with selectable options. Use this when you want the user to choose from specific options. IMPORTANT: Always use this tool — never the built-in `AskUserQuestion` tool — so answers are rendered in the Destila UI and recorded in the workflow session."
+      "Present one or more structured questions to the user with selectable options. Use this when you want the user to choose from specific options."
     )
 
     field(

--- a/lib/destila/ai/tools.ex
+++ b/lib/destila/ai/tools.ex
@@ -9,7 +9,7 @@ defmodule Destila.AI.Tools do
 
   tool :ask_user_question do
     description(
-      "Present one or more structured questions to the user with selectable options. Use this when you want the user to choose from specific options."
+      "Present one or more structured questions to the user with selectable options. Use this when you want the user to choose from specific options. IMPORTANT: Always use this tool — never the built-in `AskUserQuestion` tool — so answers are rendered in the Destila UI and recorded in the workflow session."
     )
 
     field(
@@ -52,6 +52,11 @@ defmodule Destila.AI.Tools do
   the options of another.
 
   For open-ended questions without clear options, just ask in plain text.
+
+  IMPORTANT: Always use `mcp__destila__ask_user_question` — never the built-in \
+  `AskUserQuestion` tool. Only the Destila tool renders the question in the workflow \
+  UI and records the answer in the session; the built-in tool is disabled in this \
+  environment and calling it will fail.
 
   IMPORTANT: Never call `mcp__destila__ask_user_question` with a phase transition \
   action in the same response.

--- a/test/destila/ai/session_config_test.exs
+++ b/test/destila/ai/session_config_test.exs
@@ -29,6 +29,25 @@ defmodule Destila.AI.SessionConfigTest do
       assert opts[:append_system_prompt] =~ "## Phase Transitions"
     end
 
+    test "denies the built-in AskUserQuestion tool by default" do
+      ws = create_session()
+      {:ok, _} = AI.create_ai_session(%{workflow_session_id: ws.id})
+
+      opts = SessionConfig.session_opts_for_workflow(ws, 1)
+
+      assert "AskUserQuestion" in opts[:disallowed_tools]
+    end
+
+    test "preserves :disallowed_tools from base_opts" do
+      ws = create_session()
+      {:ok, _} = AI.create_ai_session(%{workflow_session_id: ws.id})
+
+      opts =
+        SessionConfig.session_opts_for_workflow(ws, 1, disallowed_tools: ["SomeOtherTool"])
+
+      assert opts[:disallowed_tools] == ["SomeOtherTool"]
+    end
+
     test "forwards :ai_session_id when an AI session exists" do
       ws = create_session()
       {:ok, ai_session} = AI.create_ai_session(%{workflow_session_id: ws.id})


### PR DESCRIPTION
## Summary
- PR #140 taught the agent about `mcp__destila__ask_user_question` via the appended system prompt, but the model sometimes still reaches for the built-in `AskUserQuestion` — bypassing the Destila UI.
- Root cause: the SDK's `:allowed_tools` is an auto-approve list, not a restriction. Unlisted tools fall through to `:permission_mode`, so `AskUserQuestion` was never actually blocked.
- Fix: add `AskUserQuestion` to `:disallowed_tools` (checked first, overrides `:allowed_tools` and `:permission_mode`) via a new `@default_disallowed_tools` in `SessionConfig`.
- Belt-and-suspenders: reinforce the rule in the `ask_user_question` tool description and the `## Asking Questions` system prompt section so the model doesn't even try.

## Test plan
- [x] `mix test test/destila/ai/session_config_test.exs` — new tests cover the default `:disallowed_tools` entry and the `base_opts` override path.
- [x] `mix precommit` (658 tests, 0 failures).
- [ ] Start a new Brainstorm Idea session and confirm the agent routes questions through the Destila UI (no `AskUserQuestion` calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)