### PR TITLE
feat(ai): default workflow AI sessions to --effort xhigh

### DIFF
--- a/lib/destila/ai/session_config.ex
+++ b/lib/destila/ai/session_config.ex
@@ -13,6 +13,11 @@ defmodule Destila.AI.SessionConfig do
   Every session also registers `Destila.AI.Hooks.SessionStart` on the
   `SessionStart` event so the current phase's initial prompt is re-injected
   into the agent's context after a compaction (`source: "compact"`).
+
+  Every session also defaults to `--effort xhigh` (passed via `:extra_args`
+  since the SDK's typed `:effort` option doesn't yet expose the `xhigh` tier
+  the CLI supports). Callers can override by passing their own
+  `extra_args: %{"--effort" => "..."}`.
   """
 
   alias Destila.AI.{Hooks, Tools}
@@ -36,6 +41,10 @@ defmodule Destila.AI.SessionConfig do
   # it forces the agent to use the Destila tool, which is the one wired into the UI.
   @default_disallowed_tools ["AskUserQuestion"]
 
+  # Routed through :extra_args because the SDK's typed :effort option (v0.36)
+  # only accepts :low/:medium/:high/:max, while the CLI also accepts "xhigh".
+  @default_effort "xhigh"
+
   @doc """
   Builds ClaudeCode session options for a workflow session and phase.
 
@@ -58,6 +67,16 @@ defmodule Destila.AI.SessionConfig do
     |> put_resume(ai_session)
     |> put_cwd(ai_session)
     |> put_hooks()
+    |> put_effort()
+  end
+
+  defp put_effort(opts) do
+    extra_args =
+      opts
+      |> Keyword.get(:extra_args, %{})
+      |> Map.put_new("--effort", @default_effort)
+
+    Keyword.put(opts, :extra_args, extra_args)
   end
 
   defp put_disallowed_tools(opts),

--- a/test/destila/ai/session_config_test.exs
+++ b/test/destila/ai/session_config_test.exs
@@ -111,6 +111,25 @@ defmodule Destila.AI.SessionConfigTest do
       assert opts[:hooks] == %{SessionStart: [Destila.AI.Hooks.SessionStart]}
     end
 
+    test "defaults --effort to xhigh via :extra_args" do
+      ws = create_session()
+      {:ok, _} = AI.create_ai_session(%{workflow_session_id: ws.id})
+
+      opts = SessionConfig.session_opts_for_workflow(ws, 1)
+
+      assert opts[:extra_args]["--effort"] == "xhigh"
+    end
+
+    test "preserves a caller-supplied --effort in :extra_args" do
+      ws = create_session()
+      {:ok, _} = AI.create_ai_session(%{workflow_session_id: ws.id})
+
+      opts =
+        SessionConfig.session_opts_for_workflow(ws, 1, extra_args: %{"--effort" => "high"})
+
+      assert opts[:extra_args]["--effort"] == "high"
+    end
+
     test ":hooks coexists with the other session options" do
       ws = create_session()
 


### PR DESCRIPTION
## Summary
- Every workflow AI session now starts the underlying Claude Code CLI with `--effort xhigh`.
- Routed via `:extra_args` because the Elixir SDK at v0.36.3 only validates the typed `:effort` option against `:low/:medium/:high/:max`, while the CLI itself accepts `xhigh` (per `claude --help`: "low, medium, high, xhigh, max").
- Callers can still override per-call by passing `extra_args: %{"--effort" => "..."}` — the default uses `Map.put_new/3`.

## Test plan
- [x] `mix test test/destila/ai/session_config_test.exs` — 17/17 pass, including two new tests covering the default and the override.
- [x] `mix precommit` — 761/761 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)