### PR TITLE
feat(ai): default sessions to claude-opus-4-7 + tolerate pull failures

### DIFF
--- a/lib/destila/ai/session_config.ex
+++ b/lib/destila/ai/session_config.ex
@@ -18,6 +18,9 @@ defmodule Destila.AI.SessionConfig do
   since the SDK's typed `:effort` option doesn't yet expose the `xhigh` tier
   the CLI supports). Callers can override by passing their own
   `extra_args: %{"--effort" => "..."}`.
+
+  Every session also defaults to the `claude-opus-4-7` model. Callers can
+  override by passing their own `model: "..."`.
   """
 
   alias Destila.AI.{Hooks, Tools}
@@ -44,6 +47,7 @@ defmodule Destila.AI.SessionConfig do
   # Routed through :extra_args because the SDK's typed :effort option (v0.36)
   # only accepts :low/:medium/:high/:max, while the CLI also accepts "xhigh".
   @default_effort "xhigh"
+  @default_model "claude-opus-4-7"
 
   @doc """
   Builds ClaudeCode session options for a workflow session and phase.
@@ -68,6 +72,7 @@ defmodule Destila.AI.SessionConfig do
     |> put_cwd(ai_session)
     |> put_hooks()
     |> put_effort()
+    |> put_model()
   end
 
   defp put_effort(opts) do
@@ -78,6 +83,8 @@ defmodule Destila.AI.SessionConfig do
 
     Keyword.put(opts, :extra_args, extra_args)
   end
+
+  defp put_model(opts), do: Keyword.put_new(opts, :model, @default_model)
 
   defp put_disallowed_tools(opts),
     do: Keyword.put_new(opts, :disallowed_tools, @default_disallowed_tools)

--- a/lib/destila/workers/prepare_workflow_session.ex
+++ b/lib/destila/workers/prepare_workflow_session.ex
@@ -63,14 +63,24 @@ defmodule Destila.Workers.PrepareWorkflowSession do
     cond do
       project.local_folder && project.local_folder != "" ->
         case Git.pull(project.local_folder) do
-          {:ok, _} -> :ok
-          {:error, reason} -> {:error, reason}
+          {:ok, _} ->
+            :ok
+
+          {:error, reason} ->
+            Logger.warning("Failed to pull #{project.local_folder}: #{inspect(reason)}")
+            :ok
         end
 
       project.git_repo_url && project.git_repo_url != "" ->
-        with {:ok, path} <- Git.effective_local_folder(project),
-             {:ok, _} <- Git.pull(path) do
-          :ok
+        with {:ok, path} <- Git.effective_local_folder(project) do
+          case Git.pull(path) do
+            {:ok, _} ->
+              :ok
+
+            {:error, reason} ->
+              Logger.warning("Failed to pull #{path}: #{inspect(reason)}")
+              :ok
+          end
         end
 
       true ->


### PR DESCRIPTION
## Summary
- Default every workflow AI session to `claude-opus-4-7` via a new `put_model/1` step in `Destila.AI.SessionConfig`. Callers can still override with `model: "..."`.
- Make `PrepareWorkflowSession.sync_repo/1` tolerate `Git.pull` failures (e.g. a working tree on a branch with no upstream): log a warning and continue instead of failing the Oban job and aborting worktree creation.

## Test plan
- [x] `mix precommit` (802 tests, 0 failures)
- [x] Trigger a workflow session against a project whose `local_folder` is on an unpushed branch and confirm the job completes with a `Failed to pull ...` warning instead of erroring.
- [x] Start a new workflow AI session and confirm it runs on `claude-opus-4-7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)