### PR TITLE
fix(prod): bind endpoint to IPv6 loopback only

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -67,11 +67,11 @@ if config_env() == :prod do
   config :destila, DestilaWeb.Endpoint,
     url: [host: host, port: 443, scheme: "https"],
     http: [
-      # Enable IPv6 and bind on all interfaces.
-      # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
+      # Bind to the IPv6 loopback address only. A reverse proxy (e.g. Caddy)
+      # is expected to terminate TLS and forward requests locally.
       # See the documentation on https://hexdocs.pm/bandit/Bandit.html#t:options/0
       # for details about using IPv6 vs IPv4 and loopback vs public addresses.
-      ip: {0, 0, 0, 0, 0, 0, 0, 0}
+      ip: {0, 0, 0, 0, 0, 0, 0, 1}
     ],
     secret_key_base: secret_key_base
 


### PR DESCRIPTION
## Summary
- `config/runtime.exs` previously bound the production endpoint to `{0, 0, 0, 0, 0, 0, 0, 0}` (IPv6 `::`, all interfaces), exposing the Phoenix app directly to the Internet.
- Switch to `{0, 0, 0, 0, 0, 0, 0, 1}` (IPv6 loopback `::1`) so only the local reverse proxy (Caddy) can reach the endpoint.
- `runtime.exs` runs after `prod.exs` and was overriding the loopback binding already present there, so this is the change that actually takes effect.

## Test plan
- [ ] Deploy and verify the endpoint is no longer reachable from the public internet (e.g. `curl http://<public-ip>:<port>` should fail).
- [ ] Verify the site still works end-to-end through Caddy on the production host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)